### PR TITLE
Improve Arabic verse display

### DIFF
--- a/__tests__/getVerses.test.ts
+++ b/__tests__/getVerses.test.ts
@@ -1,0 +1,27 @@
+import { getVersesByChapter, API_BASE_URL } from '@/lib/api';
+import { Verse } from '@/types';
+
+describe('getVersesByChapter', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('requests verses with text_uthmani word field', async () => {
+    const mockVerse: Verse = {
+      id: 1,
+      verse_key: '1:1',
+      text_uthmani: 'text',
+      words: [],
+    } as Verse;
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
+    }) as jest.Mock;
+
+    await getVersesByChapter(1, 20, 1, 1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE_URL}/verses/by_chapter/1?language=en&words=true&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
+    );
+  });
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,6 +4,7 @@ import { Chapter, TranslationResource, Verse, Juz, Word } from '@/types';
 
 interface ApiWord extends Record<string, unknown> {
   text: string;
+  text_uthmani?: string;
   translation?: { text?: string };
 }
 
@@ -16,7 +17,7 @@ function normalizeVerse(raw: ApiVerse): Verse {
     ...raw,
     words: raw.words?.map(w => ({
       ...w,
-      uthmani: w.text,
+      uthmani: (w as ApiWord).text_uthmani ?? w.text,
       en: w.translation?.text,
     })) as Word[],
   };
@@ -58,7 +59,7 @@ export async function getVersesByChapter(
   page = 1,
   perPage = 20
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=en&words=true&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
@@ -107,7 +108,7 @@ export async function getVersesByJuz(
   page = 1,
   perPage = 20
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_juz/${juzId}?language=en&words=true&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_juz/${juzId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
@@ -124,7 +125,7 @@ export async function getVersesByPage(
   page = 1,
   perPage = 20
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_page/${pageId}?language=en&words=true&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_page/${pageId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);


### PR DESCRIPTION
## Summary
- request `text_uthmani` for word data from the Quran API
- map Arabic words using the returned `text_uthmani` property
- test that `getVersesByChapter` calls the API with the new parameter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6881e8a38cbc832ba53196c860531762