### PR TITLE
Fix HomePage Page tab assertion

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -67,7 +67,7 @@ it('tab switching between “Surah,” “Juz,” and “Page” changes rendere
   expect(screen.getByText('Juz 1')).toBeInTheDocument();
 
   await userEvent.click(screen.getByRole('button', { name: 'Page' }));
-  expect(screen.getByText(/Page view is not yet implemented/i)).toBeInTheDocument();
+  expect(screen.getByText('Page 1')).toBeInTheDocument();
 
   await userEvent.click(screen.getByRole('button', { name: 'Surah' }));
   expect(screen.getByText('Al-Fatihah')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update HomePage test to assert that `Page 1` appears when switching to the Page tab

## Testing
- `npx jest --runInBand --color=false`

------
https://chatgpt.com/codex/tasks/task_b_687f4d83aaa0832b87185794d87e281e