### PR TITLE
Replace inline colors with theme variables

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -21,7 +21,7 @@ const Header = () => {
 
   return (
     // Adjusted background, padding, and grid layout for cleaner look
-    <header className="h-16 grid grid-cols-3 items-center px-4 sm:px-8 bg-white shadow-sm sticky top-0 z-30">
+    <header className="h-16 grid grid-cols-3 items-center px-4 sm:px-8 bg-[var(--background)] text-[var(--foreground)] shadow-sm sticky top-0 z-30">
       {/* Column 1: Title & Surah List Toggle */}
       <div className="flex items-center gap-2">
         <button
@@ -31,7 +31,7 @@ const Header = () => {
         >
           <FaBars size={20} />
         </button>
-        <h1 className="text-xl font-semibold text-gray-800">{t('title')}</h1>
+        <h1 className="text-xl font-semibold text-[var(--foreground)]">{t('title')}</h1>
       </div>
 
       {/* Column 2: Centered Search Bar */}
@@ -44,7 +44,7 @@ const Header = () => {
             value={query}
             onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            className="w-full bg-gray-100 border border-gray-200 rounded-md py-2 px-10 focus:ring-1 focus:ring-teal-500 outline-none transition text-gray-700"
+            className="w-full bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-md py-2 px-10 focus:ring-1 focus:ring-teal-500 outline-none transition text-gray-700 dark:text-gray-200"
           />
         </div>
       </div>

--- a/app/components/common/IconSidebar.tsx
+++ b/app/components/common/IconSidebar.tsx
@@ -14,13 +14,13 @@ const IconSidebar = () => {
 
     return (
         // CHANGE: Removed the border-r class for a cleaner look and centered content vertically
-        <aside className="w-20 bg-[#F0FAF8] flex flex-col justify-center py-4">
+        <aside className="w-20 bg-[var(--background)] text-[var(--foreground)] flex flex-col justify-center py-4">
             <nav className="flex flex-col items-center space-y-2">
                 {navItems.map((item, index) => (
                     <Link key={index} href={item.href} title={item.label}>
                         <button
                             aria-label={item.label}
-                            className="p-3 rounded-lg hover:bg-gray-200 text-gray-600 hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+                            className="p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-[var(--foreground)] hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
                         >
                             <item.icon className="h-6 w-6" />
                         </button>

--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -69,7 +69,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
       />
       {/* Sidebar */}
       <aside
-        className={`fixed md:static inset-y-0 left-0 w-80 bg-[#F0FAF8] flex flex-col flex-shrink-0 shadow-[5px_0px_15px_-5px_rgba(0,0,0,0.05)] z-50 md:z-10 transition-transform duration-300 ${isSurahListOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0`}
+        className={`fixed md:static inset-y-0 left-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col flex-shrink-0 shadow-[5px_0px_15px_-5px_rgba(0,0,0,0.05)] z-50 md:z-10 transition-transform duration-300 ${isSurahListOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0`}
       >
         <div className="p-4 border-b border-gray-200/80">
           <div className="flex bg-gray-200 rounded-full p-1">
@@ -78,7 +78,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 key={tab.key}
                 onClick={() => setActiveTab(tab.key)}
                 className={`w-full py-2 text-sm font-semibold rounded-full transition-colors ${
-                  activeTab === tab.key ? 'bg-white text-teal-700 shadow' : 'text-gray-600 hover:bg-white'
+                  activeTab === tab.key ? 'bg-[var(--background)] text-teal-700 shadow' : 'text-gray-600 dark:text-gray-300 hover:bg-[var(--background)]'
                 }`}
               >
                 {tab.label}
@@ -94,7 +94,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
               placeholder={t('search_surah')}
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full bg-white border border-gray-200/80 rounded-lg py-2 pl-9 pr-3 focus:ring-2 focus:ring-teal-500 outline-none transition"
+              className="w-full bg-[var(--background)] border border-gray-200/80 dark:border-gray-600 rounded-lg py-2 pl-9 pr-3 focus:ring-2 focus:ring-teal-500 outline-none transition"
             />
           </div>
         </div>
@@ -106,15 +106,15 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <Link href={`/features/surah/${chapter.id}`} key={chapter.id}
                     className={`flex items-center gap-4 p-3 rounded-lg cursor-pointer transition-colors border-l-2 ${
-                      isActive ? 'border-teal-600 bg-teal-50' : 'border-transparent hover:bg-white'
+                      isActive ? 'border-teal-600 bg-teal-50' : 'border-transparent hover:bg-[var(--background)] dark:hover:bg-gray-800'
                     }`}>
                       <div className={`w-10 h-10 flex items-center justify-center rounded-xl text-sm font-semibold transition-colors ${
-                        isActive ? 'bg-teal-600 text-white' : 'bg-gray-200 text-gray-600'
+                        isActive ? 'bg-teal-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
                       }`}>
                         <span>{chapter.id}</span>
                       </div>
                       <div className="flex-grow">
-                        <p className={`font-semibold ${isActive ? 'text-teal-800' : 'text-gray-800'}`}>{chapter.name_simple}</p>
+                        <p className={`font-semibold ${isActive ? 'text-teal-800' : 'text-[var(--foreground)]'}`}>{chapter.name_simple}</p>
                         <p className="text-xs text-gray-500">{chapter.revelation_place}</p>
                       </div>
                       <p className={`font-mono text-xl ${isActive ? 'text-teal-800' : 'text-gray-500'}`}>
@@ -132,14 +132,14 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <Link href={`/features/juz/${j}`} key={j}
                     className={`flex items-center gap-4 p-3 rounded-lg cursor-pointer transition-colors border-l-2 ${
-                      isActive ? 'border-teal-600 bg-teal-50' : 'border-transparent hover:bg-white'
+                      isActive ? 'border-teal-600 bg-teal-50' : 'border-transparent hover:bg-[var(--background)] dark:hover:bg-gray-800'
                     }`}>
                       <div className={`w-10 h-10 flex items-center justify-center rounded-xl text-sm font-semibold transition-colors ${
-                        isActive ? 'bg-teal-600 text-white' : 'bg-gray-200 text-gray-600'
+                        isActive ? 'bg-teal-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
                       }`}>
                         <span>{j}</span>
                       </div>
-                      <p className={`font-semibold ${isActive ? 'text-teal-800' : 'text-gray-800'}`}>Juz {j}</p>
+                      <p className={`font-semibold ${isActive ? 'text-teal-800' : 'text-[var(--foreground)]'}`}>Juz {j}</p>
                   </Link>
                 );
               })}
@@ -152,14 +152,14 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <Link href={`/features/page/${p}`} key={p}
                     className={`flex items-center gap-4 p-3 rounded-lg cursor-pointer transition-colors border-l-2 ${
-                      isActive ? 'border-teal-600 bg-teal-50' : 'border-transparent hover:bg-white'
+                      isActive ? 'border-teal-600 bg-teal-50' : 'border-transparent hover:bg-[var(--background)] dark:hover:bg-gray-800'
                     }`}>
                       <div className={`w-10 h-10 flex items-center justify-center rounded-xl text-sm font-semibold transition-colors ${
-                        isActive ? 'bg-teal-600 text-white' : 'bg-gray-200 text-gray-600'
+                        isActive ? 'bg-teal-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
                       }`}>
                         <span>{p}</span>
                       </div>
-                      <p className={`font-semibold ${isActive ? 'text-teal-800' : 'text-gray-800'}`}>Page {p}</p>
+                      <p className={`font-semibold ${isActive ? 'text-teal-800' : 'text-[var(--foreground)]'}`}>Page {p}</p>
                   </Link>
                 );
               })}

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -89,8 +89,8 @@ export default function JuzPage({ params }: JuzPageProps) {
   );
   
   return (
-    <div className="flex flex-grow bg-white font-sans overflow-hidden">
-      <main className="flex-grow bg-[#F0FAF8] p-6 lg:p-10 overflow-y-auto">
+    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
           {isLoading ? (
             <div className="text-center py-20 text-teal-600">{t('loading_surah')}</div>

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -89,8 +89,8 @@ export default function QuranPage({ params }: QuranPageProps) {
   );
   
   return (
-    <div className="flex flex-grow bg-white font-sans overflow-hidden">
-      <main className="flex-grow bg-[#F0FAF8] p-6 lg:p-10 overflow-y-auto">
+    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
           {isLoading ? (
             <div className="text-center py-20 text-teal-600">{t('loading_surah')}</div>

--- a/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
+++ b/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
@@ -31,7 +31,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
   return (
     <>
       {/* No overlay div */}
-      <div className={`fixed top-0 right-0 w-80 h-full bg-[#F7F9F9] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+      <div className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button
             aria-label="Back"
@@ -40,16 +40,16 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
           >
             <FaArrowLeft size={18} />
           </button>
-          <h2 className="font-bold text-lg text-gray-800">{t('select_font_face')}</h2> {/* Assuming a translation key for the title */}
+          <h2 className="font-bold text-lg text-[var(--foreground)]">{t('select_font_face')}</h2> {/* Assuming a translation key for the title */}
           <div className="w-8"></div>
         </div>
         
         {/* Tab Buttons */}
-        <div className="flex justify-center p-3 space-x-2 bg-gray-100 border-b border-gray-200/80">
+        <div className="flex justify-center p-3 space-x-2 bg-gray-100 dark:bg-gray-800 border-b border-gray-200/80 dark:border-gray-600">
           {Object.keys(groupedFonts).map(category => (
             <button
               key={category}
-              className={`px-4 py-2 text-sm font-medium rounded-full transition-colors duration-200 ${activeTab === category ? 'bg-teal-600 text-white' : 'bg-gray-200 text-gray-600'}`}
+              className={`px-4 py-2 text-sm font-medium rounded-full transition-colors duration-200 ${activeTab === category ? 'bg-teal-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}
               onClick={() => setActiveTab(category)}
             >
               {category}
@@ -65,7 +65,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
                 className={`flex items-center justify-between w-full p-2 rounded-md hover:bg-teal-50 cursor-pointer ${settings.arabicFontFace === font.value ? 'bg-teal-100' : ''}`}
                 onClick={() => handleFontSelect(font.value)}
               >
-                <span className="text-sm text-gray-700" style={{ fontFamily: font.value }}>{font.name}</span> {/* Apply font family for preview */}
+                <span className="text-sm text-[var(--foreground)]" style={{ fontFamily: font.value }}>{font.name}</span> {/* Apply font family for preview */}
                 {settings.arabicFontFace === font.value && <FaCheck size={16} className="text-teal-600" />} {/* Checkmark for selected font */}
               </button>
             ))}

--- a/app/features/surah/[surahId]/_components/CollapsibleSection.tsx
+++ b/app/features/surah/[surahId]/_components/CollapsibleSection.tsx
@@ -6,11 +6,11 @@ import { FaChevronDown } from '@/app/components/common/SvgIcons';
 export const CollapsibleSection = ({ title, icon, children }: { title: string, icon: React.ReactNode, children: React.ReactNode }) => {
     const [isOpen, setIsOpen] = useState(true);
     return (
-        <div className="border-b border-gray-200/80">
+        <div className="border-b border-gray-200/80 dark:border-gray-600">
             <button onClick={() => setIsOpen(!isOpen)} className="w-full flex items-center justify-between p-4 text-left">
                 <div className="flex items-center space-x-3">
                     {icon}
-                    <span className="font-semibold text-gray-800">{title}</span>
+                    <span className="font-semibold text-[var(--foreground)]">{title}</span>
                 </div>
                 <FaChevronDown size={16} className={`text-gray-500 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
             </button>

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -39,14 +39,14 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
         onClick={() => setSettingsOpen(false)}
       />
       <aside
-        className={`fixed lg:static inset-y-0 right-0 w-80 bg-[#F0FAF8] flex-col flex-shrink-0 overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
+        className={`fixed lg:static inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >
         <div className="flex-grow">
           <CollapsibleSection title={t('reading_setting')} icon={<FaBookReader size={20} className="text-teal-700" />}>
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">{t('translations')}</label>
-              <button onClick={onTranslationPanelOpen} className="w-full flex justify-between items-center bg-white border border-gray-300 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
-                <span className="truncate text-gray-800">{selectedTranslationName}</span>
+              <label className="block text-sm font-medium text-[var(--foreground)]">{t('translations')}</label>
+              <button onClick={onTranslationPanelOpen} className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
+                <span className="truncate text-[var(--foreground)]">{selectedTranslationName}</span>
                 <FaChevronDown className="text-gray-500" />
               </button>
             </div>
@@ -54,7 +54,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
           <CollapsibleSection title={t('font_setting')} icon={<FaFontSetting size={20} className="text-teal-700" />}>
             <div className="space-y-4">
               <div>
-                <div className="flex justify-between mb-1 text-sm"><label className="text-gray-700">{t('arabic_font_size')}</label><span className="font-semibold text-teal-700">{settings.arabicFontSize}</span></div>
+                <div className="flex justify-between mb-1 text-sm"><label className="text-[var(--foreground)]">{t('arabic_font_size')}</label><span className="font-semibold text-teal-700">{settings.arabicFontSize}</span></div>
                 <input
                   type="range"
                   min="16"
@@ -65,7 +65,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
                 />
               </div>
               <div>
-                <div className="flex justify-between mb-1 text-sm"><label className="text-gray-700">{t('translation_font_size')}</label><span className="font-semibold text-teal-700">{settings.translationFontSize}</span></div>
+                <div className="flex justify-between mb-1 text-sm"><label className="text-[var(--foreground)]">{t('translation_font_size')}</label><span className="font-semibold text-teal-700">{settings.translationFontSize}</span></div>
                 <input
                   type="range"
                   min="12"
@@ -77,19 +77,19 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
               </div>
               {/* Arabic Font Face Selection Button */}
               <div>
-                <label className="block mb-2 text-sm font-medium text-gray-700">{t('arabic_font_face')}</label>
-                <button onClick={() => setIsArabicFontPanelOpen(true)} className="w-full flex justify-between items-center bg-white border border-gray-300 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
-                  <span className="truncate text-gray-800">{selectedArabicFont}</span>
+                <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">{t('arabic_font_face')}</label>
+                <button onClick={() => setIsArabicFontPanelOpen(true)} className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
+                  <span className="truncate text-[var(--foreground)]">{selectedArabicFont}</span>
                   <FaChevronDown className="text-gray-500" />
                 </button>
               </div>
             </div>
           </CollapsibleSection>
         </div>
-        <div className="p-4 border-t border-gray-200/80">
+        <div className="p-4 border-t border-gray-200/80 dark:border-gray-600">
           <button
             onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-            className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-sm hover:border-teal-500 transition"
+            className="w-full bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm hover:border-teal-500 transition"
           >
             {theme === 'light' ? t('switch_to_dark') : t('switch_to_light')}
           </button>

--- a/app/features/surah/[surahId]/_components/TafsirModal.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirModal.tsx
@@ -21,10 +21,10 @@ export const TafsirModal = ({ verseKey, isOpen, onClose }: TafsirModalProps) => 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
-      <div className="bg-white relative max-w-lg w-full max-h-[80vh] overflow-y-auto rounded-lg shadow-lg p-6">
+      <div className="bg-[var(--background)] text-[var(--foreground)] relative max-w-lg w-full max-h-[80vh] overflow-y-auto rounded-lg shadow-lg p-6">
         <button
           onClick={onClose}
-          className="absolute left-3 top-3 p-2 rounded-full hover:bg-gray-200"
+          className="absolute left-3 top-3 p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700"
         >
           <FaArrowLeft size={18} />
         </button>

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -18,7 +18,7 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
   return (
     <>
       {/* Removed the overlay div */}
-      <div className={`fixed top-0 right-0 w-80 h-full bg-[#F7F9F9] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+      <div className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button
             aria-label="Back"
@@ -27,13 +27,13 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
           >
             <FaArrowLeft size={18} />
           </button>
-          <h2 className="font-bold text-lg text-gray-800">{t('translations_panel_title')}</h2>
+          <h2 className="font-bold text-lg text-[var(--foreground)]">{t('translations_panel_title')}</h2>
           <div className="w-8"></div>
         </div>
         <div className="p-3 border-b border-gray-200/80">
           <div className="relative">
             <FaSearch className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
-            <input type="text" placeholder={t('search')} value={searchTerm} onChange={e => onSearchTermChange(e.target.value)} className="w-full pl-10 pr-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none" />
+            <input type="text" placeholder={t('search')} value={searchTerm} onChange={e => onSearchTermChange(e.target.value)} className="w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none bg-[var(--background)] text-[var(--foreground)]" />
           </div>
         </div>
         <div className="flex-grow overflow-y-auto">
@@ -53,7 +53,7 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
                         onClose();
                       }}
                     />
-                    <span className="text-sm text-gray-700">{opt.name}</span>
+                    <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
                   </label>
                 ))}
               </div>

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -24,14 +24,14 @@ export const Verse = ({ verse }: VerseProps) => {
       <div className="flex items-start gap-x-6 mb-12 border-b pb-8 border-gray-200">
         <div className="w-16 text-center pt-1 space-y-2 flex-shrink-0">
           <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>
-          <div className="flex flex-col items-center space-y-1 text-gray-400">
+          <div className="flex flex-col items-center space-y-1 text-gray-400 dark:text-gray-500">
             <button
               aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
               onClick={() =>
                 setPlayingId(currentId => (currentId === verse.id ? null : verse.id))
               }
               title="Play/Pause"
-              className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
+              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
             >
               {isLoadingAudio ? (
                 <Spinner className="h-4 w-4 text-teal-600" />
@@ -46,7 +46,7 @@ export const Verse = ({ verse }: VerseProps) => {
               aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
               title="Bookmark"
               onClick={() => toggleBookmark(String(verse.id))}
-              className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
+              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
             >
               {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
             </button>
@@ -56,7 +56,7 @@ export const Verse = ({ verse }: VerseProps) => {
               aria-label="Tafsir"
               title="Tafsir"
               onClick={() => setShowTafsir(true)}
-              className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             >
               <FaBookReader size={18} />
             </button>
@@ -64,7 +64,7 @@ export const Verse = ({ verse }: VerseProps) => {
             <button
               aria-label="More options"
               title="More"
-              className="p-1.5 rounded-full hover:bg-gray-100 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             >
               <FaEllipsisH size={18} />
             </button>
@@ -72,7 +72,7 @@ export const Verse = ({ verse }: VerseProps) => {
         </div>
         <div className="flex-grow space-y-6">
           <p
-            className="text-right leading-loose text-gray-800"
+            className="text-right leading-loose text-[var(--foreground)]"
             style={{ fontFamily: settings.arabicFontFace, fontSize: `${settings.arabicFontSize}px`, lineHeight: 2.2 }}
           >
             {verse.text_uthmani}
@@ -80,7 +80,7 @@ export const Verse = ({ verse }: VerseProps) => {
           {verse.translations?.map((t: Translation) => (
             <div key={t.resource_id}>
               <p
-                className="text-left leading-relaxed text-gray-600"
+                className="text-left leading-relaxed text-[var(--foreground)]"
                 style={{ fontSize: `${settings.translationFontSize}px` }}
                 dangerouslySetInnerHTML={{ __html: t.text }}
               />

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -90,8 +90,8 @@ export default function SurahPage({ params }: SurahPageProps) {
   );
   
   return (
-    <div className="flex flex-grow bg-white font-sans overflow-hidden">
-      <main className="flex-grow bg-[#F0FAF8] p-6 lg:p-10 overflow-y-auto">
+    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
           {isLoading ? (
             <div className="flex justify-center py-20">


### PR DESCRIPTION
## Summary
- use CSS variables for colors in shared components
- update surah/juz/page pages to use theme variables
- tweak SettingsSidebar and other panels for theme-aware styles
- keep Tailwind dark variants where needed

## Testing
- `npm test` *(fails: useSidebar must be used within SidebarProvider)*

------
https://chatgpt.com/codex/tasks/task_b_687dce156080832ba8a158ddafc3991c