### PR TITLE
Add font license summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To make a font selectable in the application, edit `ARABIC_FONTS` in `app/contex
 `name` determines the label shown in the UI, `value` is the CSS `font-family`, and `category` controls which tab the font appears under.
 
 Only include fonts you are licensed to distribute. Keep any required attribution or license files with the font files inside `public/fonts/`.
+Font licenses for the fonts shipped with this project are documented in [public/fonts/LICENSES.md](public/fonts/LICENSES.md).
 
 ## Progressive Web App
 
@@ -110,6 +111,7 @@ We welcome contributions from the community. Please read our [CONTRIBUTING.md](C
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+All bundled fonts are licensed separately; see [public/fonts/LICENSES.md](public/fonts/LICENSES.md) for details.
 
 ## Code of Conduct
 

--- a/public/fonts/LICENSES.md
+++ b/public/fonts/LICENSES.md
@@ -1,0 +1,31 @@
+# Font Licenses
+
+The following fonts are distributed with this application. Each font is provided under its own license terms.
+
+- **Al-Mushaf.ttf**
+  - Source: [Alvi Technologies](http://www.alvitechnologies.com)
+  - License: License information not included in the font metadata. Contact the author for usage terms.
+- **Amiri.ttf**
+  - Source: [Amiri Font Project](http://www.amirifont.org)
+  - License: [SIL Open Font License 1.1](https://scripts.sil.org/OFL)
+- **KFGQPC-Uthman-Taha.ttf** and **KFGQPC-Uthman-Taha-Bold.ttf**
+  - Source: [King Fahd Glorious Quran Printing Complex](https://fonts.qurancomplex.gov.sa/)
+  - License: Electronic End-User License Agreement included with the font files.
+- **Lateef.ttf**
+  - Source: [SIL](https://software.sil.org/lateef)
+  - License: [SIL Open Font License 1.1](https://openfontlicense.org/)
+- **Me-Quran.ttf**
+  - Source: Meor Ridzuan
+  - License: Free for non-commercial use. Contact the author for other permissions.
+- **Noor-e-Hira.ttf**
+  - Source: [NooreHidayat](http://www.noorehidayat.org/)
+  - License: License agreement included with the font file.
+- **Noto Nastaliq Urdu.ttf** and **Noto-Naskh-Arabic.ttf**
+  - Source: [Google Noto Fonts](http://www.google.com/get/noto/)
+  - License: [SIL Open Font License 1.1](https://scripts.sil.org/OFL)
+- **PDMS-Saleem-Quran.ttf**
+  - Source: [Pakistan Data Management Services](http://www.pakdata.com)
+  - License: PDMS End User License Agreement.
+- **Scheherazade-New.ttf**
+  - Source: [SIL](https://software.sil.org/scheherazade)
+  - License: [SIL Open Font License 1.1](https://openfontlicense.org/)


### PR DESCRIPTION
## Summary
- document licenses for fonts in `public/fonts`
- point README to new license info and clarify fonts licensed separately

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688284dc05e0832b854e47c3142848dd