### PR TITLE
Set global Inter font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,7 +21,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif; /* You might want to change this to a more modern font */
+  font-family: Inter, sans-serif;
   margin: 0;
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary
- use Inter globally in app styles

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, anchor-is-valid)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ecce4dd54832b8fe94cf28d2079a8