### PR TITLE
Improve accessibility labels and nav markup

### DIFF
--- a/app/components/common/IconSidebar.tsx
+++ b/app/components/common/IconSidebar.tsx
@@ -17,8 +17,11 @@ const IconSidebar = () => {
         <aside className="w-20 bg-[#F0FAF8] flex flex-col justify-center py-4">
             <nav className="flex flex-col items-center space-y-2">
                 {navItems.map((item, index) => (
-                    <Link key={index} href={item.href} title={item.label}> {/* Use Link component */}
-                        <button className="p-3 rounded-lg hover:bg-gray-200 text-gray-600 hover:text-teal-600 transition-colors duration-200">
+                    <Link key={index} href={item.href} title={item.label}>
+                        <button
+                            aria-label={item.label}
+                            className="p-3 rounded-lg hover:bg-gray-200 text-gray-600 hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+                        >
                             <item.icon className="h-6 w-6" />
                         </button>
                     </Link>

--- a/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
+++ b/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
@@ -33,7 +33,13 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
       {/* No overlay div */}
       <div className={`fixed top-0 right-0 w-80 h-full bg-[#F7F9F9] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
-          <button onClick={onClose} className="p-2 rounded-full hover:bg-gray-200"><FaArrowLeft size={18} /></button>
+          <button
+            aria-label="Back"
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            <FaArrowLeft size={18} />
+          </button>
           <h2 className="font-bold text-lg text-gray-800">{t('select_font_face')}</h2> {/* Assuming a translation key for the title */}
           <div className="w-8"></div>
         </div>

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -20,7 +20,13 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
       {/* Removed the overlay div */}
       <div className={`fixed top-0 right-0 w-80 h-full bg-[#F7F9F9] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
-          <button onClick={onClose} className="p-2 rounded-full hover:bg-gray-200"><FaArrowLeft size={18} /></button>
+          <button
+            aria-label="Back"
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            <FaArrowLeft size={18} />
+          </button>
           <h2 className="font-bold text-lg text-gray-800">{t('translations_panel_title')}</h2>
           <div className="w-8"></div>
         </div>

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -12,7 +12,7 @@ export const Verse = ({ verse }: VerseProps) => {
   const { playingId, setPlayingId } = useAudio();
   const { settings, bookmarkedVerses, toggleBookmark } = useSettings(); // Get bookmarkedVerses and toggleBookmark
   const isPlaying = playingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(verse.id); // Check if verse is bookmarked
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id)); // Check if verse is bookmarked
 
   return (
     <div className="flex items-start gap-x-6 mb-12 border-b pb-8 border-gray-200">
@@ -20,27 +20,41 @@ export const Verse = ({ verse }: VerseProps) => {
         <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>
         <div className="flex flex-col items-center space-y-1 text-gray-400">
           <button
+            aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
             onClick={() =>
               setPlayingId(currentId => (currentId === verse.id ? null : verse.id))
             }
             title="Play/Pause"
-            className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'}`}
+            className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
           >
             {isPlaying ? <FaPause size={18} /> : <FaPlay size={18} />}
           </button>
           {/* Bookmark button */}
           <button
+            aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
             title="Bookmark"
-            onClick={() => toggleBookmark(verse.id)} // Call toggleBookmark on click
-            className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'}`}
+            onClick={() => toggleBookmark(String(verse.id))}
+            className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
           >
             {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />} {/* Change icon based on bookmark status */}
           </button>
           
           {/* This is the Tafsir icon that was missing */}
-          <button title="Tafsir" className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition"><FaBookReader size={18} /></button>
-          
-          <button title="More" className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition"><FaEllipsisH size={18} /></button>
+          <button
+            aria-label="Tafsir"
+            title="Tafsir"
+            className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            <FaBookReader size={18} />
+          </button>
+
+          <button
+            aria-label="More options"
+            title="More"
+            className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            <FaEllipsisH size={18} />
+          </button>
         </div>
       </div>
       <div className="flex-grow space-y-6">

--- a/app/features/surah/[surahId]/layout.tsx
+++ b/app/features/surah/[surahId]/layout.tsx
@@ -12,8 +12,12 @@ export default function SurahLayout({ children }: { children: React.ReactNode })
         <div className="h-screen flex flex-col">
           <Header />
           <div className="flex flex-grow overflow-hidden">
-            <IconSidebar />
-            <SurahListSidebar />
+            <nav aria-label="Primary navigation">
+              <IconSidebar />
+            </nav>
+            <nav aria-label="Surah navigation">
+              <SurahListSidebar />
+            </nav>
             {children}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add aria-labels and focus styles to navigation icons
- make verse controls accessible
- add aria-labels to panel back buttons
- wrap sidebars in `<nav>` for semantics

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687d52717ed0832b83a922c233b6a0b2