### PR TITLE
Add per-word display for verses

### DIFF
--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect, useState, useCallback } from 'react';
-import { Verse } from '@/types';
+import { Verse, Word } from '@/types';
 import { getRandomVerse } from '@/lib/api';
 import { useSettings } from '@/app/context/SettingsContext';
 import Spinner from '@/app/components/common/Spinner';
@@ -94,8 +94,22 @@ export default function VerseOfDay() {
     content = (
       <>
         {/* <p className={`mb-4 text-sm ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}>Verse of the Day</p> */}
-        <h3 className={`font-amiri text-3xl md:text-4xl leading-relaxed text-right ${theme === 'light' ? 'text-emerald-700' : 'text-emerald-400'}`} dir="rtl">
-          {verse.text_uthmani}
+        <h3
+          className={`font-amiri text-3xl md:text-4xl leading-relaxed text-right ${theme === 'light' ? 'text-emerald-700' : 'text-emerald-400'}`}
+          dir="rtl"
+        >
+          {verse.words
+            ? verse.words.map((w: Word) => (
+                <span key={w.id} className="inline-block mx-0.5 relative group">
+                  {w.uthmani}
+                  {w.en && (
+                    <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1 py-0.5 rounded bg-gray-800 text-white text-xs whitespace-nowrap opacity-0 group-hover:opacity-100">
+                      {w.en}
+                    </span>
+                  )}
+                </span>
+              ))
+            : verse.text_uthmani}
         </h3>
         {verse.translations?.[0] && (
           <p className={`mt-4 text-left text-sm ${theme === 'light' ? 'text-slate-800' : 'text-slate-400'}`}>

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -1,7 +1,7 @@
 // app/surah/[surahId]/_components/Verse.tsx
 import { FaPlay, FaPause, FaBookmark, FaRegBookmark, FaEllipsisH, FaBookReader } from '@/app/components/common/SvgIcons';
 import { TafsirModal } from './TafsirModal';
-import { Verse as VerseType, Translation } from '@/types';
+import { Verse as VerseType, Translation, Word } from '@/types';
 import { useAudio } from '@/app/context/AudioContext';
 import Spinner from '@/app/components/common/Spinner';
 import { useSettings } from '@/app/context/SettingsContext';
@@ -75,7 +75,18 @@ export const Verse = ({ verse }: VerseProps) => {
             className="text-right leading-loose text-[var(--foreground)]"
             style={{ fontFamily: settings.arabicFontFace, fontSize: `${settings.arabicFontSize}px`, lineHeight: 2.2 }}
           >
-            {verse.text_uthmani}
+            {verse.words
+              ? verse.words.map((w: Word) => (
+                  <span key={w.id} className="inline-block mx-0.5 relative group">
+                    {w.uthmani}
+                    {w.en && (
+                      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1 py-0.5 rounded bg-gray-800 text-white text-xs whitespace-nowrap opacity-0 group-hover:opacity-100">
+                        {w.en}
+                      </span>
+                    )}
+                  </span>
+                ))
+              : verse.text_uthmani}
           </p>
           {verse.translations?.map((t: Translation) => (
             <div key={t.resource_id}>

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,6 +3,7 @@ export * from './chapter';
 export * from './translation';
 export * from './settings';
 export * from './surah';
+export * from './word';
 
 export interface Juz {
   id: number;

--- a/types/verse.ts
+++ b/types/verse.ts
@@ -8,10 +8,13 @@ export interface Audio {
   url: string;
 }
 
+import type { Word } from './word';
+
 export interface Verse {
   id: number;
   verse_key: string;
   text_uthmani: string;
   audio?: Audio;
   translations?: Translation[];
+  words?: Word[];
 }

--- a/types/word.ts
+++ b/types/word.ts
@@ -1,0 +1,6 @@
+export interface Word {
+  id: number;
+  uthmani: string;
+  en?: string;
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- add `Word` interface
- allow verses to carry optional `words` array
- render words inline with translations on hover
- show word translations in Verse of the Day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881d65ae718832b826a976cfbabe772