### PR TITLE
Fix Jest setup for fetch and update HomePage tests

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -3,6 +3,21 @@ import userEvent from '@testing-library/user-event';
 import HomePage from '@/app/components/HomePage';
 import { ThemeProvider } from '@/app/context/ThemeContext';
 import { SettingsProvider } from '@/app/context/SettingsContext';
+import { Verse } from '@/types';
+
+jest.mock('@/lib/api', () => ({
+  getRandomVerse: jest.fn().mockResolvedValue({
+    id: 1,
+    verse_key: '1:1',
+    text_uthmani: 'بِسْمِ اللّهِ',
+    translations: [
+      {
+        resource_id: 1,
+        text: 'In the name of Allah',
+      },
+    ],
+  } as Verse),
+}));
 
 // Mock next/link to simply render an anchor tag
 jest.mock('next/link', () => {
@@ -67,7 +82,7 @@ it('tab switching between “Surah,” “Juz,” and “Page” changes rendere
   expect(screen.getByText('Juz 1')).toBeInTheDocument();
 
   await userEvent.click(screen.getByRole('button', { name: 'Page' }));
-  expect(screen.getByText(/Page view is not yet implemented/i)).toBeInTheDocument();
+  expect(screen.getByText('Page 1')).toBeInTheDocument();
 
   await userEvent.click(screen.getByRole('button', { name: 'Surah' }));
   expect(screen.getByText('Al-Fatihah')).toBeInTheDocument();

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import 'whatwg-fetch';

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "jest-environment-jsdom": "^30.0.4",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10873,6 +10874,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jest-environment-jsdom": "^30.0.4",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "whatwg-fetch": "^3.6.20"
   }
 }


### PR DESCRIPTION
## Summary
- add `whatwg-fetch` polyfill for Jest
- mock `getRandomVerse` in HomePage test
- update Page tab expectation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f4d82a698832bb6cb7fc9296da15d