### PR TITLE
Add Bangla word translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 Copy `.env.example` to `.env` and adjust the values if necessary. The default configuration includes the Quran API base URL.
 
+This project supports word-by-word translations in multiple languages, including a newly added Bengali option.
+
 ## Getting Started
 
 First, run the development server:

--- a/__tests__/getVerses.test.ts
+++ b/__tests__/getVerses.test.ts
@@ -19,9 +19,9 @@ describe('getVersesByChapter', () => {
       json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
     }) as jest.Mock;
 
-    await getVersesByChapter(1, 20, 1, 1);
+    await getVersesByChapter(1, 20, 1, 1, 'en');
     expect(global.fetch).toHaveBeenCalledWith(
-      `${API_BASE_URL}/verses/by_chapter/1?language=en&words=true&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
+      `${API_BASE_URL}/verses/by_chapter/1?language=en&words=true&word_translation_language=en&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
     );
   });
 });

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -52,7 +52,7 @@ export default function JuzPage({ params }: JuzPageProps) {
         ? ['verses', juzId, settings.translationId, index + 1]
         : null,
     ([, juzId, translationId, page]) =>
-      getVersesByJuz(juzId, translationId, page).catch(err => {
+      getVersesByJuz(juzId, translationId, page, 20, settings.wordLang).catch(err => {
         setError(`Failed to load content. ${err.message}`);
         return { verses: [], totalPages: 1 };
       })

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -42,7 +42,7 @@ export default function QuranPage({ params }: QuranPageProps) {
         ? ['verses', pageId, settings.translationId, index + 1]
         : null,
     ([, pageId, translationId, page]) =>
-      getVersesByPage(pageId, translationId, page).catch(err => {
+      getVersesByPage(pageId, translationId, page, 20, settings.wordLang).catch(err => {
         setError(`Failed to load content. ${err.message}`);
         return { verses: [], totalPages: 1 };
       })

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -24,6 +24,7 @@ export const SettingsSidebar = ({ onTranslationPanelOpen, selectedTranslationNam
     { value: 'en', label: 'English' },
     { value: 'id', label: 'Bahasa Indonesia' },
     { value: 'tr', label: 'Türkçe' },
+    { value: 'bn', label: 'Bengali' },
   ];
 
   // Helper function to calculate the slider's progress percentage

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -47,7 +47,7 @@ export default function SurahPage({ params }: SurahPageProps) {
         ? ['verses', surahId, settings.translationId, index + 1]
         : null,
     ([, surahId, translationId, page]) =>
-      getVersesByChapter(surahId, translationId, page).catch(err => {
+      getVersesByChapter(surahId, translationId, page, 20, settings.wordLang).catch(err => {
         setError(`Failed to load content. ${err.message}`);
         return { verses: [], totalPages: 1 };
       })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,9 +57,10 @@ export async function getVersesByChapter(
   chapterId: string | number,
   translationId: number,
   page = 1,
-  perPage = 20
+  perPage = 20,
+  wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=${wordLang}&words=true&word_translation_language=${wordLang}&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
@@ -106,9 +107,10 @@ export async function getVersesByJuz(
   juzId: string | number,
   translationId: number,
   page = 1,
-  perPage = 20
+  perPage = 20,
+  wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_juz/${juzId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_juz/${juzId}?language=${wordLang}&words=true&word_translation_language=${wordLang}&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);
@@ -123,9 +125,10 @@ export async function getVersesByPage(
   pageId: string | number,
   translationId: number,
   page = 1,
-  perPage = 20
+  perPage = 20,
+  wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_page/${pageId}?language=en&words=true&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  const url = `${API_BASE_URL}/verses/by_page/${pageId}?language=${wordLang}&words=true&word_translation_language=${wordLang}&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);


### PR DESCRIPTION
## Summary
- enable Bengali word-by-word translations
- update API helpers to request translations by language
- wire `settings.wordLang` through surah, juz and page pages
- test fetch URL updates
- document Bengali support in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688228a07fac832ba02478e9dfd43b8b