### PR TITLE
Remove unused index params

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -141,7 +141,7 @@ export default function HomePage() {
 
             {activeTab === 'Surah' && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {filteredSurahs.map((surah, index) => (
+                {filteredSurahs.map(surah => (
                   <Link
                     href={`/features/surah/${surah.number}`}
                     key={surah.number}
@@ -169,7 +169,7 @@ export default function HomePage() {
             )}
             {activeTab === 'Juz' && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {allJuz.map((juz, index) => (
+                {allJuz.map(juz => (
                   <Link
                     href={`/features/juz/${juz.number}`}
                     key={juz.number}
@@ -191,7 +191,7 @@ export default function HomePage() {
             )}
             {activeTab === 'Page' && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {allPages.map((page, index) => (
+                {allPages.map(page => (
                   <Link
                     href={`/features/page/${page}`}
                     key={page}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -61,9 +61,7 @@ export async function getVersesByChapter(
   wordLang = 'en'
 ): Promise<PaginatedVerses> {
   let url = `${API_BASE_URL}/verses/by_chapter/${chapterId}?language=${wordLang}&words=true`;
-  if (wordLang === 'en') {
-    url += `&word_translation_language=${wordLang}`;
-  }
+  url += `&word_translation_language=${wordLang}`;
   url += `&word_fields=text_uthmani&translations=${translationId}&fields=text_uthmani,audio&per_page=${perPage}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- clean up unused variables in `HomePage` map callbacks
- always include `word_translation_language` in `getVersesByChapter`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6882424c3450832b93fb2fd65a0fa68a