### PR TITLE
Enable data-theme dark mode

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,6 +2,7 @@ import designTokens from './design-system.json' assert { type: 'json' };
 
 /** @type {import('tailwindcss').Config} */
 const config = {
+  darkMode: ['class', '[data-theme="dark"]'],
   content: [
     './app/**/*.{ts,tsx,js,jsx}',
     './lib/**/*.{ts,tsx,js,jsx}',


### PR DESCRIPTION
## Summary
- enable Tailwind `dark:` styles to react to `[data-theme="dark"]`

## Testing
- `npm test`
- `npm run build` *(fails: `Failed to compile` due to lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_687ec27694dc832bafebe64123f68c24