### PR TITLE
Add tests for pages and bookmarks

### DIFF
--- a/__tests__/Bookmarks.test.tsx
+++ b/__tests__/Bookmarks.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import BookmarkedVersesList from '@/app/features/bookmarks/_components/BookmarkedVersesList';
+import BookmarksPage from '@/app/features/bookmarks/page';
+
+describe('Bookmarked verses components', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('BookmarkedVersesList shows empty message', () => {
+    render(
+      <SettingsProvider>
+        <BookmarkedVersesList />
+      </SettingsProvider>
+    );
+    expect(screen.getByText('No verses bookmarked yet.')).toBeInTheDocument();
+  });
+
+  test('BookmarkedVersesList displays saved bookmarks', () => {
+    localStorage.setItem('quranAppBookmarks', JSON.stringify(['1:1', '2:3']));
+    render(
+      <SettingsProvider>
+        <BookmarkedVersesList />
+      </SettingsProvider>
+    );
+    expect(
+      screen.getByText('Displaying bookmarked verses: 1:1, 2:3')
+    ).toBeInTheDocument();
+  });
+
+  test('BookmarksPage renders heading', () => {
+    render(
+      <SettingsProvider>
+        <BookmarksPage />
+      </SettingsProvider>
+    );
+    expect(screen.getByText('Bookmarked Verses')).toBeInTheDocument();
+  });
+});

--- a/__tests__/JuzPage.test.tsx
+++ b/__tests__/JuzPage.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
+import { SidebarProvider } from '@/app/context/SidebarContext';
+import { ThemeProvider } from '@/app/context/ThemeContext';
+import JuzPage from '@/app/features/juz/[juzId]/page';
+import { Verse, Juz } from '@/types';
+import * as api from '@/lib/api';
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return { ...actual, use: (v: any) => v };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+const mockVerse: Verse = {
+  id: 1,
+  verse_key: '1:1',
+  text_uthmani: 'verse text',
+  words: [],
+} as Verse;
+const mockJuz: Juz = {
+  id: 1,
+  juz_number: 1,
+  verse_mapping: {},
+  first_verse_id: 1,
+  last_verse_id: 1,
+  verses_count: 1,
+};
+
+jest.mock('@/lib/api');
+
+beforeAll(() => {
+  class IO {
+    observe() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.IntersectionObserver = IO;
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  (api.getTranslations as jest.Mock).mockResolvedValue([]);
+  (api.getVersesByJuz as jest.Mock).mockResolvedValue({ verses: [mockVerse], totalPages: 1 });
+  (api.getJuz as jest.Mock).mockResolvedValue(mockJuz);
+});
+
+const renderPage = () =>
+  render(
+    <AudioProvider>
+      <SettingsProvider>
+        <ThemeProvider>
+          <SidebarProvider>
+            <JuzPage params={{ juzId: '1' }} />
+          </SidebarProvider>
+        </ThemeProvider>
+      </SettingsProvider>
+    </AudioProvider>
+  );
+
+test('renders juz info and verses', async () => {
+  renderPage();
+  expect(await screen.findByText('juz_number')).toBeInTheDocument();
+  expect(await screen.findByText('verse text')).toBeInTheDocument();
+});

--- a/__tests__/PagePage.test.tsx
+++ b/__tests__/PagePage.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
+import { SidebarProvider } from '@/app/context/SidebarContext';
+import { ThemeProvider } from '@/app/context/ThemeContext';
+import QuranPage from '@/app/features/page/[pageId]/page';
+import { Verse } from '@/types';
+import * as api from '@/lib/api';
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return { ...actual, use: (v: any) => v };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+const mockVerse: Verse = {
+  id: 1,
+  verse_key: '1:1',
+  text_uthmani: 'page verse',
+  words: [],
+} as Verse;
+
+jest.mock('@/lib/api');
+
+beforeAll(() => {
+  class IO {
+    observe() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.IntersectionObserver = IO;
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  (api.getTranslations as jest.Mock).mockResolvedValue([]);
+  (api.getVersesByPage as jest.Mock).mockResolvedValue({ verses: [mockVerse], totalPages: 1 });
+});
+
+const renderPage = () =>
+  render(
+    <AudioProvider>
+      <SettingsProvider>
+        <ThemeProvider>
+          <SidebarProvider>
+            <QuranPage params={{ pageId: '1' }} />
+          </SidebarProvider>
+        </ThemeProvider>
+      </SettingsProvider>
+    </AudioProvider>
+  );
+
+test('renders verses for page', async () => {
+  renderPage();
+  expect(await screen.findByText('page verse')).toBeInTheDocument();
+});

--- a/__tests__/getVerses.test.ts
+++ b/__tests__/getVerses.test.ts
@@ -40,7 +40,7 @@ describe('getVersesByChapter', () => {
 
     await getVersesByChapter(1, 20, 1, 1, 'tr');
     expect(global.fetch).toHaveBeenCalledWith(
-      `${API_BASE_URL}/verses/by_chapter/1?language=tr&words=true&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
+      `${API_BASE_URL}/verses/by_chapter/1?language=tr&words=true&word_translation_language=tr&word_fields=text_uthmani&translations=20&fields=text_uthmani,audio&per_page=1&page=1`
     );
   });
 });


### PR DESCRIPTION
## Summary
- update existing `getVerses` test
- add tests for juz page and page components
- add tests for bookmarks components

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68823a2df2b4832b9ec875290b068350