### PR TITLE
Update README with dev dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Development
 
+Before running tests or linting, execute `npm install` to install dev dependencies.
+
 Run the linter:
 
 ```bash


### PR DESCRIPTION
## Summary
- remind developers to run `npm install` before linting or testing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68809af70060832bbccb8c5f4c5cc45d