### PR TITLE
Add new reading option strings

### DIFF
--- a/app/context/SettingsContext.tsx
+++ b/app/context/SettingsContext.tsx
@@ -21,6 +21,9 @@ const defaultSettings: Settings = {
   arabicFontSize: 28,
   translationFontSize: 16,
   arabicFontFace: ARABIC_FONTS[0].value,
+  wordByWord: false,
+  showWords: false,
+  tajweed: false,
 };
 
 interface SettingsContextType {
@@ -45,7 +48,7 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
       const savedSettings = localStorage.getItem('quranAppSettings');
       if (savedSettings) {
         try {
-          setSettings(JSON.parse(savedSettings));
+          setSettings({ ...defaultSettings, ...JSON.parse(savedSettings) });
         } catch (error) {
           console.error('Error parsing settings from localStorage:', error);
           // Optionally, clear localStorage if corrupted

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -56,6 +56,35 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
                 <span className="truncate text-[var(--foreground)]">{selectedTranslationName}</span>
                 <FaChevronDown className="text-gray-500" />
               </button>
+              <div className="pt-1 space-y-1">
+                <label className="inline-flex items-center space-x-2 text-sm text-[var(--foreground)]">
+                  <input
+                    type="checkbox"
+                    className="form-checkbox text-teal-600"
+                    checked={settings.wordByWord}
+                    onChange={e => setSettings({ ...settings, wordByWord: e.target.checked })}
+                  />
+                  <span>{t('word_by_word')}</span>
+                </label>
+                <label className="inline-flex items-center space-x-2 text-sm text-[var(--foreground)]">
+                  <input
+                    type="checkbox"
+                    className="form-checkbox text-teal-600"
+                    checked={settings.showWords}
+                    onChange={e => setSettings({ ...settings, showWords: e.target.checked })}
+                  />
+                  <span>{t('show_words')}</span>
+                </label>
+                <label className="inline-flex items-center space-x-2 text-sm text-[var(--foreground)]">
+                  <input
+                    type="checkbox"
+                    className="form-checkbox text-teal-600"
+                    checked={settings.tajweed}
+                    onChange={e => setSettings({ ...settings, tajweed: e.target.checked })}
+                  />
+                  <span>{t('tajweed')}</span>
+                </label>
+              </div>
             </div>
           </CollapsibleSection>
           <CollapsibleSection title={t('font_setting')} icon={<FaFontSetting size={20} className="text-teal-700" />}>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -35,5 +35,8 @@
   "switch_to_dark": "Switch to dark mode",
   "switch_to_light": "Switch to light mode",
   "light_mode": "Light",
-  "dark_mode": "Dark"
+  "dark_mode": "Dark",
+  "word_by_word": "Word-by-word translations",
+  "show_words": "Show words",
+  "tajweed": "Tajweed coloring"
 }

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -3,4 +3,7 @@ export interface Settings {
   arabicFontSize: number;
   translationFontSize: number;
   arabicFontFace: string;
+  wordByWord: boolean;
+  showWords: boolean;
+  tajweed: boolean;
 }


### PR DESCRIPTION
## Summary
- add word-by-word, show words and tajweed strings to English i18n
- support new toggle settings in SettingsContext
- expose toggles in reading options sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881d6805158832b9c7fcaa2a7abe95e