### PR TITLE
Fix scrollbar accent in Firefox on hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,6 @@
 }
 
 /* Add a hover effect to the scrollbar thumb for Firefox (limited support) */
-* {
+*:hover {
   scrollbar-color: var(--accent) var(--background); /* thumb color track color */
 }


### PR DESCRIPTION
## Summary
- update Firefox scrollbar rule so accent color only applies on hover

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688151b2e368832bac39fcd9e668a676