### PR TITLE
Enable multi-language word translations

### DIFF
--- a/__tests__/getVerses.test.ts
+++ b/__tests__/getVerses.test.ts
@@ -19,9 +19,28 @@ describe('getVersesByChapter', () => {
       json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
     }) as jest.Mock;
 
-    await getVersesByChapter(1, 20, 1, 1);
+    await getVersesByChapter(1, 20, 1, 1, 'en');
     expect(global.fetch).toHaveBeenCalledWith(
       `${API_BASE_URL}/verses/by_chapter/1?language=en&words=true&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
+    );
+  });
+
+  it('uses provided word language in request', async () => {
+    const mockVerse: Verse = {
+      id: 1,
+      verse_key: '1:1',
+      text_uthmani: 'text',
+      words: [],
+    } as Verse;
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
+    }) as jest.Mock;
+
+    await getVersesByChapter(1, 20, 1, 1, 'tr');
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE_URL}/verses/by_chapter/1?language=tr&words=true&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
     );
   });
 });

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -49,10 +49,10 @@ export default function JuzPage({ params }: JuzPageProps) {
   } = useSWRInfinite(
     index =>
       juzId
-        ? ['verses', juzId, settings.translationId, index + 1]
+        ? ['verses', juzId, settings.translationId, settings.wordLang, index + 1]
         : null,
-    ([, juzId, translationId, page]) =>
-      getVersesByJuz(juzId, translationId, page).catch(err => {
+    ([, juzId, translationId, wordLang, page]) =>
+      getVersesByJuz(juzId, translationId, page, 20, wordLang).catch(err => {
         setError(`Failed to load content. ${err.message}`);
         return { verses: [], totalPages: 1 };
       })

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -39,10 +39,10 @@ export default function QuranPage({ params }: QuranPageProps) {
   } = useSWRInfinite(
     index =>
       pageId
-        ? ['verses', pageId, settings.translationId, index + 1]
+        ? ['verses', pageId, settings.translationId, settings.wordLang, index + 1]
         : null,
-    ([, pageId, translationId, page]) =>
-      getVersesByPage(pageId, translationId, page).catch(err => {
+    ([, pageId, translationId, wordLang, page]) =>
+      getVersesByPage(pageId, translationId, page, 20, wordLang).catch(err => {
         setError(`Failed to load content. ${err.message}`);
         return { verses: [], totalPages: 1 };
       })

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -44,10 +44,10 @@ export default function SurahPage({ params }: SurahPageProps) {
   } = useSWRInfinite(
     index =>
       surahId
-        ? ['verses', surahId, settings.translationId, index + 1]
+        ? ['verses', surahId, settings.translationId, settings.wordLang, index + 1]
         : null,
-    ([, surahId, translationId, page]) =>
-      getVersesByChapter(surahId, translationId, page).catch(err => {
+    ([, surahId, translationId, wordLang, page]) =>
+      getVersesByChapter(surahId, translationId, page, 20, wordLang).catch(err => {
         setError(`Failed to load content. ${err.message}`);
         return { verses: [], totalPages: 1 };
       })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -12,13 +12,13 @@ interface ApiVerse extends Verse {
   words?: ApiWord[];
 }
 
-function normalizeVerse(raw: ApiVerse): Verse {
+function normalizeVerse(raw: ApiVerse, wordLang = 'en'): Verse {
   return {
     ...raw,
     words: raw.words?.map(w => ({
       ...w,
       uthmani: (w as ApiWord).text_uthmani ?? w.text,
-      en: w.translation?.text,
+      [wordLang]: w.translation?.text,
     })) as Word[],
   };
 }
@@ -57,16 +57,17 @@ export async function getVersesByChapter(
   chapterId: string | number,
   translationId: number,
   page = 1,
-  perPage = 20
+  perPage = 20,
+  wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=${wordLang}&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
   }
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
-  const verses = (data.verses as ApiVerse[]).map(normalizeVerse);
+  const verses = (data.verses as ApiVerse[]).map(v => normalizeVerse(v, wordLang));
   return { verses, totalPages };
 }
 
@@ -106,16 +107,17 @@ export async function getVersesByJuz(
   juzId: string | number,
   translationId: number,
   page = 1,
-  perPage = 20
+  perPage = 20,
+  wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_juz/${juzId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_juz/${juzId}?language=${wordLang}&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
   }
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
-  const verses = (data.verses as ApiVerse[]).map(normalizeVerse);
+  const verses = (data.verses as ApiVerse[]).map(v => normalizeVerse(v, wordLang));
   return { verses, totalPages };
 }
 
@@ -123,16 +125,17 @@ export async function getVersesByPage(
   pageId: string | number,
   translationId: number,
   page = 1,
-  perPage = 20
+  perPage = 20,
+  wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_page/${pageId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_page/${pageId}?language=${wordLang}&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
   }
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
-  const verses = (data.verses as ApiVerse[]).map(normalizeVerse);
+  const verses = (data.verses as ApiVerse[]).map(v => normalizeVerse(v, wordLang));
   return { verses, totalPages };
 }
 


### PR DESCRIPTION
## Summary
- support dynamic word languages in API helpers
- fetch the selected `wordLang` when loading surah/juz/page verses
- test wordLang functionality in getVerses

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68822800d124832b9b515603858c4bbe