### PR TITLE
Replace theme variables with Tailwind

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -93,8 +93,8 @@ export default function JuzPage({ params }: JuzPageProps) {
   );
 
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
+    <div className="flex flex-grow bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-sans overflow-hidden">
+      <main className="flex-grow bg-white dark:bg-slate-800 p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
           {/* Only render content when juzId is available */}
           {juzId ? (
@@ -109,7 +109,7 @@ export default function JuzPage({ params }: JuzPageProps) {
                 {/* Display Juz information */}
                 {juz && (
                   <div className="mb-8 text-center">
-                    <h1 className="text-3xl font-bold text-[var(--foreground)]">{t('juz_number', { number: juz.juz_number })}</h1>
+                    <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-200">{t('juz_number', { number: juz.juz_number })}</h1>
                     {/* Add more Juz information here if available in your API response */}
                   </div>
                 )}

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -86,8 +86,8 @@ export default function QuranPage({ params }: QuranPageProps) {
   );
 
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
+    <div className="flex flex-grow bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-sans overflow-hidden">
+      <main className="flex-grow bg-white dark:bg-slate-800 p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
           {/* Only render content when pageId is available */}
           {pageId ? (

--- a/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
+++ b/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
@@ -31,7 +31,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
   return (
     <>
       {/* No overlay div */}
-      <div className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+      <div className={`fixed top-0 right-0 w-80 h-full bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button
             aria-label="Back"
@@ -40,7 +40,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
           >
             <FaArrowLeft size={18} />
           </button>
-          <h2 className="font-bold text-lg text-[var(--foreground)]">{t('select_font_face')}</h2> {/* Assuming a translation key for the title */}
+          <h2 className="font-bold text-lg text-slate-800 dark:text-slate-200">{t('select_font_face')}</h2> {/* Assuming a translation key for the title */}
           <div className="w-8"></div>
         </div>
         
@@ -71,7 +71,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
                   checked={settings.arabicFontFace === font.value}
                   onChange={() => handleFontSelect(font.value)}
                 />
-                <span className="text-sm text-[var(--foreground)]">{font.name}</span>
+                <span className="text-sm text-slate-800 dark:text-slate-200">{font.name}</span>
               </label>
             ))}
           </div>

--- a/app/features/surah/[surahId]/_components/CollapsibleSection.tsx
+++ b/app/features/surah/[surahId]/_components/CollapsibleSection.tsx
@@ -10,7 +10,7 @@ export const CollapsibleSection = ({ title, icon, children }: { title: string, i
             <button onClick={() => setIsOpen(!isOpen)} className="w-full flex items-center justify-between p-4 text-left">
                 <div className="flex items-center space-x-3">
                     {icon}
-                    <span className="font-semibold text-[var(--foreground)]">{title}</span>
+                    <span className="font-semibold text-slate-800 dark:text-slate-200">{title}</span>
                 </div>
                 <FaChevronDown size={16} className={`text-gray-500 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
             </button>

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -46,14 +46,14 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
         }}
       />
       <aside
-        className={`fixed lg:static inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
+        className={`fixed lg:static inset-y-0 right-0 w-80 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex-col flex-shrink-0 overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >
         <div className="flex-grow">
           <CollapsibleSection title={t('reading_setting')} icon={<FaBookReader size={20} className="text-teal-700" />}>
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-[var(--foreground)]">{t('translations')}</label>
-              <button onClick={onTranslationPanelOpen} className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
-                <span className="truncate text-[var(--foreground)]">{selectedTranslationName}</span>
+              <label className="block text-sm font-medium text-slate-800 dark:text-slate-200">{t('translations')}</label>
+              <button onClick={onTranslationPanelOpen} className="w-full flex justify-between items-center bg-white dark:bg-slate-800 border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
+                <span className="truncate text-slate-800 dark:text-slate-200">{selectedTranslationName}</span>
                 <FaChevronDown className="text-gray-500" />
               </button>
             </div>
@@ -61,7 +61,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
           <CollapsibleSection title={t('font_setting')} icon={<FaFontSetting size={20} className="text-teal-700" />}>
             <div className="space-y-4">
               <div>
-                <div className="flex justify-between mb-1 text-sm"><label className="text-[var(--foreground)]">{t('arabic_font_size')}</label><span className="font-semibold text-teal-700">{settings.arabicFontSize}</span></div>
+                <div className="flex justify-between mb-1 text-sm"><label className="text-slate-800 dark:text-slate-200">{t('arabic_font_size')}</label><span className="font-semibold text-teal-700">{settings.arabicFontSize}</span></div>
                 <input
                   type="range"
                   min="16"
@@ -72,7 +72,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
                 />
               </div>
               <div>
-                <div className="flex justify-between mb-1 text-sm"><label className="text-[var(--foreground)]">{t('translation_font_size')}</label><span className="font-semibold text-teal-700">{settings.translationFontSize}</span></div>
+                <div className="flex justify-between mb-1 text-sm"><label className="text-slate-800 dark:text-slate-200">{t('translation_font_size')}</label><span className="font-semibold text-teal-700">{settings.translationFontSize}</span></div>
                 <input
                   type="range"
                   min="12"
@@ -84,9 +84,9 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
               </div>
               {/* Arabic Font Face Selection Button */}
               <div>
-                <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">{t('arabic_font_face')}</label>
-                <button onClick={() => setIsArabicFontPanelOpen(true)} className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
-                  <span className="truncate text-[var(--foreground)]">{selectedArabicFont}</span>
+                <label className="block mb-2 text-sm font-medium text-slate-800 dark:text-slate-200">{t('arabic_font_face')}</label>
+                <button onClick={() => setIsArabicFontPanelOpen(true)} className="w-full flex justify-between items-center bg-white dark:bg-slate-800 border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition">
+                  <span className="truncate text-slate-800 dark:text-slate-200">{selectedArabicFont}</span>
                   <FaChevronDown className="text-gray-500" />
                 </button>
               </div>
@@ -96,7 +96,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
         <div className="p-4 border-t border-gray-200/80 dark:border-gray-600">
           <button
             onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-            className="w-full bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm hover:border-teal-500 transition"
+            className="w-full bg-white dark:bg-slate-800 border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm hover:border-teal-500 transition"
           >
             {theme === 'light' ? t('switch_to_dark') : t('switch_to_light')}
           </button>

--- a/app/features/surah/[surahId]/_components/TafsirModal.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirModal.tsx
@@ -21,7 +21,7 @@ export const TafsirModal = ({ verseKey, isOpen, onClose }: TafsirModalProps) => 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
-      <div className="bg-[var(--background)] text-[var(--foreground)] relative max-w-lg w-full max-h-[80vh] overflow-y-auto rounded-lg shadow-lg p-6">
+      <div className="bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 relative max-w-lg w-full max-h-[80vh] overflow-y-auto rounded-lg shadow-lg p-6">
         <button
           onClick={onClose}
           className="absolute left-3 top-3 p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700"

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -18,7 +18,7 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
   return (
     <>
       {/* Removed the overlay div */}
-      <div className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+      <div className={`fixed top-0 right-0 w-80 h-full bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button
             aria-label="Back"
@@ -27,13 +27,13 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
           >
             <FaArrowLeft size={18} />
           </button>
-          <h2 className="font-bold text-lg text-[var(--foreground)]">{t('translations_panel_title')}</h2>
+          <h2 className="font-bold text-lg text-slate-800 dark:text-slate-200">{t('translations_panel_title')}</h2>
           <div className="w-8"></div>
         </div>
         <div className="p-3 border-b border-gray-200/80">
           <div className="relative">
             <FaSearch className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
-            <input type="text" placeholder={t('search')} value={searchTerm} onChange={e => onSearchTermChange(e.target.value)} className="w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none bg-[var(--background)] text-[var(--foreground)]" />
+            <input type="text" placeholder={t('search')} value={searchTerm} onChange={e => onSearchTermChange(e.target.value)} className="w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200" />
           </div>
         </div>
         <div className="flex-grow overflow-y-auto">
@@ -53,7 +53,7 @@ export const TranslationPanel = ({ isOpen, onClose, groupedTranslations, searchT
                         onClose();
                       }}
                     />
-                    <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
+                    <span className="text-sm text-slate-800 dark:text-slate-200">{opt.name}</span>
                   </label>
                 ))}
               </div>

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -72,7 +72,7 @@ export const Verse = ({ verse }: VerseProps) => {
         </div>
         <div className="flex-grow space-y-6">
           <p
-            className="text-right leading-loose text-[var(--foreground)]"
+            className="text-right leading-loose text-slate-800 dark:text-slate-200"
             style={{ fontFamily: settings.arabicFontFace, fontSize: `${settings.arabicFontSize}px`, lineHeight: 2.2 }}
           >
             {verse.text_uthmani}
@@ -80,7 +80,7 @@ export const Verse = ({ verse }: VerseProps) => {
           {verse.translations?.map((t: Translation) => (
             <div key={t.resource_id}>
               <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
+                className="text-left leading-relaxed text-slate-800 dark:text-slate-200"
                 style={{ fontSize: `${settings.translationFontSize}px` }}
                 dangerouslySetInnerHTML={{ __html: t.text }}
               />

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -91,8 +91,8 @@ export default function SurahPage({ params }: SurahPageProps) {
   );
   
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
+    <div className="flex flex-grow bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 font-sans overflow-hidden">
+      <main className="flex-grow bg-white dark:bg-slate-800 p-6 lg:p-10 overflow-y-auto">
         <div className="max-w-4xl mx-auto relative">
           {isLoading ? (
             <div className="flex justify-center py-20">


### PR DESCRIPTION
## Summary
- swap `var(--background)` and `var(--foreground)` usage for Tailwind classes
- update modal and sidebar components to use Tailwind dark/light colors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687f86b2c514832b86025b1da63cec67