### PR TITLE
Fix Arabic verse display and params usage

### DIFF
--- a/__tests__/SettingsContext.test.tsx
+++ b/__tests__/SettingsContext.test.tsx
@@ -75,6 +75,9 @@ describe('SettingsContext settings state', () => {
     arabicFontSize: 28,
     translationFontSize: 16,
     arabicFontFace: '"KFGQPC-Uthman-Taha", serif',
+    wordLang: 'en',
+    showByWords: false,
+    tajweed: false,
   };
 
   it('defaults to expected values', () => {

--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -120,7 +120,7 @@ export default function VerseOfDay() {
         </h3>
         {verse.translations?.[0] && (
           <p className={`mt-4 text-left text-sm ${theme === 'light' ? 'text-slate-800' : 'text-slate-400'}`}>
-            "{stripHtml(verse.translations[0].text)}" - [Surah {surahName ?? surahNum}, {verse.verse_key}]
+            &quot;{stripHtml(verse.translations[0].text)}&quot; - [Surah {surahName ?? surahNum}, {verse.verse_key}]
           </p>
         )}
       </>

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -1,7 +1,7 @@
 // app/features/juz/[juzId]/page.tsx
 'use client';
 
-import React, { useEffect, useState, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useMemo, useRef, use } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
@@ -21,7 +21,7 @@ interface JuzPageProps {
 }
 
 export default function JuzPage({ params }: JuzPageProps) {
-  const { juzId } = params;
+  const { juzId } = use(params);
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -1,7 +1,7 @@
 // app/features/page/[pageId]/page.tsx
 'use client';
 
-import React, { useEffect, useState, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useMemo, useRef, use } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
@@ -18,7 +18,7 @@ interface QuranPageProps {
 }
 
 export default function QuranPage({ params }: QuranPageProps) {
-  const { pageId } = params;
+  const { pageId } = use(params);
 
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -5,7 +5,7 @@ interface SurahPageProps {
   params: { surahId: string };
 }
 
-import React, { useEffect, useState, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useMemo, useRef, use } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Verse } from './_components/Verse';
 import { SettingsSidebar } from './_components/SettingsSidebar';
@@ -24,7 +24,7 @@ import useSWRInfinite from 'swr/infinite';
 // If you encounter build errors, you may need to revert to `any` as Next.js's
 // type for PageProps can sometimes cause mismatches.
 export default function SurahPage({ params }: SurahPageProps) {
-  const { surahId } = params;
+  const { surahId } = use(params);
   const [error, setError] = useState<string | null>(null);
   const { settings } = useSettings();
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- handle Next.js `params` objects with React.use
- map API word data to internal type for Arabic text rendering
- escape quotes in VerseOfDay component
- update SettingsContext test defaults

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881e6120fa4832bbe8fb8bd12f3f9a1