### PR TITLE
Add AGENTS with guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Contributor Guidelines
+
+## Setup
+
+Run the following commands before pushing changes:
+
+```bash
+npm install
+npm run lint
+npm test
+```
+
+## Commit Messages
+
+- Use a short summary in the imperative mood ("Add feature" not "Added" or "Adds").
+- Keep the first line under 50 characters.
+- Separate the summary from any additional details with a blank line.
+
+## Code Style
+
+- Follow the project's ESLint configuration. Run `npm run lint` and fix warnings when possible.
+- Use two spaces for indentation.
+- Write clear, descriptive variable and function names.
+


### PR DESCRIPTION
## Summary
- define contributor guidelines in root `AGENTS.md`

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: getVersesByChapter uses provided word language)*

------
https://chatgpt.com/codex/tasks/task_b_6882302935ac832b9f1b58e4e0dd0bab