### PR TITLE
Update theme initialization

### DIFF
--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -10,13 +10,19 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  // Initialize theme with a default value
-  const [theme, setTheme] = useState<Theme>('light');
+export const ThemeProvider = ({
+  children,
+  initialTheme,
+}: {
+  children: React.ReactNode;
+  initialTheme?: Theme;
+}) => {
+  // Initialize theme with a default value or provided initial theme
+  const [theme, setTheme] = useState<Theme>(initialTheme ?? 'light');
 
   // Effect to load theme from localStorage on the client side after initial render
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && initialTheme === undefined) {
       const stored = localStorage.getItem('theme');
       if (stored === 'light' || stored === 'dark') {
         setTheme(stored as Theme);
@@ -24,7 +30,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
         setTheme('dark');
       }
     }
-  }, []); // Empty dependency array ensures this effect runs only once on mount
+  }, [initialTheme]); // Run once on mount unless initialTheme changes
 
   // Effect to save theme to localStorage and update data attribute whenever theme changes
   useEffect(() => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,12 +44,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const theme = stored && (stored.value === 'light' || stored.value === 'dark') ? stored.value as 'light' | 'dark' : 'light';
 
   return (
-    <html lang="en" data-theme={theme}>
+    <html lang="en" className={theme}>
       <body
         className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${inter.className}`}
       >
         <TranslationProvider>
-          <ThemeProvider>
+          <ThemeProvider initialTheme={theme}>
             <SettingsProvider> {/* Wrap with SettingsProvider */}
               <SidebarProvider> {/* Wrap with SidebarProvider */}
                 {children}


### PR DESCRIPTION
## Summary
- pass initial theme to ThemeProvider
- use theme as html class instead of `data-theme`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f86b11458832b909f79d1c7225132