### PR TITLE
Add global settings and audio context providers

### DIFF
--- a/app/context/AudioContext.tsx
+++ b/app/context/AudioContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React, { createContext, useContext, useState } from 'react';
+
+interface AudioContextType {
+  playingId: number | null;
+  setPlayingId: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+const AudioContext = createContext<AudioContextType | undefined>(undefined);
+
+export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
+  const [playingId, setPlayingId] = useState<number | null>(null);
+
+  return (
+    <AudioContext.Provider value={{ playingId, setPlayingId }}>
+      {children}
+    </AudioContext.Provider>
+  );
+};
+
+export const useAudio = () => {
+  const ctx = useContext(AudioContext);
+  if (!ctx) throw new Error('useAudio must be used within AudioProvider');
+  return ctx;
+};

--- a/app/context/SettingsContext.tsx
+++ b/app/context/SettingsContext.tsx
@@ -1,0 +1,38 @@
+'use client';
+import React, { createContext, useContext, useState } from 'react';
+import { Settings } from '@/types';
+
+export const ARABIC_FONTS = [
+  { name: 'KFGQ', value: '"KFGQPC Uthman Taha Naskh", serif' },
+  { name: 'Me Quran', value: '"Me Quran", sans-serif' },
+  { name: 'Al Mushaf', value: '"Al Mushaf", serif' },
+];
+
+interface SettingsContextType {
+  settings: Settings;
+  setSettings: React.Dispatch<React.SetStateAction<Settings>>;
+  arabicFonts: { name: string; value: string }[];
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [settings, setSettings] = useState<Settings>({
+    translationId: 20,
+    arabicFontSize: 28,
+    translationFontSize: 16,
+    arabicFontFace: ARABIC_FONTS[0].value,
+  });
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSettings, arabicFonts: ARABIC_FONTS }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
+  return ctx;
+};

--- a/app/surah/[SurahId]/_components/SettingsSidebar.tsx
+++ b/app/surah/[SurahId]/_components/SettingsSidebar.tsx
@@ -1,17 +1,15 @@
 // app/surah/[surahId]/_components/SettingsSidebar.tsx
 import { FaBookReader, FaFontSetting, FaChevronDown } from '@/app/components/SvgIcons';
 import { CollapsibleSection } from './CollapsibleSection';
-import { Settings } from '@/types';
+import { useSettings } from '@/app/context/SettingsContext';
 
 interface SettingsSidebarProps {
-  settings: Settings;
-  onSettingsChange: (newSettings: Settings) => void;
   onTranslationPanelOpen: () => void;
   selectedTranslationName: string;
-  arabicFonts: { name: string; value: string; }[];
 }
 
-export const SettingsSidebar = ({ settings, onSettingsChange, onTranslationPanelOpen, selectedTranslationName, arabicFonts }: SettingsSidebarProps) => {
+export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationName }: SettingsSidebarProps) => {
+  const { settings, setSettings, arabicFonts } = useSettings();
   
   // Helper function to calculate the slider's progress percentage
   const getPercentage = (value: number, min: number, max: number) => {
@@ -43,7 +41,7 @@ export const SettingsSidebar = ({ settings, onSettingsChange, onTranslationPanel
                 min="16"
                 max="48"
                 value={settings.arabicFontSize}
-                onChange={e => onSettingsChange({ ...settings, arabicFontSize: +e.target.value })}
+                onChange={e => setSettings({ ...settings, arabicFontSize: +e.target.value })}
                 // CHANGE: Apply the percentage as a CSS variable
                 style={{ '--value-percent': `${arabicSizePercent}%` } as React.CSSProperties}
               />
@@ -55,14 +53,14 @@ export const SettingsSidebar = ({ settings, onSettingsChange, onTranslationPanel
                 min="12"
                 max="28"
                 value={settings.translationFontSize}
-                onChange={e => onSettingsChange({ ...settings, translationFontSize: +e.target.value })}
+                onChange={e => setSettings({ ...settings, translationFontSize: +e.target.value })}
                 // CHANGE: Apply the percentage as a CSS variable
                 style={{ '--value-percent': `${translationSizePercent}%` } as React.CSSProperties}
               />
             </div>
             <div>
               <label className="block mb-2 text-sm font-medium text-gray-700">Arabic Font Face</label>
-              <select onChange={e => onSettingsChange({ ...settings, arabicFontFace: e.target.value })} value={settings.arabicFontFace} className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-sm focus:ring-teal-500 focus:border-teal-500 text-gray-800">
+              <select onChange={e => setSettings({ ...settings, arabicFontFace: e.target.value })} value={settings.arabicFontFace} className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-sm focus:ring-teal-500 focus:border-teal-500 text-gray-800">
                 {arabicFonts.map(font => (<option key={font.name} value={font.value}>{font.name}</option>))}
               </select>
             </div>

--- a/app/surah/[SurahId]/_components/TranslationPanel.tsx
+++ b/app/surah/[SurahId]/_components/TranslationPanel.tsx
@@ -1,6 +1,7 @@
 // app/surah/[surahId]/_components/TranslationPanel.tsx
 import { FaArrowLeft, FaSearch } from '@/app/components/SvgIcons';
-import { Settings, TranslationResource } from '@/types';
+import { TranslationResource } from '@/types';
+import { useSettings } from '@/app/context/SettingsContext';
 
 interface TranslationPanelProps {
   isOpen: boolean;
@@ -8,11 +9,10 @@ interface TranslationPanelProps {
   groupedTranslations: Record<string, TranslationResource[]>;
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
-  settings: Settings;
-  onSettingsChange: (newSettings: Settings) => void;
 }
 
-export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchTerm, onSearchTermChange, settings, onSettingsChange }: TranslationPanelProps) => {
+export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchTerm, onSearchTermChange }: TranslationPanelProps) => {
+  const { settings, setSettings } = useSettings();
   return (
     <>
       {isOpen && <div onClick={onClose} className="fixed inset-0 bg-black/20 z-40"></div>}
@@ -35,7 +35,16 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
               <div className="p-2 space-y-1">
                 {groupedTranslations[lang].map(opt => (
                   <label key={opt.id} className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer">
-                    <input type="radio" name="translation" className="form-radio h-4 w-4 text-teal-600" checked={settings.translationId === opt.id} onChange={() => { onSettingsChange({ ...settings, translationId: opt.id }); onClose(); }} />
+                    <input
+                      type="radio"
+                      name="translation"
+                      className="form-radio h-4 w-4 text-teal-600"
+                      checked={settings.translationId === opt.id}
+                      onChange={() => {
+                        setSettings({ ...settings, translationId: opt.id });
+                        onClose();
+                      }}
+                    />
                     <span className="text-sm text-gray-700">{opt.name}</span>
                   </label>
                 ))}

--- a/app/surah/[SurahId]/_components/Verse.tsx
+++ b/app/surah/[SurahId]/_components/Verse.tsx
@@ -1,17 +1,16 @@
 // app/surah/[surahId]/_components/Verse.tsx
 import { FaPlay, FaPause, FaBookmark, FaEllipsisH, FaBookReader } from '@/app/components/SvgIcons'; // Added FaBookReader back
 import { Verse as VerseType, Translation } from '@/types';
+import { useAudio } from '@/app/context/AudioContext';
+import { useSettings } from '@/app/context/SettingsContext';
 
 interface VerseProps {
   verse: VerseType;
-  playingId: number | null;
-  onPlayToggle: (id: number) => void;
-  arabicFontFace: string;
-  arabicFontSize: number;
-  translationFontSize: number;
 }
 
-export const Verse = ({ verse, playingId, onPlayToggle, arabicFontFace, arabicFontSize, translationFontSize }: VerseProps) => {
+export const Verse = ({ verse }: VerseProps) => {
+  const { playingId, setPlayingId } = useAudio();
+  const { settings } = useSettings();
   const isPlaying = playingId === verse.id;
 
   return (
@@ -19,7 +18,13 @@ export const Verse = ({ verse, playingId, onPlayToggle, arabicFontFace, arabicFo
       <div className="w-16 text-center pt-1 space-y-2 flex-shrink-0">
         <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>
         <div className="flex flex-col items-center space-y-1 text-gray-400">
-          <button onClick={() => onPlayToggle(verse.id)} title="Play/Pause" className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'}`}>
+          <button
+            onClick={() =>
+              setPlayingId(currentId => (currentId === verse.id ? null : verse.id))
+            }
+            title="Play/Pause"
+            className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'}`}
+          >
             {isPlaying ? <FaPause size={18} /> : <FaPlay size={18} />}
           </button>
           <button title="Bookmark" className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition"><FaBookmark size={18} /></button>
@@ -31,12 +36,19 @@ export const Verse = ({ verse, playingId, onPlayToggle, arabicFontFace, arabicFo
         </div>
       </div>
       <div className="flex-grow space-y-6">
-        <p className="text-right leading-loose text-gray-800" style={{ fontFamily: arabicFontFace, fontSize: `${arabicFontSize}px`, lineHeight: 2.2 }}>
+        <p
+          className="text-right leading-loose text-gray-800"
+          style={{ fontFamily: settings.arabicFontFace, fontSize: `${settings.arabicFontSize}px`, lineHeight: 2.2 }}
+        >
           {verse.text_uthmani}
         </p>
         {verse.translations?.map((t: Translation) => (
           <div key={t.resource_id}>
-            <p className="text-left leading-relaxed text-gray-600" style={{ fontSize: `${translationFontSize}px` }} dangerouslySetInnerHTML={{ __html: t.text }} />
+            <p
+              className="text-left leading-relaxed text-gray-600"
+              style={{ fontSize: `${settings.translationFontSize}px` }}
+              dangerouslySetInnerHTML={{ __html: t.text }}
+            />
           </div>
         ))}
       </div>

--- a/app/surah/[SurahId]/layout.tsx
+++ b/app/surah/[SurahId]/layout.tsx
@@ -2,16 +2,22 @@
 import Header from '@/app/components/Header';
 import IconSidebar from '@/app/components/IconSidebar';
 import SurahListSidebar from '@/app/components/SurahListSidebar';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function SurahLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="h-screen flex flex-col">
-      <Header />
-      <div className="flex flex-grow overflow-hidden">
-        <IconSidebar />
-        <SurahListSidebar />
-        {children}
-      </div>
-    </div>
+    <SettingsProvider>
+      <AudioProvider>
+        <div className="h-screen flex flex-col">
+          <Header />
+          <div className="flex flex-grow overflow-hidden">
+            <IconSidebar />
+            <SurahListSidebar />
+            {children}
+          </div>
+        </div>
+      </AudioProvider>
+    </SettingsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- create `SettingsContext` and `AudioContext` under `app/context`
- wrap Surah layout with the new providers
- refactor `SurahPage` and related components to consume these contexts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687bd02b72b4832b9f1a995ad88a62a3