### PR TITLE
Fix params retrieval in dynamic pages

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -17,11 +17,8 @@ interface JuzPageProps {
   params: { juzId: string };
 }
 
-export default function JuzPage(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  { params }: any
-) {
-  const { juzId } = React.use(params) as JuzPageProps['params'];
+export default function JuzPage({ params }: JuzPageProps) {
+  const { juzId } = params;
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -17,11 +17,8 @@ interface QuranPageProps {
   params: { pageId: string };
 }
 
-export default function QuranPage(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  { params }: any
-) {
-  const { pageId } = React.use(params) as QuranPageProps['params'];
+export default function QuranPage({ params }: QuranPageProps) {
+  const { pageId } = params;
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -23,11 +23,8 @@ import useSWRInfinite from 'swr/infinite';
 // Using a specific type for params is good practice.
 // If you encounter build errors, you may need to revert to `any` as Next.js's
 // type for PageProps can sometimes cause mismatches.
-export default function SurahPage(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  { params }: any
-) {
-  const { surahId } = React.use(params) as SurahPageProps['params'];
+export default function SurahPage({ params }: SurahPageProps) {
+  const { surahId } = params;
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- correct dynamic params access in Surah, Juz and Quran page routes
- type the page props directly instead of using `any`

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687e979833d4832bb288a89b83f15855