### PR TITLE
Fix unescaped quotes in VerseOfDay

### DIFF
--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -49,7 +49,7 @@ export default function VerseOfDay() {
         </h3>
         {verse.translations?.[0] && (
           <p className="mt-4 text-left text-slate-600 dark:text-slate-400 text-sm">
-            "{verse.translations[0].text}" - [Surah {surahName ?? surahNum}, {verse.verse_key}]
+            &quot;{verse.translations[0].text}&quot; - [Surah {surahName ?? surahNum}, {verse.verse_key}]
           </p>
         )}
       </>


### PR DESCRIPTION
## Summary
- escape quote entities in `VerseOfDay`

## Testing
- `npm run lint`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_b_687f4d84fff0832bb773874a8f80d8a3