### PR TITLE
Add global CSS variables for theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,17 @@
 /* Keep the original Tailwind import to avoid breaking the structure */
 @import "tailwindcss";
 
-/* --- The conflicting :root and [data-theme] blocks have been removed --- */
+:root {
+  --background: #F7F9F9;
+  --foreground: #374151;
+  --border-color: #e5e7eb;
+}
+
+[data-theme='dark'] {
+  --background: #1a202c;
+  --foreground: #d1d5db;
+  --border-color: #4b5563;
+}
 
 @layer base {
   body {


### PR DESCRIPTION
## Summary
- define `--background`, `--foreground`, and `--border-color` CSS variables
- override them in `[data-theme='dark']`
- keep ThemeProvider updating `dataset.theme`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68813ac93180832b80e062682dbe8a68