### PR TITLE
Fix Verse tests translation provider

### DIFF
--- a/__tests__/Verse.test.tsx
+++ b/__tests__/Verse.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { Verse as VerseComponent } from '@/app/features/surah/[surahId]/_components/Verse';
 import { SettingsProvider } from '@/app/context/SettingsContext';
 import { AudioProvider } from '@/app/context/AudioContext';
+import TranslationProvider from '@/app/providers/TranslationProvider';
 import { Verse } from '@/types';
 
 const verse: Verse = {
@@ -16,11 +17,13 @@ const verse: Verse = {
 
 const renderVerse = () =>
   render(
-    <AudioProvider>
-      <SettingsProvider>
-        <VerseComponent verse={verse} />
-      </SettingsProvider>
-    </AudioProvider>
+    <TranslationProvider>
+      <AudioProvider>
+        <SettingsProvider>
+          <VerseComponent verse={verse} />
+        </SettingsProvider>
+      </AudioProvider>
+    </TranslationProvider>
   );
 
 describe('Verse word-by-word font size', () => {


### PR DESCRIPTION
## Summary
- wrap translation context around verse tests
- ensure tests run without NO_I18NEXT_INSTANCE warning

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6882ae7b7f78832b86130571124eb185