### PR TITLE
Fix homepage links

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState, useMemo } from 'react';
 import { useTheme } from '@/app/context/ThemeContext';
+import Link from 'next/link';
 
 // --- Data for all 114 Surahs with English meanings ---
 const allSurahs = [
@@ -212,7 +213,7 @@ export default function HomePage() {
         <div className="relative z-10 flex flex-col min-h-screen px-4 sm:px-6 lg:px-8">
           <header className="w-full py-4">
             <nav className="flex justify-between items-center max-w-7xl mx-auto p-3 sm:p-4 bg-white/50 dark:bg-slate-800/50 border border-white/60 dark:border-slate-700/60 rounded-2xl shadow-lg backdrop-blur-xl">
-              <h1 className="text-2xl font-bold tracking-wider text-slate-900 dark:text-white">Al Qur'an</h1>
+              <h1 className="text-2xl font-bold tracking-wider text-slate-900 dark:text-white">Al Qur&apos;an</h1>
               <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')} className="p-2 bg-black/5 dark:bg-white/10 rounded-full hover:bg-black/10 dark:hover:bg-white/20 transition-colors">
                 {theme === 'light' ? <Moon className="w-5 h-5 text-slate-700" /> : <Sun className="w-5 h-5 text-yellow-400" />}
               </button>
@@ -221,9 +222,9 @@ export default function HomePage() {
 
           <main className="flex-grow flex flex-col items-center justify-center text-center pt-20 pb-10">
             <div className="content-visibility-auto animate-fade-in-up">
-              <h2 className="text-5xl md:text-7xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-b from-slate-900 to-slate-600 dark:from-white dark:to-slate-400">
-                The Noble Qur'an
-              </h2>
+              <h2 className="text-5xl md:text-7xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-b from-slate-900 to-slate-600 dark:from-white dark:to-slate-400">
+                The Noble Qur&apos;an
+              </h2>
               <p className="mt-4 text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
                 Read! In the name of your Lord
               </p>
@@ -257,7 +258,7 @@ export default function HomePage() {
               <h3 className="font-amiri text-3xl md:text-4xl text-emerald-600 dark:text-emerald-400 leading-relaxed text-right" dir="rtl">
                 فَإِنَّ مَعَ ٱلْعُسْرِ يُسْرًا
               </h3>
-              <p className="mt-4 text-left text-slate-600 dark:text-slate-400 text-sm">"So, surely with hardship comes ease." - [Surah Ash-Sharh, 94:5]</p>
+              <p className="mt-4 text-left text-slate-600 dark:text-slate-400 text-sm">&quot;So, surely with hardship comes ease.&quot; - [Surah Ash-Sharh, 94:5]</p>
             </div>
           </main>
 
@@ -273,13 +274,13 @@ export default function HomePage() {
 
             {activeTab === 'Surah' && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {filteredSurahs.map((surah, index) => (
-                  <a
-                    href="#"
-                    key={surah.number}
-                    className="group p-4 sm:p-5 bg-white/40 dark:bg-slate-800/40 border border-white/50 dark:border-slate-700/50 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl hover:bg-white/60 dark:hover:bg-slate-700/60 hover:border-emerald-500/60 dark:hover:border-emerald-500/60 transition-all duration-300 content-visibility-auto animate-fade-in-up"
-                    style={{ animationDelay: `${600 + index * 15}ms` }}
-                  >
+                {filteredSurahs.map((surah, index) => (
+                  <Link
+                    href={`/features/surah/${surah.number}`}
+                    key={surah.number}
+                    className="group p-4 sm:p-5 bg-white/40 dark:bg-slate-800/40 border border-white/50 dark:border-slate-700/50 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl hover:bg-white/60 dark:hover:bg-slate-700/60 hover:border-emerald-500/60 dark:hover:border-emerald-500/60 transition-all duration-300 content-visibility-auto animate-fade-in-up"
+                    style={{ animationDelay: `${600 + index * 15}ms` }}
+                  >
                     <div className="flex items-center justify-between">
                       <div className="flex items-center space-x-4">
                         <div className="flex items-center justify-center w-12 h-12 bg-black/5 dark:bg-slate-700/50 rounded-xl text-emerald-600 dark:text-emerald-400 font-bold text-lg group-hover:bg-emerald-500/10 dark:group-hover:bg-emerald-500/20 transition-colors">
@@ -297,19 +298,19 @@ export default function HomePage() {
                         <p className="text-sm text-slate-500 dark:text-slate-400">{surah.verses} Verses</p>
                       </div>
                     </div>
-                  </a>
-                ))}
-              </div>
-            )}
+                  </Link>
+                ))}
+              </div>
+            )}
             {activeTab === 'Juz' && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {allJuz.map((juz, index) => (
-                  <a
-                    href="#"
-                    key={juz.number}
-                    className="group p-4 sm:p-5 bg-white/40 dark:bg-slate-800/40 border border-white/50 dark:border-slate-700/50 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl hover:bg-white/60 dark:hover:bg-slate-700/60 hover:border-emerald-500/60 dark:hover:border-emerald-500/60 transition-all duration-300 content-visibility-auto animate-fade-in-up"
-                    style={{ animationDelay: `${100 + index * 15}ms` }}
-                  >
+                {allJuz.map((juz, index) => (
+                  <Link
+                    href={`/features/juz/${juz.number}`}
+                    key={juz.number}
+                    className="group p-4 sm:p-5 bg-white/40 dark:bg-slate-800/40 border border-white/50 dark:border-slate-700/50 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl hover:bg-white/60 dark:hover:bg-slate-700/60 hover:border-emerald-500/60 dark:hover:border-emerald-500/60 transition-all duration-300 content-visibility-auto animate-fade-in-up"
+                    style={{ animationDelay: `${100 + index * 15}ms` }}
+                  >
                     <div className="flex items-center justify-between">
                       <div className="flex items-center space-x-4">
                         <div className="flex items-center justify-center w-12 h-12 bg-black/5 dark:bg-slate-700/50 rounded-xl text-emerald-600 dark:text-emerald-400 font-bold text-lg group-hover:bg-emerald-500/10 dark:group-hover:bg-emerald-500/20 transition-colors">
@@ -321,10 +322,10 @@ export default function HomePage() {
                         </div>
                       </div>
                     </div>
-                  </a>
-                ))}
-              </div>
-            )}
+                  </Link>
+                ))}
+              </div>
+            )}
             {activeTab === 'Page' && (
               <div className="text-center py-20 bg-white/30 dark:bg-slate-800/30 border border-white/50 dark:border-slate-700/50 rounded-2xl shadow-lg backdrop-blur-xl content-visibility-auto animate-fade-in-up">
                 <p className="text-slate-500 dark:text-slate-400 text-lg">Page view is not yet implemented.</p>


### PR DESCRIPTION
## Summary
- import `Link` in `HomePage`
- use `next/link` instead of `<a href="#">`
- escape apostrophes for linting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ecceb1328832b9f83ddb2e5075359