### PR TITLE
Add EditorConfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Copy `.env.example` to `.env` and adjust the values if necessary. The default co
 
 An `.nvmrc` file pins Node.js to version **20**. Run `nvm use` to match this version before contributing.
 
+This project also provides an `.editorconfig` file. Ensure your editor respects
+it so that files use UTF-8 encoding, two spaces for indentation, and always end
+with a newline.
+
 ## Running the Development Server
 
 Start the development server with:


### PR DESCRIPTION
## Summary
- enforce consistent editor settings via `.editorconfig`
- note EditorConfig in contributing guidelines

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688249d55510832ba8002159d393d6c7