### PR TITLE
Fix home page dark theme gradient

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -37,7 +37,7 @@ export default function HomePage() {
 
   return (
     <>
-      <div className="min-h-screen w-full text-slate-800 dark:text-slate-200 bg-gradient-to-br from-cyan-50/20 via-white to-emerald-50/20 dark:bg-gray-900 dark:from-gray-900 dark:to-slate-900 overflow-x-hidden">
+      <div className="min-h-screen w-full text-slate-800 dark:text-slate-200 bg-gradient-to-br from-cyan-50/20 via-white to-emerald-50/20 dark:bg-gradient-to-br dark:from-gray-900 dark:to-slate-900 overflow-x-hidden">
         <div className="absolute top-0 left-0 w-full h-full z-0">
           <div className="absolute top-[-10rem] right-[-10rem] w-72 h-72 bg-emerald-400/10 dark:bg-emerald-500/10 rounded-full filter blur-3xl opacity-50" />
           <div className="absolute bottom-[-5rem] left-[-10rem] w-80 h-80 bg-cyan-400/10 dark:bg-cyan-500/10 rounded-full filter blur-3xl opacity-40" />


### PR DESCRIPTION
## Summary
- ensure the home page container uses a gradient background for dark mode

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f659de104832b88de24ec3e4dac80