### PR TITLE
Add random verse feature

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import HomePage from '@/app/components/HomePage';
 import { ThemeProvider } from '@/app/context/ThemeContext';
+import { SettingsProvider } from '@/app/context/SettingsContext';
 
 // Mock next/link to simply render an anchor tag
 jest.mock('next/link', () => {
@@ -27,7 +28,9 @@ beforeAll(() => {
 const renderHome = () =>
   render(
     <ThemeProvider>
-      <HomePage />
+      <SettingsProvider>
+        <HomePage />
+      </SettingsProvider>
     </ThemeProvider>
   );
 

--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Search, Sun, Moon } from '@/app/components/common/SvgIcons';
 import surahsData from '@/data/surahs.json';
 import juzData from '@/data/juz.json';
+import VerseOfDay from './VerseOfDay';
 import type { Surah, Juz } from '@/types';
 
 const allSurahs: Surah[] = surahsData;
@@ -79,13 +80,7 @@ export default function HomePage() {
               ))}
             </div>
 
-            <div className="mt-12 w-full max-w-3xl p-4 sm:p-6 md:p-8 bg-white/30 dark:bg-slate-800/30 border border-white/50 dark:border-slate-700/50 rounded-2xl shadow-lg backdrop-blur-xl content-visibility-auto animate-fade-in-up animation-delay-400">
-              <p className="text-slate-500 dark:text-slate-400 mb-4 text-sm">Verse of the Day</p>
-              <h3 className="font-amiri text-3xl md:text-4xl text-emerald-600 dark:text-emerald-400 leading-relaxed text-right" dir="rtl">
-                فَإِنَّ مَعَ ٱلْعُسْرِ يُسْرًا
-              </h3>
-              <p className="mt-4 text-left text-slate-600 dark:text-slate-400 text-sm">&quot;So, surely with hardship comes ease.&quot; - [Surah Ash-Sharh, 94:5]</p>
-            </div>
+          <VerseOfDay />
           </main>
 
           <section id="surahs" className="py-20 max-w-7xl mx-auto w-full">

--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -1,0 +1,64 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { Verse } from '@/types';
+import { getRandomVerse } from '@/lib/api';
+import { useSettings } from '@/app/context/SettingsContext';
+import Spinner from '@/app/components/common/Spinner';
+import surahsData from '@/data/surahs.json';
+import type { Surah } from '@/types';
+
+const surahs: Surah[] = surahsData;
+
+export default function VerseOfDay() {
+  const { settings } = useSettings();
+  const [verse, setVerse] = useState<Verse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    getRandomVerse(settings.translationId)
+      .then(v => {
+        setVerse(v);
+        setError(null);
+      })
+      .catch(err => {
+        console.error(err);
+        setError('Failed to load verse.');
+      })
+      .finally(() => setLoading(false));
+  }, [settings.translationId]);
+
+  let content: React.ReactNode = null;
+  if (loading) {
+    content = (
+      <div className="flex justify-center py-8">
+        <Spinner className="h-6 w-6 text-emerald-600" />
+      </div>
+    );
+  } else if (error) {
+    content = <div className="text-center py-8 text-red-600">{error}</div>;
+  } else if (verse) {
+    const [surahNum] = verse.verse_key.split(':');
+    const surahName = surahs.find(s => s.number === Number(surahNum))?.name;
+    content = (
+      <>
+        <p className="text-slate-500 dark:text-slate-400 mb-4 text-sm">Verse of the Day</p>
+        <h3 className="font-amiri text-3xl md:text-4xl text-emerald-600 dark:text-emerald-400 leading-relaxed text-right" dir="rtl">
+          {verse.text_uthmani}
+        </h3>
+        {verse.translations?.[0] && (
+          <p className="mt-4 text-left text-slate-600 dark:text-slate-400 text-sm">
+            "{verse.translations[0].text}" - [Surah {surahName ?? surahNum}, {verse.verse_key}]
+          </p>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div className="mt-12 w-full max-w-3xl p-4 sm:p-6 md:p-8 bg-white/30 dark:bg-slate-800/30 border border-white/50 dark:border-slate-700/50 rounded-2xl shadow-lg backdrop-blur-xl content-visibility-auto animate-fade-in-up animation-delay-400">
+      {content}
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -122,4 +122,17 @@ export async function getJuz(juzId: string | number): Promise<Juz> {
   return data.juz as Juz;
 }
 
+// Fetch a random verse with translation
+export async function getRandomVerse(
+  translationId: number
+): Promise<Verse> {
+  const url = `${API_BASE_URL}/verses/random?translations=${translationId}&fields=text_uthmani`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch random verse: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.verse as Verse;
+}
+
 export { API_BASE_URL };


### PR DESCRIPTION
## Summary
- add `getRandomVerse` helper to API utilities
- create `VerseOfDay` component that fetches a random verse with translation
- inject `VerseOfDay` into `HomePage`
- wrap `HomePage` tests with `SettingsProvider` to support new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f40873e88832ba6c9e006f3f5bd95