### PR TITLE
Update commit header rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ npx husky install
 ## Commit Message Style
 
 This project uses Conventional Commits. Messages are linted automatically by the `commit-msg` hook using commitlint.
+The summary line must not exceed **50** characters.
 
 Example:
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 50],
+  },
+};


### PR DESCRIPTION
## Summary
- enforce a 50-character limit for commit headers
- mention the limit in CONTRIBUTING guidelines

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6882a35345ac832b8450b67636f78c60