### PR TITLE
Fix sidebar layout on large screens

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -48,7 +48,12 @@ describe('SettingsSidebar interactions', () => {
     render(
       <Wrapper>
         <Header />
-        <SettingsSidebar onTranslationPanelOpen={() => {}} selectedTranslationName="English" />
+        <SettingsSidebar
+          onTranslationPanelOpen={() => {}}
+          onWordTranslationPanelOpen={() => {}}
+          selectedTranslationName="English"
+          selectedWordTranslationName="English"
+        />
       </Wrapper>
     );
 
@@ -64,7 +69,7 @@ describe('SettingsSidebar interactions', () => {
     expect(screen.getByText('Noto Nastaliq Urdu')).toBeInTheDocument();
 
     const panel = screen.getByText('select_font_face').parentElement?.parentElement as HTMLElement;
-    await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await userEvent.click(screen.getAllByRole('button', { name: 'Back' })[1]);
     expect(panel?.className).toContain('translate-x-full');
   });
 });

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -60,7 +60,9 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 rounded-l-[20px] ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 rounded-l-[20px] ${
+          isSettingsOpen ? 'translate-x-0' : 'translate-x-full lg:translate-x-0'
+        } lg:static lg:block`}
       >
         <header className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button


### PR DESCRIPTION
## Summary
- keep settings sidebar visible on wide displays
- adjust SettingsSidebar test with new props and selectors

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6883b95f0214832bbae89e606f487f80