### PR TITLE
Fix HomePage background classes

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -37,7 +37,7 @@ export default function HomePage() {
 
   return (
     <>
-      <div className="min-h-screen w-full text-slate-800 dark:text-slate-200 bg-gradient-to-br from-cyan-50/20 via-white to-emerald-50/20 dark:bg-gray-900 dark:from-gray-900 dark:to-slate-900 overflow-x-hidden">
+      <div className="min-h-screen w-full bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-200 bg-gradient-to-br from-cyan-50/20 via-white to-emerald-50/20 dark:bg-gray-900 dark:from-gray-900 dark:to-slate-900 overflow-x-hidden">
         <div className="absolute top-0 left-0 w-full h-full z-0">
           <div className="absolute top-[-10rem] right-[-10rem] w-72 h-72 bg-emerald-400/10 dark:bg-emerald-500/10 rounded-full filter blur-3xl opacity-50" />
           <div className="absolute bottom-[-5rem] left-[-10rem] w-80 h-80 bg-cyan-400/10 dark:bg-cyan-500/10 rounded-full filter blur-3xl opacity-40" />


### PR DESCRIPTION
## Summary
- apply missing dark/light background classes for home page container

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687f644f2ff8832baa072965577d6127