### PR TITLE
Add theme switching support

### DIFF
--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: React.Dispatch<React.SetStateAction<Theme>>;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') return stored as Theme;
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme);
+      document.documentElement.dataset.theme = theme;
+    }
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -5,6 +5,7 @@ import { useSettings } from '@/app/context/SettingsContext';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react'; // Import useState
 import { ArabicFontPanel } from './ArabicFontPanel'; // Import ArabicFontPanel
+import { useTheme } from '@/app/context/ThemeContext';
 
 interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
@@ -15,6 +16,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
   const { settings, setSettings, arabicFonts } = useSettings();
   const { t } = useTranslation();
   const [isArabicFontPanelOpen, setIsArabicFontPanelOpen] = useState(false); // State for ArabicFontPanel
+  const { theme, setTheme } = useTheme();
 
   // Helper function to calculate the slider's progress percentage
   const getPercentage = (value: number, min: number, max: number) => {
@@ -74,6 +76,14 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
             </div>
           </div>
         </CollapsibleSection>
+      </div>
+      <div className="p-4 border-t border-gray-200/80">
+        <button
+          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-sm hover:border-teal-500 transition"
+        >
+          {theme === 'light' ? 'Switch to Dark' : 'Switch to Light'}
+        </button>
       </div>
       {/* Arabic Font Panel */}
       <ArabicFontPanel isOpen={isArabicFontPanelOpen} onClose={() => setIsArabicFontPanelOpen(false)} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,12 +7,10 @@
   --border-color: #e5e7eb; /* Subtle border color */
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #1a202c; /* Darker background for dark mode */
-    --foreground: #d1d5db; /* Lighter foreground for dark mode */
-    --border-color: #4b5563; /* Darker border for dark mode */
-  }
+[data-theme='dark'] {
+  --background: #1a202c; /* Darker background for dark mode */
+  --foreground: #d1d5db; /* Lighter foreground for dark mode */
+  --border-color: #4b5563; /* Darker border for dark mode */
 }
 
 body {
@@ -25,10 +23,13 @@ h1, h2, h3, h4, h5, h6 {
   color: #111827; /* Darker heading color */
 }
 
-@media (prefers-color-scheme: dark) {
-  h1, h2, h3, h4, h5, h6 {
-    color: #f3f4f6; /* Lighter heading color for dark mode */
-  }
+[data-theme='dark'] h1,
+[data-theme='dark'] h2,
+[data-theme='dark'] h3,
+[data-theme='dark'] h4,
+[data-theme='dark'] h5,
+[data-theme='dark'] h6 {
+  color: #f3f4f6; /* Lighter heading color for dark mode */
 }
 
 /* --- Custom Modern Range Slider Styles --- */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 // app/layout.tsx
 import './globals.css';
 import TranslationProvider from './providers/TranslationProvider';
+import { ThemeProvider } from './context/ThemeContext';
 
 export const metadata = {
   title: 'Quran Mazid',
@@ -17,7 +18,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="font-sans">
         <TranslationProvider>
-          {children}
+          <ThemeProvider>
+            {children}
+          </ThemeProvider>
         </TranslationProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- create a ThemeContext for storing the chosen theme
- update layout to provide the ThemeContext
- set CSS variables based on the theme
- add toggle button in settings sidebar to switch between themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d526e524c832b8781b0b24e392757