### PR TITLE
Add type checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
       - run: npm ci
       - run: npm run format -- --check
       - run: npm run lint
+      - run: npm run type-check
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "i18next": "^25.3.2",


### PR DESCRIPTION
## Summary
- add a `type-check` script for tsc
- run type checks in CI before tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688249d8cf68832b90b6e33fc6ced0a6