### PR TITLE
Add CHANGELOG and reference from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-07-24
+
+### Added
+
+- Bengali translations with accompanying tests.
+- `npm audit` verification step in the CI workflow.
+
+### Changed
+
+- Updated Node.js engine requirement.
+- Added type-check script and step in CI.
+- Documented contributing guidelines in README.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ This project is licensed under the [MIT License](LICENSE).
 ## Code of Conduct
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing to ensure a welcoming and inclusive environment.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for recent updates.


### PR DESCRIPTION
## Summary
- document project changes in new `CHANGELOG.md`
- link to the changelog from the README

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm audit --omit=dev`

------
https://chatgpt.com/codex/tasks/task_b_688284e580c0832b843549173de2d294