### PR TITLE
Add Jest coverage report to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,9 @@ jobs:
       - name: Audit dependencies
         run: npm audit --omit=dev --audit-level=high
       - run: npm run check
+      - run: npm run test:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "format": "prettier --write .",
     "type-check": "tsc --noEmit",
     "check": "npm run format -- --check && npm run lint && npm run type-check && npm test",


### PR DESCRIPTION
## Summary
- add `test:coverage` script
- run coverage in GitHub Actions CI and upload artifact

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_b_6882ae7be660832b84f7ec9b796a0154