### PR TITLE
Fix font family token in Tailwind config

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -18,7 +18,7 @@ const config = {
       },
       spacing: designTokens.spacing,
       fontFamily: {
-        base: [designTokens.typography.fontFamilyBase, 'sans-serif'],
+        base: [designTokens.typography.fontFamily, 'sans-serif'],
       },
       fontSize: {
         base: designTokens.typography.fontSizeBase,


### PR DESCRIPTION
## Summary
- update Tailwind configuration to use `fontFamily` token

## Testing
- `BROWSERSLIST_IGNORE_OLD_DATA=1 npx tailwindcss-cli -i app/globals.css -o /tmp/tailwind.out.css -c tailwind.config.cjs --minify`

------
https://chatgpt.com/codex/tasks/task_b_687f4d870b4c832bb2d67f59a8e47877