### PR TITLE
Wrap search page in Suspense

### DIFF
--- a/app/features/search/page.tsx
+++ b/app/features/search/page.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { searchVerses } from '@/lib/api';
 import { Verse as VerseType } from '@/types';
 import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
 
-export default function SearchPage() {
+function SearchContent() {
   const searchParams = useSearchParams();
   const query = searchParams.get('query') || '';
   const [verses, setVerses] = useState<VerseType[]>([]);
@@ -43,5 +43,13 @@ export default function SearchPage() {
         ))}
       </div>
     </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<div className="p-6 max-w-4xl mx-auto">Loading...</div>}>
+      <SearchContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap search page content in a `<Suspense>` boundary

## Testing
- `npx next build`

------
https://chatgpt.com/codex/tasks/task_b_687e9798b4ac832bbb2c91dec8827b65