### PR TITLE
Fix light mode gradient visibility

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -38,7 +38,7 @@ export default function HomePage() {
 
   return (
     <>
-      <div className="relative h-screen flex flex-col bg-[var(--background)] text-slate-900 dark:text-[var(--foreground)] overflow-hidden">
+      <div className="relative h-screen flex flex-col bg-transparent text-slate-900 dark:text-[var(--foreground)] overflow-hidden">
         <HomePageBackground />
 
         <div className="relative z-10 flex flex-col h-full overflow-y-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- show the gradient background on the home page by removing the solid background color

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688097580568832bb6184d29cfe3565a