### PR TITLE
Fix scrollbar style for homepage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -55,6 +55,25 @@
   display: none;
 }
 
+/* Simple scroll stick style for homepage-scrollable-area */
+.homepage-scrollable-area::-webkit-scrollbar {
+  width: 4px; /* Made scrollbar slimmer */
+}
+
+.homepage-scrollable-area::-webkit-scrollbar-track {
+  background: var(--background); /* Color of the track */
+}
+
+.homepage-scrollable-area::-webkit-scrollbar-thumb {
+  background: var(--subtle-grey); /* subtle grey color by default */
+  border-radius: 2px; /* Made corners slightly less rounded */
+  border: 1px solid var(--background); /* Add a border around the thumb */
+}
+
+.homepage-scrollable-area::-webkit-scrollbar-thumb:hover {
+  background: var(--accent); /* accent color on hover */
+}
+
 /* Target Firefox */
 /* Note: Firefox scrollbar styling is limited */
 * {


### PR DESCRIPTION
## Summary
- restore dedicated scrollbar styles for `.homepage-scrollable-area`
- keep accent hover colour and subtle grey thumb in light and dark modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688151b74164832bb26ea3e03cb6bfc2