### PR TITLE
Add basic search functionality

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -8,6 +8,10 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
 describe('Header', () => {
   it('renders the title', () => {
     render(<Header />);

--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -2,9 +2,20 @@
 'use client';
 import { FaSearch } from './SvgIcons';
 import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 const Header = () => {
   const { t } = useTranslation();
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && query.trim()) {
+      router.push(`/features/search?query=${encodeURIComponent(query.trim())}`);
+    }
+  };
+
   return (
     // CHANGE: Adjusted background, padding, and grid layout for cleaner look
     <header className="h-16 grid grid-cols-3 items-center px-8 bg-white shadow-sm sticky top-0 z-30">
@@ -20,7 +31,9 @@ const Header = () => {
           <input
             type="text"
             placeholder={t('search_placeholder')}
-            // CHANGE: Softer border, adjusted padding, and rounded corners
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
             className="w-full bg-gray-100 border border-gray-200 rounded-md py-2 px-10 focus:ring-1 focus:ring-teal-500 outline-none transition text-gray-700"
           /> {/* Adjusted styles */}
         </div>

--- a/app/features/search/page.tsx
+++ b/app/features/search/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { searchVerses } from '@/lib/api';
+import { Verse as VerseType } from '@/types';
+import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
+
+export default function SearchPage() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('query') || '';
+  const [verses, setVerses] = useState<VerseType[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!query) {
+      setVerses([]);
+      return;
+    }
+    setLoading(true);
+    searchVerses(query)
+      .then(setVerses)
+      .catch(err => {
+        console.error(err);
+        setError('Failed to load results.');
+      })
+      .finally(() => setLoading(false));
+  }, [query]);
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {query && (
+        <h1 className="text-2xl font-bold mb-6">Search results for: {query}</h1>
+      )}
+      {loading && <p className="text-teal-600">Loading...</p>}
+      {error && <p className="text-red-600 mb-4">{error}</p>}
+      {!loading && verses.length === 0 && !error && query && (
+        <p className="text-gray-500">No verses found.</p>
+      )}
+      <div className="space-y-8">
+        {verses.map(v => (
+          <Verse key={v.id} verse={v} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -25,6 +25,13 @@ export interface PaginatedVerses {
   totalPages: number;
 }
 
+interface SearchApiResult {
+  verse_key: string;
+  verse_id: number;
+  text: string;
+  translations?: Verse['translations'];
+}
+
 export async function getVersesByChapter(
   chapterId: string | number,
   translationId: number,
@@ -39,6 +46,22 @@ export async function getVersesByChapter(
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
   return { verses: data.verses as Verse[], totalPages };
+}
+
+export async function searchVerses(query: string): Promise<Verse[]> {
+  const url = `${API_BASE_URL}/search?q=${encodeURIComponent(query)}&size=20&translations=20`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to search verses: ${res.status}`);
+  }
+  const data = await res.json();
+  const results: SearchApiResult[] = data.search?.results || [];
+  return results.map(r => ({
+    id: r.verse_id,
+    verse_key: r.verse_key,
+    text_uthmani: r.text,
+    translations: r.translations,
+  })) as Verse[];
 }
 
 export { API_BASE_URL };


### PR DESCRIPTION
## Summary
- implement `searchVerses` in API library
- new page to display search results
- hook up header search input
- adjust tests for new header dependencies

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687d526d0eb4832b91ff6ab6cc77f2e9