### PR TITLE
Add weekly dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` to automatically check npm dependencies weekly

## Testing Steps
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688249d7ba44832b96ca1e2563c41545