### PR TITLE
Integrate design system tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,12 +6,16 @@
   --background: #F7F9F9; /* Lighter background color */
   --foreground: #374151; /* Softer foreground color */
   --border-color: #e5e7eb; /* Subtle border color */
+  --accent: #0d9488;
+  --accent-hover: #0f766e;
 }
 
 [data-theme='dark'] {
   --background: #1a202c; /* Darker background for dark mode */
   --foreground: #d1d5db; /* Lighter foreground for dark mode */
   --border-color: #4b5563; /* Darker border for dark mode */
+  --accent: #0d9488;
+  --accent-hover: #0f766e;
 }
 
 body {
@@ -41,7 +45,7 @@ input[type="range"] {
   height: 6px;
   border-radius: 5px;
   outline: none;
-  background: linear-gradient(to right, #0d9488 var(--value-percent, 0%), var(--border-color) var(--value-percent, 0%)); /* Use border-color variable */
+  background: linear-gradient(to right, var(--accent) var(--value-percent, 0%), var(--border-color) var(--value-percent, 0%));
 }
 
 input[type="range"]::-webkit-slider-thumb {
@@ -70,16 +74,16 @@ input[type="range"]::-moz-range-thumb {
 /* CHANGE: Glow effect now on hover and active, not focus */
 input[type="range"]:hover::-webkit-slider-thumb,
 input[type="range"]:active::-webkit-slider-thumb {
-  background: #0d9488;
-  border-color: #0d9488;
-  box-shadow: 0 0 0 4px rgba(13, 148, 136, 0.2);
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 input[type="range"]:hover::-moz-range-thumb,
 input[type="range"]:active::-moz-range-thumb {
-  background: #0d9488;
-  border-color: #0d9488;
-  box-shadow: 0 0 0 4px rgba(13, 148, 136, 0.2);
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 /* --- Custom Modern Scrollbar Styles --- */
@@ -92,11 +96,11 @@ input[type="range"]:active::-moz-range-thumb {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #0d9488;
+  background: var(--accent);
   border-radius: 10px;
-  border: 2px solid var(--background); /* Use background variable */
+  border: 2px solid var(--background);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #0f766e;
+  background: var(--accent-hover);
 }

--- a/design-system.json
+++ b/design-system.json
@@ -1,0 +1,33 @@
+{
+  "colors": {
+    "background": "#F7F9F9",
+    "foreground": "#374151",
+    "border": "#e5e7eb",
+    "backgroundDark": "#1a202c",
+    "foregroundDark": "#d1d5db",
+    "borderDark": "#4b5563",
+    "accent": "#0d9488",
+    "accentHover": "#0f766e"
+  },
+  "typography": {
+    "fontFamilyBase": "Arial, Helvetica, sans-serif",
+    "fontSizeBase": "16px",
+    "headings": {
+      "h1": "2rem",
+      "h2": "1.5rem",
+      "h3": "1.25rem"
+    }
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px"
+  },
+  "components": {
+    "borderRadius": "0.375rem",
+    "shadow": "0 1px 2px rgba(0,0,0,0.05)",
+    "transition": "0.2s ease-in-out"
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,39 @@
+import designTokens from './design-system.json' assert { type: 'json' };
+
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: [
+    './app/**/*.{ts,tsx,js,jsx}',
+    './lib/**/*.{ts,tsx,js,jsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        border: 'var(--border-color)',
+        accent: designTokens.colors.accent,
+        'accent-hover': designTokens.colors.accentHover,
+      },
+      spacing: designTokens.spacing,
+      fontFamily: {
+        base: [designTokens.typography.fontFamilyBase, 'sans-serif'],
+      },
+      fontSize: {
+        base: designTokens.typography.fontSizeBase,
+        h1: designTokens.typography.headings.h1,
+        h2: designTokens.typography.headings.h2,
+        h3: designTokens.typography.headings.h3,
+      },
+      borderRadius: {
+        DEFAULT: designTokens.components.borderRadius,
+      },
+      boxShadow: {
+        default: designTokens.components.shadow,
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add `design-system.json` with color, typography, spacing and component tokens
- create `tailwind.config.mjs` that loads these tokens
- use design tokens as CSS variables in `globals.css`

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: useSearchParams() should be wrapped in a suspense boundary)*

------
https://chatgpt.com/codex/tasks/task_b_687e9796c94c832ba7d881b617282e3d