### PR TITLE
Introduce shared types and apply across components

### DIFF
--- a/app/components/SurahListSidebar.tsx
+++ b/app/components/SurahListSidebar.tsx
@@ -4,14 +4,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { FaSearch } from './SvgIcons';
-
-interface Chapter {
-  id: number;
-  name_simple: string;
-  name_arabic: string;
-  revelation_place: string;
-  verses_count: number;
-}
+import { Chapter } from '@/types';
 
 const SurahListSidebar = () => {
   const [chapters, setChapters] = useState<Chapter[]>([]);

--- a/app/surah/[SurahId]/_components/SettingsSidebar.tsx
+++ b/app/surah/[SurahId]/_components/SettingsSidebar.tsx
@@ -1,10 +1,11 @@
 // app/surah/[surahId]/_components/SettingsSidebar.tsx
 import { FaBookReader, FaFontSetting, FaChevronDown } from '@/app/components/SvgIcons';
 import { CollapsibleSection } from './CollapsibleSection';
+import { Settings } from '@/types';
 
 interface SettingsSidebarProps {
-  settings: any;
-  onSettingsChange: (newSettings: any) => void;
+  settings: Settings;
+  onSettingsChange: (newSettings: Settings) => void;
   onTranslationPanelOpen: () => void;
   selectedTranslationName: string;
   arabicFonts: { name: string; value: string; }[];

--- a/app/surah/[SurahId]/_components/TranslationPanel.tsx
+++ b/app/surah/[SurahId]/_components/TranslationPanel.tsx
@@ -1,14 +1,15 @@
 // app/surah/[surahId]/_components/TranslationPanel.tsx
 import { FaArrowLeft, FaSearch } from '@/app/components/SvgIcons';
+import { Settings, TranslationResource } from '@/types';
 
 interface TranslationPanelProps {
   isOpen: boolean;
   onClose: () => void;
-  groupedTranslations: Record<string, any[]>;
+  groupedTranslations: Record<string, TranslationResource[]>;
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
-  settings: any;
-  onSettingsChange: (newSettings: any) => void;
+  settings: Settings;
+  onSettingsChange: (newSettings: Settings) => void;
 }
 
 export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchTerm, onSearchTermChange, settings, onSettingsChange }: TranslationPanelProps) => {

--- a/app/surah/[SurahId]/_components/Verse.tsx
+++ b/app/surah/[SurahId]/_components/Verse.tsx
@@ -1,8 +1,9 @@
 // app/surah/[surahId]/_components/Verse.tsx
 import { FaPlay, FaPause, FaBookmark, FaEllipsisH, FaBookReader } from '@/app/components/SvgIcons'; // Added FaBookReader back
+import { Verse as VerseType, Translation } from '@/types';
 
 interface VerseProps {
-  verse: any;
+  verse: VerseType;
   playingId: number | null;
   onPlayToggle: (id: number) => void;
   arabicFontFace: string;
@@ -33,7 +34,7 @@ export const Verse = ({ verse, playingId, onPlayToggle, arabicFontFace, arabicFo
         <p className="text-right leading-loose text-gray-800" style={{ fontFamily: arabicFontFace, fontSize: `${arabicFontSize}px`, lineHeight: 2.2 }}>
           {verse.text_uthmani}
         </p>
-        {verse.translations?.map((t: any) => (
+        {verse.translations?.map((t: Translation) => (
           <div key={t.resource_id}>
             <p className="text-left leading-relaxed text-gray-600" style={{ fontSize: `${translationFontSize}px` }} dangerouslySetInnerHTML={{ __html: t.text }} />
           </div>

--- a/app/surah/[SurahId]/page.tsx
+++ b/app/surah/[SurahId]/page.tsx
@@ -5,10 +5,9 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { Verse } from './_components/Verse';
 import { SettingsSidebar } from './_components/SettingsSidebar';
 import { TranslationPanel } from './_components/TranslationPanel';
+import { Verse as VerseType, TranslationResource, Settings } from '@/types';
 
 // --- Interfaces & Data ---
-interface TranslationResource { id: number; name: string; language_name: string; }
-interface Settings { translationId: number; arabicFontSize: number; translationFontSize: number; arabicFontFace: string; }
 const arabicFonts = [
     { name: 'KFGQ', value: '"KFGQPC Uthman Taha Naskh", serif' },
     { name: 'Me Quran', value: '"Me Quran", sans-serif' },
@@ -16,7 +15,7 @@ const arabicFonts = [
 ];
 
 export default function SurahPage({ params }: { params: { surahId: string } }) {
-  const [verses, setVerses] = useState<any[]>([]);
+  const [verses, setVerses] = useState<VerseType[]>([]);
   const [playingId, setPlayingId] = useState<number | null>(null);
   const [translationOptions, setTranslationOptions] = useState<TranslationResource[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/types/chapter.ts
+++ b/types/chapter.ts
@@ -1,0 +1,7 @@
+export interface Chapter {
+  id: number;
+  name_simple: string;
+  name_arabic: string;
+  revelation_place: string;
+  verses_count: number;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,4 @@
+export * from './verse';
+export * from './chapter';
+export * from './translation';
+export * from './settings';

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,0 +1,6 @@
+export interface Settings {
+  translationId: number;
+  arabicFontSize: number;
+  translationFontSize: number;
+  arabicFontFace: string;
+}

--- a/types/translation.ts
+++ b/types/translation.ts
@@ -1,0 +1,5 @@
+export interface TranslationResource {
+  id: number;
+  name: string;
+  language_name: string;
+}

--- a/types/verse.ts
+++ b/types/verse.ts
@@ -1,0 +1,17 @@
+export interface Translation {
+  id?: number;
+  resource_id: number;
+  text: string;
+}
+
+export interface Audio {
+  url: string;
+}
+
+export interface Verse {
+  id: number;
+  verse_key: string;
+  text_uthmani: string;
+  audio?: Audio;
+  translations?: Translation[];
+}


### PR DESCRIPTION
## Summary
- define common interfaces under `types/`
- use the interfaces in page and component files instead of `any`
- remove remaining `any` usage in shared types

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687baf2470c8832bb0a8e20ad298682b