### PR TITLE
Add API utilities and refactor fetches

### DIFF
--- a/app/components/SurahListSidebar.tsx
+++ b/app/components/SurahListSidebar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { FaSearch } from './SvgIcons';
 import { Chapter } from '@/types';
+import { getChapters } from '@/lib/api';
 
 const SurahListSidebar = () => {
   const [chapters, setChapters] = useState<Chapter[]>([]);
@@ -14,10 +15,9 @@ const SurahListSidebar = () => {
   const activeSurahId = params.surahId;
 
   useEffect(() => {
-    fetch('https://api.quran.com/api/v4/chapters?language=en')
-      .then(res => res.json())
-      .then(data => setChapters(data.chapters))
-      .catch(err => console.error("Failed to fetch chapters:", err));
+    getChapters()
+      .then(setChapters)
+      .catch(err => console.error('Failed to fetch chapters:', err));
   }, []);
 
   const filteredChapters = useMemo(() =>

--- a/app/surah/[SurahId]/page.tsx
+++ b/app/surah/[SurahId]/page.tsx
@@ -6,6 +6,7 @@ import { Verse } from './_components/Verse';
 import { SettingsSidebar } from './_components/SettingsSidebar';
 import { TranslationPanel } from './_components/TranslationPanel';
 import { Verse as VerseType, TranslationResource, Settings } from '@/types';
+import { getTranslations, getVersesByChapter } from '@/lib/api';
 
 // --- Interfaces & Data ---
 const arabicFonts = [
@@ -32,24 +33,17 @@ export default function SurahPage({ params }: { params: { surahId: string } }) {
   // --- Data Fetching Effect ---
   useEffect(() => {
     // Fetch all available translations once
-    fetch('https://api.quran.com/api/v4/resources/translations')
-      .then(res => res.json())
-      .then(json => setTranslationOptions(json.translations || []))
+    getTranslations()
+      .then(setTranslationOptions)
       .catch(err => console.error('Translations load error:', err));
   }, []);
   
   useEffect(() => {
     if (!params.surahId) return;
     setIsLoading(true);
-    const url = `https://api.quran.com/api/v4/verses/by_chapter/${params.surahId}?language=en&words=true&translations=${settings.translationId}&fields=text_uthmani,audio&per_page=300`;
-    
-    fetch(url)
-      .then(res => {
-        if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
-        return res.json();
-      })
-      .then(json => {
-        setVerses(json.verses || []);
+    getVersesByChapter(params.surahId, settings.translationId)
+      .then(vs => {
+        setVerses(vs);
         setError(null);
       })
       .catch(err => {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,36 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_QURAN_API_BASE_URL ?? 'https://api.quran.com/api/v4';
+
+import { Chapter, TranslationResource, Verse } from '@/types';
+
+export async function getChapters(): Promise<Chapter[]> {
+  const res = await fetch(`${API_BASE_URL}/chapters?language=en`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch chapters: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.chapters as Chapter[];
+}
+
+export async function getTranslations(): Promise<TranslationResource[]> {
+  const res = await fetch(`${API_BASE_URL}/resources/translations`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch translations: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.translations as TranslationResource[];
+}
+
+export async function getVersesByChapter(
+  chapterId: string | number,
+  translationId: number
+): Promise<Verse[]> {
+  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=en&words=true&translations=${translationId}&fields=text_uthmani,audio&per_page=300`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch verses: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.verses as Verse[];
+}
+
+export { API_BASE_URL };


### PR DESCRIPTION
## Summary
- centralize Quran API calls in `lib/api.ts`
- replace direct fetch usage with new API helpers

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687bca231038832b86da7ae6a9a704ea