### PR TITLE
Remove inline styles from HomePage

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -160,34 +160,6 @@ export default function HomePage() {
   const [activeTab, setActiveTab] = useState<'Surah' | 'Juz' | 'Page'>('Surah');
   const { theme, setTheme } = useTheme();
 
-  const customStyles = `
-    @import url('https://fonts.googleapis.com/css2?family=Amiri:wght@700&family=Inter:wght@300;400;500;600;700&display=swap');
-
-    body {
-      font-family: 'Inter', sans-serif;
-      background-color: #f8fafc;
-      transition: background-color 0.3s ease;
-    }
-
-    [data-theme='dark'] body {
-      background-color: #020617;
-    }
-
-    .font-amiri {
-      font-family: 'Amiri', serif;
-    }
-
-    @keyframes fadeInUp {
-      from { opacity: 0; transform: translateY(20px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-
-    .animate-fade-in-up { animation: fadeInUp 0.8s ease-out forwards; }
-    .animation-delay-200 { animation-delay: 200ms; }
-    .animation-delay-400 { animation-delay: 400ms; }
-    .animation-delay-600 { animation-delay: 600ms; }
-    .content-visibility-auto { opacity: 0; }
-  `;
 
   const filteredSurahs = useMemo(() => {
     if (!searchQuery) return allSurahs;
@@ -199,9 +171,8 @@ export default function HomePage() {
 
   const shortcutSurahs = ['Al-Mulk', 'Al-Kahf', 'Ya-Sin', 'Al-Ikhlas'];
 
-  return (
-    <>
-      <style>{customStyles}</style>
+  return (
+    <>
       <div className="min-h-screen w-full text-slate-800 dark:text-slate-200 bg-gradient-to-br from-cyan-50/20 via-white to-emerald-50/20 dark:bg-gray-900 dark:from-gray-900 dark:to-slate-900 overflow-x-hidden">
         <div className="absolute top-0 left-0 w-full h-full z-0">
           <div className="absolute top-[-10rem] right-[-10rem] w-72 h-72 bg-emerald-400/10 dark:bg-emerald-500/10 rounded-full filter blur-3xl opacity-50" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,9 +21,10 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif; /* You might want to change this to a more modern font */
+  font-family: Inter, sans-serif;
   margin: 0;
   overflow-x: hidden;
+  transition: background-color 0.3s ease;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -137,4 +138,9 @@ input[type="range"]:active::-moz-range-thumb {
 
 .content-visibility-auto {
   opacity: 0;
+}
+
+/* Utility class for Arabic font */
+.font-amiri {
+  font-family: var(--font-amiri), 'Amiri', serif;
 }


### PR DESCRIPTION
## Summary
- remove `customStyles` from `HomePage`
- move body styling and `.font-amiri` class to `globals.css`
- keep animations and fonts globally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687eccea5700832b8374680ec042f114