### PR TITLE
Fix light mode toggle

### DIFF
--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -31,6 +31,8 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('theme', theme);
       document.documentElement.dataset.theme = theme;
+      // Ensure the dark class is toggled for Tailwind's class strategy
+      document.documentElement.classList.toggle('dark', theme === 'dark');
       document.cookie = `theme=${theme}; path=/; max-age=31536000`;
     }
   }, [theme]);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const theme = stored && (stored.value === 'light' || stored.value === 'dark') ? stored.value as 'light' | 'dark' : 'light';
 
   return (
-    <html lang="en" data-theme={theme}>
+    <html
+      lang="en"
+      data-theme={theme}
+      className={theme === 'dark' ? 'dark' : undefined}
+    >
       <body
         className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${inter.className}`}
       >


### PR DESCRIPTION
## Summary
- toggle `dark` class based on theme in context
- set `dark` class on initial page render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687fbf2629e0832b984483fead773d38