### PR TITLE
Remove param state usage

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -17,15 +17,11 @@ interface JuzPageProps {
   params: { juzId: string };
 }
 
-export default function JuzPage({ params }: JuzPageProps) {
-  const [currentJuzId, setCurrentJuzId] = useState<string | null>(null); // Use state to store juzId
-
-  useEffect(() => {
-    // Access params.juzId in useEffect on the client side
-    if (params?.juzId) {
-      setCurrentJuzId(params.juzId);
-    }
-  }, [params]); // Re-run effect if params changes
+export default function JuzPage(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { params }: any
+) {
+  const { juzId } = params as JuzPageProps['params'];
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
@@ -35,9 +31,9 @@ export default function JuzPage({ params }: JuzPageProps) {
   const [translationSearchTerm, setTranslationSearchTerm] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-  // Fetch Juz information using currentJuzId
+  // Fetch Juz information using juzId
   const { data: juzData, error: juzError } = useSWR(
-    currentJuzId ? ['juz', currentJuzId] : null,
+    juzId ? ['juz', juzId] : null,
     ([, id]) => getJuz(id)
   );
   const juz: Juz | undefined = juzData;
@@ -52,8 +48,8 @@ export default function JuzPage({ params }: JuzPageProps) {
     isValidating
   } = useSWRInfinite(
     index =>
-      currentJuzId
-        ? ['verses', currentJuzId, settings.translationId, index + 1]
+      juzId
+        ? ['verses', juzId, settings.translationId, index + 1]
         : null,
     ([, juzId, translationId, page]) =>
       getVersesByJuz(juzId, translationId, page).catch(err => {
@@ -103,8 +99,8 @@ export default function JuzPage({ params }: JuzPageProps) {
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
       <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
-          {/* Only render content when currentJuzId is available */}
-          {currentJuzId ? (
+          {/* Only render content when juzId is available */}
+          {juzId ? (
             isLoading ? (
               <div className="text-center py-20 text-teal-600">{t('loading')}</div>
             ) : error ? (

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -17,15 +17,11 @@ interface QuranPageProps {
   params: { pageId: string };
 }
 
-export default function QuranPage({ params }: QuranPageProps) {
-  const [currentPageId, setCurrentPageId] = useState<string | null>(null); // Use state to store pageId
-
-  useEffect(() => {
-    // Access params.pageId in useEffect on the client side
-    if (params?.pageId) {
-      setCurrentPageId(params.pageId);
-    }
-  }, [params]); // Re-run effect if params changes
+export default function QuranPage(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { params }: any
+) {
+  const { pageId } = params as QuranPageProps['params'];
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
@@ -45,8 +41,8 @@ export default function QuranPage({ params }: QuranPageProps) {
     isValidating
   } = useSWRInfinite(
     index =>
-      currentPageId
-        ? ['verses', currentPageId, settings.translationId, index + 1]
+      pageId
+        ? ['verses', pageId, settings.translationId, index + 1]
         : null,
     ([, pageId, translationId, page]) =>
       getVersesByPage(pageId, translationId, page).catch(err => {
@@ -96,8 +92,8 @@ export default function QuranPage({ params }: QuranPageProps) {
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
       <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
-          {/* Only render content when currentPageId is available */}
-          {currentPageId ? (
+          {/* Only render content when pageId is available */}
+          {pageId ? (
             isLoading ? (
               <div className="text-center py-20 text-teal-600">{t('loading')}</div>
             ) : error ? (

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 interface SurahPageProps {
-  params: Promise<{ surahId: string }>;
+  params: { surahId: string };
 }
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';
@@ -23,8 +23,11 @@ import useSWRInfinite from 'swr/infinite';
 // Using a specific type for params is good practice.
 // If you encounter build errors, you may need to revert to `any` as Next.js's
 // type for PageProps can sometimes cause mismatches.
-export default function SurahPage({ params }: SurahPageProps) {
-  const { surahId } = React.use(params);
+export default function SurahPage(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { params }: any
+) {
+  const { surahId } = params as SurahPageProps['params'];
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- use params directly in dynamic pages
- drop React.use usage and related state

## Testing
- `npm run build` *(fails: useSearchParams needs Suspense)*

------
https://chatgpt.com/codex/tasks/task_b_687e01af9e88832bbf1385a939ef2c56