### PR TITLE
Fix ESLint warnings

### DIFF
--- a/app/features/bookmarks/_components/BookmarkedVersesList.tsx
+++ b/app/features/bookmarks/_components/BookmarkedVersesList.tsx
@@ -3,7 +3,6 @@
 import { useSettings } from '@/app/context/SettingsContext';
 // You will likely need to fetch verse data based on the bookmarkedVerseIds
 // import { fetchVerseById } from '@/lib/api'; // Assuming you have an API function to fetch verse data
-import { useEffect, useState } from 'react';
 // import { Verse } from '@/types'; // Assuming you have a Verse type
 
 const BookmarkedVersesList = () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { SettingsProvider } from './context/SettingsContext'; // Import SettingsProvider
 import { SidebarProvider } from './context/SidebarContext'; // Import SidebarProvider
 import localFont from 'next/font/local';
+import { Inter } from 'next/font/google';
 
 const kfgqpc = localFont({
   src: '../public/fonts/KFGQPC-Uthman-Taha.ttf',
@@ -25,6 +26,12 @@ const amiri = localFont({
   display: 'swap',
 });
 
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+});
+
 export const metadata = {
   title: 'Quran Mazid',
   description: 'Read, Study, and Learn The Holy Quran',
@@ -33,12 +40,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-      </head>
-      <body className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable}`}>
+      <body
+        className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${inter.className}`}
+      >
         <TranslationProvider>
           <ThemeProvider>
             <SettingsProvider> {/* Wrap with SettingsProvider */}


### PR DESCRIPTION
## Summary
- remove unused `useEffect` and `useState` imports from `BookmarkedVersesList`
- use the Next.js `Inter` font helper in `layout.tsx` to avoid the custom font lint warning

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e979ae388832bb1f12654ee662e6c