### PR TITLE
Persist font settings across navigation

### DIFF
--- a/app/features/juz/[juzId]/layout.tsx
+++ b/app/features/juz/[juzId]/layout.tsx
@@ -2,22 +2,19 @@
 import Header from '@/app/components/common/Header';
 import IconSidebar from '@/app/components/common/IconSidebar';
 import SurahListSidebar from '@/app/components/common/SurahListSidebar';
-import { SettingsProvider } from '@/app/context/SettingsContext';
 import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function JuzLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SettingsProvider>
-      <AudioProvider>
-        <div className="h-screen flex flex-col">
-          <Header />
-          <div className="flex flex-grow overflow-hidden">
-            <IconSidebar />
-            <SurahListSidebar />
-            {children}
-          </div>
+    <AudioProvider>
+      <div className="h-screen flex flex-col">
+        <Header />
+        <div className="flex flex-grow overflow-hidden">
+          <IconSidebar />
+          <SurahListSidebar />
+          {children}
         </div>
-      </AudioProvider>
-    </SettingsProvider>
+      </div>
+    </AudioProvider>
   );
 }

--- a/app/features/page/[pageId]/layout.tsx
+++ b/app/features/page/[pageId]/layout.tsx
@@ -2,22 +2,19 @@
 import Header from '@/app/components/common/Header';
 import IconSidebar from '@/app/components/common/IconSidebar';
 import SurahListSidebar from '@/app/components/common/SurahListSidebar';
-import { SettingsProvider } from '@/app/context/SettingsContext';
 import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function PageLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SettingsProvider>
-      <AudioProvider>
-        <div className="h-screen flex flex-col">
-          <Header />
-          <div className="flex flex-grow overflow-hidden">
-            <IconSidebar />
-            <SurahListSidebar />
-            {children}
-          </div>
+    <AudioProvider>
+      <div className="h-screen flex flex-col">
+        <Header />
+        <div className="flex flex-grow overflow-hidden">
+          <IconSidebar />
+          <SurahListSidebar />
+          {children}
         </div>
-      </AudioProvider>
-    </SettingsProvider>
+      </div>
+    </AudioProvider>
   );
 }

--- a/app/features/surah/[surahId]/layout.tsx
+++ b/app/features/surah/[surahId]/layout.tsx
@@ -3,29 +3,23 @@
 import Header from '@/app/components/common/Header';
 import IconSidebar from '@/app/components/common/IconSidebar';
 import SurahListSidebar from '@/app/components/common/SurahListSidebar';
-import { SettingsProvider } from '@/app/context/SettingsContext';
 import { AudioProvider } from '@/app/context/AudioContext';
-import { SidebarProvider } from '@/app/context/SidebarContext';
 
 export default function SurahLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SettingsProvider>
-      <AudioProvider>
-        <SidebarProvider>
-          <div className="h-screen flex flex-col">
-            <Header />
-            <div className="flex flex-grow overflow-hidden">
-              <nav aria-label="Primary navigation">
-                <IconSidebar />
-              </nav>
-              <nav aria-label="Surah navigation">
-                <SurahListSidebar />
-              </nav>
-              {children}
-            </div>
-          </div>
-        </SidebarProvider>
-      </AudioProvider>
-    </SettingsProvider>
+    <AudioProvider>
+      <div className="h-screen flex flex-col">
+        <Header />
+        <div className="flex flex-grow overflow-hidden">
+          <nav aria-label="Primary navigation">
+            <IconSidebar />
+          </nav>
+          <nav aria-label="Surah navigation">
+            <SurahListSidebar />
+          </nav>
+          {children}
+        </div>
+      </div>
+    </AudioProvider>
   );
 }


### PR DESCRIPTION
## Summary
- avoid remounting SettingsContext in nested layouts
- clean up page, surah and juz layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e587530a0832baa229747fe9eb86a