### PR TITLE
Update theme toggle test for dark class

### DIFF
--- a/__tests__/HomePage.test.tsx
+++ b/__tests__/HomePage.test.tsx
@@ -55,6 +55,7 @@ const renderHome = () =>
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.dataset.theme = '';
+  document.documentElement.classList.remove('dark');
 });
 
 it('search filtering returns only matching Surahs', async () => {
@@ -65,14 +66,14 @@ it('search filtering returns only matching Surahs', async () => {
   expect(screen.queryByText('Al-Fatihah')).not.toBeInTheDocument();
 });
 
-it('theme toggle updates the data-theme attribute', async () => {
+it('theme toggle updates the dark class', async () => {
   renderHome();
   const nav = screen.getByRole('navigation');
   const themeButton = within(nav).getByRole('button');
-  expect(document.documentElement.dataset.theme).toBe('light');
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
   await userEvent.click(themeButton);
   await waitFor(() => {
-    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 });
 

--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -31,6 +31,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('theme', theme);
       document.documentElement.dataset.theme = theme;
+      document.documentElement.classList.toggle('dark', theme === 'dark');
       document.cookie = `theme=${theme}; path=/; max-age=31536000`;
     }
   }, [theme]);


### PR DESCRIPTION
## Summary
- update ThemeContext to manage `dark` class
- update tests to expect `document.documentElement.classList.contains('dark')`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f86b4790c832bb6dc58d8b9083af4