### PR TITLE
Centralize icon components

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useMemo } from 'react';
 import { useTheme } from '@/app/context/ThemeContext';
 import Link from 'next/link';
+import { Search, Sun, Moon } from '@/app/components/common/SvgIcons';
 
 // --- Data for all 114 Surahs with English meanings ---
 const allSurahs = [
@@ -126,34 +127,6 @@ const allJuz = Array.from({ length: 30 }, (_, i) => ({
   name: `Juz ${i + 1}`,
   surahRange: 'Al-Fatihah 1 - Al-Baqarah 141',
 }));
-
-// --- SVG Icon Components ---
-const Search = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
-    <circle cx="11" cy="11" r="8" />
-    <line x1="21" y1="21" x2="16.65" y2="16.65" />
-  </svg>
-);
-
-const Sun = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
-    <circle cx="12" cy="12" r="5" />
-    <line x1="12" y1="1" x2="12" y2="3" />
-    <line x1="12" y1="21" x2="12" y2="23" />
-    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-    <line x1="1" y1="12" x2="3" y2="12" />
-    <line x1="21" y1="12" x2="23" y2="12" />
-    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-  </svg>
-);
-
-const Moon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
-    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-  </svg>
-);
 
 // --- Main Page Component ---
 export default function HomePage() {

--- a/app/components/common/SvgIcons.tsx
+++ b/app/components/common/SvgIcons.tsx
@@ -15,3 +15,31 @@ export const FaTh = ({ size = 22, className = '' }) => <svg className={className
 
 // Added FaCheck icon
 export const FaCheck = ({ size = 18, className = '' }) => <svg className={className} width={size} height={size} viewBox="0 0 512 512" fill="currentColor"><path d="M173.898 439.404L166.39 432l-24.5-24.5-137.13-137.13L.74 242.5l11.314 11.314L134.5 374.3l24.5 24.5 24.5 24.5 137.13-137.13L349.5 270.5l-11.314-11.314L173.898 439.404zM504.26 105.4l-11.314 11.314L370.5 239.3l-24.5 24.5-24.5-24.5-137.13-137.13L171.898 81.4l11.314-11.314L247.5 126.3l24.5-24.5 137.13-137.13L479.26 78.5l11.314 11.314L389.5 199.3l11.314 11.314z"/></svg>;
+
+// Icons from HomePage
+export const Search = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+export const Sun = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </svg>
+);
+
+export const Moon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);


### PR DESCRIPTION
## Summary
- add `Search`, `Sun` and `Moon` SVG exports in `SvgIcons`
- import icons from `SvgIcons` and remove local defs in `HomePage`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f3ea7ef84832bbfea5006c37dc91c