### PR TITLE
Remove unused config option

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,8 +49,6 @@ const nextConfig: NextConfig = {
     ];
   },
 
-  // 4. Add allowed development origins for cross-origin requests
-  allowedDevOrigins: ['https://3000-firebase-quran-app-v1-1753035302321.cluster-ubrd2huk7jh6otbgyei4h62ope.cloudworkstations.dev'],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- delete `allowedDevOrigins` from `next.config.ts`
- verify build succeeds

## Testing
- `npm run lint`
- `npm test`
- `TSC_COMPILE_ON_ERROR=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687e01d59abc832b8d30fa102c82d5ad