### PR TITLE
Fix route param access warning

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -22,20 +22,21 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
   const pages = useMemo(() => Array.from({ length: 604 }, (_, i) => i + 1), []);
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTab, setActiveTab] = useState('Surah'); // Canonical state: 'Surah', 'Juz', 'Page'
-  const params = useParams();
+  const paramsPromise = useParams();
+  const { surahId, juzId, pageId } = React.use(paramsPromise as any);
 
   // --- MERGED AND CORRECTED SECTION ---
   const { isSurahListOpen, setSurahListOpen } = useSidebar();
-  const activeSurahId = params.surahId;
-  const activeJuzId = params.juzId;
-  const activePageId = params.pageId;
+  const activeSurahId = surahId;
+  const activeJuzId = juzId;
+  const activePageId = pageId;
 
   // Effect to set the active tab based on the current route parameters
   useEffect(() => {
-    if (params.juzId) setActiveTab('Juz');
-    else if (params.pageId) setActiveTab('Page');
-    else if (params.surahId) setActiveTab('Surah');
-  }, [params.juzId, params.pageId, params.surahId]);
+    if (juzId) setActiveTab('Juz');
+    else if (pageId) setActiveTab('Page');
+    else if (surahId) setActiveTab('Surah');
+  }, [juzId, pageId, surahId]);
   // --- END MERGED AND CORRECTED SECTION ---
 
   const filteredChapters = useMemo(() =>

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 interface JuzPageProps {
-  params: { juzId: string };
+  params: Promise<{ juzId: string }>;
 }
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';
@@ -23,6 +23,7 @@ import useSWRInfinite from 'swr/infinite';
 // If you encounter build errors, you may need to revert to `any` as Next.js's
 // type for PageProps can sometimes cause mismatches.
 export default function JuzPage({ params }: JuzPageProps) {
+  const { juzId } = React.use(params);
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();
@@ -41,8 +42,8 @@ export default function JuzPage({ params }: JuzPageProps) {
     isValidating
   } = useSWRInfinite(
     index =>
-      params.juzId
-        ? ['verses', params.juzId, settings.translationId, index + 1]
+      juzId
+        ? ['verses', juzId, settings.translationId, index + 1]
         : null,
     ([, juzId, translationId, page]) =>
       getVersesByJuz(juzId, translationId, page).catch(err => {

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 interface QuranPageProps {
-  params: { pageId: string };
+  params: Promise<{ pageId: string }>;
 }
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';
@@ -23,6 +23,7 @@ import useSWRInfinite from 'swr/infinite';
 // If you encounter build errors, you may need to revert to `any` as Next.js's
 // type for PageProps can sometimes cause mismatches.
 export default function QuranPage({ params }: QuranPageProps) {
+  const { pageId } = React.use(params);
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();
@@ -41,8 +42,8 @@ export default function QuranPage({ params }: QuranPageProps) {
     isValidating
   } = useSWRInfinite(
     index =>
-      params.pageId
-        ? ['verses', params.pageId, settings.translationId, index + 1]
+      pageId
+        ? ['verses', pageId, settings.translationId, index + 1]
         : null,
     ([, pageId, translationId, page]) =>
       getVersesByPage(pageId, translationId, page).catch(err => {

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 interface SurahPageProps {
-  params: { surahId: string };
+  params: Promise<{ surahId: string }>;
 }
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';
@@ -24,6 +24,7 @@ import useSWRInfinite from 'swr/infinite';
 // If you encounter build errors, you may need to revert to `any` as Next.js's
 // type for PageProps can sometimes cause mismatches.
 export default function SurahPage({ params }: SurahPageProps) {
+  const { surahId } = React.use(params);
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();
@@ -42,8 +43,8 @@ export default function SurahPage({ params }: SurahPageProps) {
     isValidating
   } = useSWRInfinite(
     index =>
-      params.surahId
-        ? ['verses', params.surahId, settings.translationId, index + 1]
+      surahId
+        ? ['verses', surahId, settings.translationId, index + 1]
         : null,
     ([, surahId, translationId, page]) =>
       getVersesByChapter(surahId, translationId, page).catch(err => {


### PR DESCRIPTION
## Summary
- unwrap route params with `React.use` to satisfy Next.js v15

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_687dd33ddc9c832b91ef90f640ea965e