### PR TITLE
Use React.use for promise params

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -21,7 +21,7 @@ export default function JuzPage(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   { params }: any
 ) {
-  const { juzId } = params as JuzPageProps['params'];
+  const { juzId } = React.use(params) as JuzPageProps['params'];
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -21,7 +21,7 @@ export default function QuranPage(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   { params }: any
 ) {
-  const { pageId } = params as QuranPageProps['params'];
+  const { pageId } = React.use(params) as QuranPageProps['params'];
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -27,7 +27,7 @@ export default function SurahPage(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   { params }: any
 ) {
-  const { surahId } = params as SurahPageProps['params'];
+  const { surahId } = React.use(params) as SurahPageProps['params'];
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- use `React.use` to unwrap `params` in Surah, Juz and Page pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687e10a66f80832b844c3022121d29c5