### PR TITLE
Add format step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,6 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm run format -- --check
       - run: npm run lint
       - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Run the following commands before pushing changes:
 
 ```bash
 npm install
+npm run format
 npm run lint
 npm test
 ```
@@ -18,7 +19,6 @@ npm test
 
 ## Code Style
 
-- Follow the project's ESLint configuration. Run `npm run lint` and fix warnings when possible.
+- Follow the project's ESLint configuration. Run `npm run format` followed by `npm run lint` and fix warnings when possible.
 - Use two spaces for indentation.
 - Write clear, descriptive variable and function names.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,12 @@ npx ts-node scripts/fetchData.ts
 
 This updates `data/surahs.json` and `data/juz.json`.
 
-## Linting
+## Formatting and Linting
 
-Before committing, run the linter:
+Before committing, format and lint the code:
 
 ```bash
+npm run format
 npm run lint
 ```
 
@@ -45,4 +46,3 @@ npm test
 ## Continuous Integration
 
 GitHub Actions run linting and tests automatically for every push and pull request. See [.github/workflows/ci.yml](.github/workflows/ci.yml) for details.
-

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Copy `.env.example` to `.env` and adjust the values if necessary. The default co
 
 This project supports word-by-word translations in multiple languages, including a newly added Bengali option.
 
+Run `npm run format` after installing dependencies to ensure consistent code style.
+
 ## Getting Started
 
 First, run the development server:
@@ -101,4 +103,3 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-


### PR DESCRIPTION
## Summary
- mention code formatting in README setup instructions
- instruct running `npm run format` in AGENTS & CONTRIBUTING docs
- add formatting check to CI workflow

## Testing
- `npm run lint`
- `npm test` *(fails: getVersesByChapter uses provided word language in request)*

------
https://chatgpt.com/codex/tasks/task_b_68823a2aeba0832ba8b8f5e2df679810