### PR TITLE
Sync word-by-word translation font size with Arabic text

### DIFF
--- a/__tests__/Verse.test.tsx
+++ b/__tests__/Verse.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { Verse as VerseComponent } from '@/app/features/surah/[surahId]/_components/Verse';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
+import { Verse } from '@/types';
+
+const verse: Verse = {
+  id: 1,
+  verse_key: '1:1',
+  text_uthmani: 'بِسْمِ الله',
+  words: [
+    { id: 1, uthmani: 'بِسْمِ', en: 'In' },
+    { id: 2, uthmani: 'الله', en: 'Allah' },
+  ],
+};
+
+const renderVerse = () =>
+  render(
+    <AudioProvider>
+      <SettingsProvider>
+        <VerseComponent verse={verse} />
+      </SettingsProvider>
+    </AudioProvider>
+  );
+
+describe('Verse word-by-word font size', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(
+      'quranAppSettings',
+      JSON.stringify({ arabicFontSize: 40, showByWords: true })
+    );
+  });
+
+  it('scales word translation with arabic font size', async () => {
+    renderVerse();
+    const word = await screen.findByText('In');
+    await waitFor(() => {
+      expect(word).toHaveStyle('font-size: 20px');
+    });
+  });
+});

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -106,7 +106,12 @@ export const Verse = ({ verse }: VerseProps) => {
                     </span>
                     {/* Inline translation below the word (when showByWords) */}
                     {showByWords && (
-                      <span className="block mt-1 text-xs text-gray-500">{word[wordLang] as string}</span>
+                      <span
+                        className="block mt-1 text-gray-500"
+                        style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
+                      >
+                        {word[wordLang] as string}
+                      </span>
                     )}
                   </span>
                 ))}


### PR DESCRIPTION
## Summary
- scale word-by-word translation font size according to Arabic font size
- add tests for new font scaling behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6882283f2610832b9d229e6589e3b4c2