### PR TITLE
Add Settings header and UI tweaks

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -48,12 +48,17 @@ describe('SettingsSidebar interactions', () => {
     render(
       <Wrapper>
         <Header />
-        <SettingsSidebar onTranslationPanelOpen={() => {}} selectedTranslationName="English" />
+        <SettingsSidebar
+          onTranslationPanelOpen={() => {}}
+          onWordTranslationPanelOpen={() => {}}
+          selectedTranslationName="English"
+          selectedWordTranslationName="English"
+        />
       </Wrapper>
     );
 
     const aside = document.querySelector('aside');
-    expect(aside?.className).toContain('hidden');
+    expect(aside?.className).toContain('translate-x-full');
 
     await userEvent.click(screen.getByLabelText('Open Settings'));
     expect(screen.getByText('reading_setting')).toBeInTheDocument();
@@ -64,7 +69,7 @@ describe('SettingsSidebar interactions', () => {
     expect(screen.getByText('Noto Nastaliq Urdu')).toBeInTheDocument();
 
     const panel = screen.getByText('select_font_face').parentElement?.parentElement as HTMLElement;
-    await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await userEvent.click(screen.getAllByRole('button', { name: 'Back' })[1]);
     expect(panel?.className).toContain('translate-x-full');
   });
 });

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -62,29 +62,42 @@ export const SettingsSidebar = ({
       <aside
         className={`fixed inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 rounded-l-[20px] ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
-        <header className="flex items-center justify-between p-4 border-b border-gray-200/80">
-          <button
-            aria-label="Back"
-            onClick={() => setSettingsOpen(false)}
-            className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
-          >
-            <FaArrowLeft size={18} />
-          </button>
-          <div className="flex space-x-4">
+        <header className="p-4 border-b border-gray-200/80">
+          <div className="flex items-center justify-between">
             <button
-              onClick={() => setActiveTab('translation')}
-              className={`text-sm font-semibold pb-1 border-b-2 transition-colors ${activeTab === 'translation' ? 'text-teal-600 border-teal-600' : 'text-gray-500 border-transparent'}`}
+              aria-label="Back"
+              onClick={() => setSettingsOpen(false)}
+              className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             >
-              Translation
+              <FaArrowLeft size={18} />
             </button>
-            <button
-              onClick={() => setActiveTab('reading')}
-              className={`text-sm font-semibold pb-1 border-b-2 transition-colors ${activeTab === 'reading' ? 'text-teal-600 border-teal-600' : 'text-gray-500 border-transparent'}`}
-            >
-              Reading
-            </button>
+            <h2 className="text-lg font-semibold">{t('settings')}</h2>
+            <div className="w-8" />
           </div>
-          <div className="w-8" />
+          <div className="mt-4 flex justify-center">
+            <div className="flex items-center p-1 rounded-full bg-gray-100 dark:bg-slate-800/60">
+              <button
+                onClick={() => setActiveTab('translation')}
+                className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+                  activeTab === 'translation'
+                    ? 'bg-white shadow text-slate-900 dark:bg-slate-700 dark:text-white'
+                    : 'text-slate-400 hover:text-white'
+                }`}
+              >
+                Translation
+              </button>
+              <button
+                onClick={() => setActiveTab('reading')}
+                className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+                  activeTab === 'reading'
+                    ? 'bg-white shadow text-slate-900 dark:bg-slate-700 dark:text-white'
+                    : 'text-slate-400 hover:text-white'
+                }`}
+              >
+                Reading
+              </button>
+            </div>
+          </div>
         </header>
         <div className="flex-grow">
           {activeTab === 'translation' ? (

--- a/public/locales/bn/common.json
+++ b/public/locales/bn/common.json
@@ -4,6 +4,7 @@
   "home": "বাড়ি",
   "all_surahs": "সমস্ত সূরা",
   "bookmarks": "বুকমার্কস",
+  "settings": "সেটিংস",
   "surah_tab": "সূরা",
   "juz_tab": "জুজ",
   "page_tab": "পৃষ্ঠা",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -4,6 +4,7 @@
   "home": "Home",
   "all_surahs": "All Surahs",
   "bookmarks": "Bookmarks",
+  "settings": "Settings",
   "surah_tab": "Surah",
   "juz_tab": "Juz",
   "page_tab": "Page",


### PR DESCRIPTION
## Summary
- show Settings heading and move translation/reading toggle
- style toggle buttons like the theme switcher
- add i18n entries for `settings`
- update SettingsSidebar tests

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6883b9638f7c832b82802d0efd452d13