### PR TITLE
Add translated not-found page

### DIFF
--- a/__tests__/NotFound.test.tsx
+++ b/__tests__/NotFound.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import NotFound from '@/app/not-found';
+import TranslationProvider from '@/app/providers/TranslationProvider';
+
+// Mock next/link for testing environment
+jest.mock('next/link', () => {
+  return ({ children, href }: any) => <a href={href}>{children}</a>;
+});
+
+describe('NotFound page', () => {
+  it('renders translated text', () => {
+    render(
+      <TranslationProvider>
+        <NotFound />
+      </TranslationProvider>
+    );
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,15 @@
+'use client';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background)] text-[var(--foreground)] p-6">
+      <h1 className="text-2xl font-semibold mb-4">{t('page_not_found')}</h1>
+      <Link href="/" className="text-teal-600 hover:underline">
+        {t('home')}
+      </Link>
+    </div>
+  );
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -38,5 +38,6 @@
   "switch_to_dark": "Switch to dark mode",
   "switch_to_light": "Switch to light mode",
   "light_mode": "Light",
-  "dark_mode": "Dark"
+  "dark_mode": "Dark",
+  "page_not_found": "Page not found"
 }


### PR DESCRIPTION
## Summary
- add `app/not-found.tsx` with `useTranslation`
- localize new "page_not_found" text
- test not-found page renders translated strings

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68826624b1d8832bb5f5ce79c78c76e6