### PR TITLE
Update juz ranges with local metadata

### DIFF
--- a/__tests__/juzData.test.ts
+++ b/__tests__/juzData.test.ts
@@ -1,0 +1,7 @@
+import juzData from '@/data/juz.json';
+
+describe('juz.json', () => {
+  it('has distinct ranges for first two juz', () => {
+    expect(juzData[0].surahRange).not.toEqual(juzData[1].surahRange);
+  });
+});

--- a/data/juz.json
+++ b/data/juz.json
@@ -2,151 +2,151 @@
   {
     "number": 1,
     "name": "Juz 1",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Faatiha 1 - Al-Baqara 141"
   },
   {
     "number": 2,
     "name": "Juz 2",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Baqara 142 - Al-Baqara 252"
   },
   {
     "number": 3,
     "name": "Juz 3",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Baqara 253 - Aal-i-Imraan 92"
   },
   {
     "number": 4,
     "name": "Juz 4",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Aal-i-Imraan 93 - An-Nisaa 23"
   },
   {
     "number": 5,
     "name": "Juz 5",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "An-Nisaa 24 - An-Nisaa 147"
   },
   {
     "number": 6,
     "name": "Juz 6",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "An-Nisaa 148 - Al-Maaida 81"
   },
   {
     "number": 7,
     "name": "Juz 7",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Maaida 82 - Al-An'aam 110"
   },
   {
     "number": 8,
     "name": "Juz 8",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-An'aam 111 - Al-A'raaf 87"
   },
   {
     "number": 9,
     "name": "Juz 9",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-A'raaf 88 - Al-Anfaal 40"
   },
   {
     "number": 10,
     "name": "Juz 10",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Anfaal 41 - At-Tawba 92"
   },
   {
     "number": 11,
     "name": "Juz 11",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "At-Tawba 93 - Hud 5"
   },
   {
     "number": 12,
     "name": "Juz 12",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Hud 6 - Yusuf 52"
   },
   {
     "number": 13,
     "name": "Juz 13",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Yusuf 53 - Ibrahim 52"
   },
   {
     "number": 14,
     "name": "Juz 14",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Hijr 1 - An-Nahl 128"
   },
   {
     "number": 15,
     "name": "Juz 15",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Israa 1 - Al-Kahf 74"
   },
   {
     "number": 16,
     "name": "Juz 16",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Kahf 75 - Taa-Haa 135"
   },
   {
     "number": 17,
     "name": "Juz 17",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Anbiyaa 1 - Al-Hajj 78"
   },
   {
     "number": 18,
     "name": "Juz 18",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Muminoon 1 - Al-Furqaan 20"
   },
   {
     "number": 19,
     "name": "Juz 19",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Furqaan 21 - An-Naml 55"
   },
   {
     "number": 20,
     "name": "Juz 20",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "An-Naml 56 - Al-Ankaboot 45"
   },
   {
     "number": 21,
     "name": "Juz 21",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Ankaboot 46 - Al-Ahzaab 30"
   },
   {
     "number": 22,
     "name": "Juz 22",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Ahzaab 31 - Yaseen 27"
   },
   {
     "number": 23,
     "name": "Juz 23",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Yaseen 28 - Az-Zumar 31"
   },
   {
     "number": 24,
     "name": "Juz 24",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Az-Zumar 32 - Fussilat 46"
   },
   {
     "number": 25,
     "name": "Juz 25",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Fussilat 47 - Al-Jaathiya 37"
   },
   {
     "number": 26,
     "name": "Juz 26",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Ahqaf 1 - Adh-Dhaariyat 30"
   },
   {
     "number": 27,
     "name": "Juz 27",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Adh-Dhaariyat 31 - Al-Hadid 29"
   },
   {
     "number": 28,
     "name": "Juz 28",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Mujaadila 1 - At-Tahrim 12"
   },
   {
     "number": 29,
     "name": "Juz 29",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "Al-Mulk 1 - Al-Mursalaat 50"
   },
   {
     "number": 30,
     "name": "Juz 30",
-    "surahRange": "Al-Fatihah 1 - Al-Baqarah 141"
+    "surahRange": "An-Naba 1 - An-Naas 6"
   }
 ]

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -60,7 +60,11 @@ export async function getVersesByChapter(
   perPage = 20,
   wordLang = 'en'
 ): Promise<PaginatedVerses> {
-  const url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=${wordLang}&words=true&word_translation_language=${wordLang}&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
+  let url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=${wordLang}&words=true`;
+  if (wordLang === 'en') {
+    url += `&word_translation_language=${wordLang}`;
+  }
+  url += `&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch verses: ${res.status}`);

--- a/scripts/fetchData.ts
+++ b/scripts/fetchData.ts
@@ -1,20 +1,5 @@
-const API_BASE_URL = process.env.QURAN_API_BASE_URL ?? 'https://api.quran.com/api/v4';
-
 import { writeFile } from 'fs/promises';
-
-interface Chapter {
-  id: number;
-  name_simple: string;
-  name_arabic: string;
-  verses_count: number;
-  translated_name?: { name: string };
-}
-
-interface JuzApi {
-  id: number;
-  juz_number: number;
-  verse_mapping: Record<string, string>;
-}
+import { getJuzMeta, getSurahMeta, surahNamesEn } from 'quran-meta';
 
 interface SurahMeta {
   number: number;
@@ -30,33 +15,19 @@ interface JuzMeta {
   surahRange: string;
 }
 
-async function fetchSurahs(): Promise<Chapter[]> {
-  const res = await fetch(`${API_BASE_URL}/chapters?language=en`);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch chapters: ${res.status}`);
-  }
-  const data = await res.json();
-  return data.chapters as Chapter[];
-}
-
-async function fetchJuz(num: number): Promise<JuzApi> {
-  const res = await fetch(`${API_BASE_URL}/juzs/${num}`);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch juz ${num}: ${res.status}`);
-  }
-  const data = await res.json();
-  return data.juz as JuzApi;
-}
-
 async function main() {
-  const chapters = await fetchSurahs();
-  const surahs: SurahMeta[] = chapters.map(ch => ({
-    number: ch.id,
-    name: ch.name_simple,
-    arabicName: ch.name_arabic,
-    verses: ch.verses_count,
-    meaning: ch.translated_name?.name ?? ''
-  }));
+  const surahs: SurahMeta[] = [];
+  for (let i = 1; i <= 114; i++) {
+    const meta = getSurahMeta(i);
+    const [name, meaning] = surahNamesEn[i];
+    surahs.push({
+      number: i,
+      name,
+      arabicName: meta.name,
+      verses: meta.ayahCount,
+      meaning
+    });
+  }
   await writeFile('data/surahs.json', JSON.stringify(surahs, null, 2) + '\n');
 
   const surahNames: Record<number, string> = {};
@@ -66,14 +37,11 @@ async function main() {
 
   const juzData: JuzMeta[] = [];
   for (let i = 1; i <= 30; i++) {
-    const juz = await fetchJuz(i);
-    const ids = Object.keys(juz.verse_mapping).map(Number);
-    const firstId = ids[0];
-    const lastId = ids[ids.length - 1];
-    const startVerse = juz.verse_mapping[firstId].split('-')[0];
-    const endVerse = juz.verse_mapping[lastId].split('-')[1];
-    const surahRange = `${surahNames[firstId]} ${startVerse} - ${surahNames[lastId]} ${endVerse}`;
-    juzData.push({ number: juz.juz_number, name: `Juz ${juz.juz_number}`, surahRange });
+    const meta = getJuzMeta(i);
+    const [startSurah, startAyah] = meta.first;
+    const [endSurah, endAyah] = meta.last;
+    const surahRange = `${surahNames[startSurah]} ${startAyah} - ${surahNames[endSurah]} ${endAyah}`;
+    juzData.push({ number: i, name: `Juz ${i}`, surahRange });
   }
   await writeFile('data/juz.json', JSON.stringify(juzData, null, 2) + '\n');
 }


### PR DESCRIPTION
## Summary
- fix surah range generation to use `quran-meta`
- regenerate `data/juz.json`
- adjust API to only include `word_translation_language` for English
- add a regression test for juz ranges

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68823a2c4c78832b95b47fc4f726e6be