### PR TITLE
Add env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+QURAN_API_BASE_URL=https://api.quran.com/api/v4

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Setup
+
+Copy `.env.example` to `.env` and adjust the values if necessary. The default configuration includes the Quran API base URL.
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
## Summary
- allow committing `.env.example`
- document copying the `.env.example`
- add `.env.example` file with Quran API base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687c6eed51f8832baf1e18eb4e10f2b8