### PR TITLE
Implement Juz API call and tests

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,0 +1,33 @@
+import { getJuz, API_BASE_URL } from '@/lib/api';
+import { Juz } from '@/types';
+
+describe('getJuz', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetches Juz data', async () => {
+    const mockJuz: Juz = {
+      id: 1,
+      juz_number: 1,
+      verse_mapping: { '1': '1-7' },
+      first_verse_id: 1,
+      last_verse_id: 148,
+      verses_count: 148,
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ juz: mockJuz }),
+    }) as jest.Mock;
+
+    const result = await getJuz(1);
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE_URL}/juzs/1`);
+    expect(result).toEqual(mockJuz);
+  });
+
+  it('throws on fetch error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as jest.Mock;
+    await expect(getJuz(1)).rejects.toThrow('Failed to fetch juz: 404');
+  });
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -112,15 +112,14 @@ export async function getVersesByPage(
   return { verses: data.verses as Verse[], totalPages };
 }
 
-// Placeholder for fetching Juz information
+// Fetch information about a specific Juz
 export async function getJuz(juzId: string | number): Promise<Juz> {
-  // TODO: Implement actual API call to fetch Juz information
-  console.warn(`getJuz(${juzId}) not implemented. Returning placeholder data.`);
-  return {
-    id: Number(juzId),
-    juz_number: Number(juzId),
-    // Add other placeholder properties as needed
-  };
+  const res = await fetch(`${API_BASE_URL}/juzs/${juzId}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch juz: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.juz as Juz;
 }
 
 export { API_BASE_URL };

--- a/types/index.ts
+++ b/types/index.ts
@@ -6,6 +6,8 @@ export * from './settings';
 export interface Juz {
   id: number;
   juz_number: number;
-  // Add any other properties of a Juz that your API provides
-  // For example: name_arabic, name_english, start_verse, end_verse, etc.
+  verse_mapping: Record<string, string>;
+  first_verse_id: number;
+  last_verse_id: number;
+  verses_count: number;
 }


### PR DESCRIPTION
## Summary
- implement real API call in `getJuz`
- extend `Juz` type to include API fields
- add unit tests for `getJuz`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e01c854c0832bae74dd077089a192