### PR TITLE
Fix verse translation formatting

### DIFF
--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -10,6 +10,14 @@ import { useTheme } from '@/app/context/ThemeContext';
 
 const surahs: Surah[] = surahsData;
 
+function stripHtml(html: string): string {
+  if (typeof window !== 'undefined') {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return doc.body.textContent || '';
+  }
+  return html.replace(/<[^>]*>/g, '');
+}
+
 export default function VerseOfDay() {
   const { settings } = useSettings();
   const { theme } = useTheme();
@@ -91,7 +99,7 @@ export default function VerseOfDay() {
         </h3>
         {verse.translations?.[0] && (
           <p className={`mt-4 text-left text-sm ${theme === 'light' ? 'text-slate-800' : 'text-slate-400'}`}>
-            &quot;{verse.translations[0].text}&quot; - [Surah {surahName ?? surahNum}, {verse.verse_key}]
+            "{stripHtml(verse.translations[0].text)}" - [Surah {surahName ?? surahNum}, {verse.verse_key}]
           </p>
         )}
       </>


### PR DESCRIPTION
## Summary
- sanitize HTML tags in VerseOfDay translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688174ceae78832bbfb37cfb1e759c7b