### PR TITLE
Add check script and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,4 @@ jobs:
       - run: npm ci
       - name: Audit dependencies
         run: npm audit --omit=dev --audit-level=high
-      - run: npm run format -- --check
-      - run: npm run lint
-      - run: npm run type-check
-      - run: npm test
+      - run: npm run check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,7 @@ Run the following commands before pushing changes:
 ```bash
 npm install
 npm audit --omit=dev
-npm run format
-npm run lint
-npm run type-check
-npm test
+npm run check
 ```
 
 ## Commit Messages

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "next lint",
     "test": "jest",
     "format": "prettier --write .",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "check": "npm run format -- --check && npm run lint && npm run type-check && npm test"
   },
   "dependencies": {
     "i18next": "^25.3.2",


### PR DESCRIPTION
## Summary
- add a `check` script to run formatting, linting, type checking, and tests
- update contributor instructions to use `npm run check`
- simplify CI workflow with the new script

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68828cc59224832b9ea27095bb8ddb2c