### PR TITLE
Add overflow hiding to sidebars

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -48,7 +48,12 @@ describe('SettingsSidebar interactions', () => {
     render(
       <Wrapper>
         <Header />
-        <SettingsSidebar onTranslationPanelOpen={() => {}} selectedTranslationName="English" />
+        <SettingsSidebar
+          onTranslationPanelOpen={() => {}}
+          onWordTranslationPanelOpen={() => {}}
+          selectedTranslationName="English"
+          selectedWordTranslationName="English"
+        />
       </Wrapper>
     );
 
@@ -64,7 +69,8 @@ describe('SettingsSidebar interactions', () => {
     expect(screen.getByText('Noto Nastaliq Urdu')).toBeInTheDocument();
 
     const panel = screen.getByText('select_font_face').parentElement?.parentElement as HTMLElement;
-    await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+    const backButtons = screen.getAllByRole('button', { name: 'Back' });
+    await userEvent.click(backButtons[1]);
     expect(panel?.className).toContain('translate-x-full');
   });
 });

--- a/app/components/common/IconSidebar.tsx
+++ b/app/components/common/IconSidebar.tsx
@@ -15,7 +15,7 @@ const IconSidebar = () => {
   return (
     // CHANGE: Removed the border-r class for a cleaner look and centered content vertically
     // Added h-full to make the sidebar take full height for vertical centering
-    <aside className="w-20 bg-[var(--background)] text-[var(--foreground)] flex flex-col justify-center py-4 h-full">
+    <aside className="w-20 bg-[var(--background)] text-[var(--foreground)] flex flex-col justify-center py-4 h-full overflow-x-hidden">
       <nav className="flex flex-col items-center space-y-2">
         {navItems.map((item, index) => (
           <Link key={index} href={item.href} title={item.label}>

--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -99,7 +99,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
       {/* Sidebar */}
       <aside
         ref={sidebarRef} // Assign the ref to the aside element
-        className={`fixed md:static inset-y-0 left-0 w-80 h-full overflow-y-auto bg-[var(--background)] text-[var(--foreground)] flex flex-col flex-shrink-0 shadow-[5px_0px_15px_-5px_rgba(0,0,0,0.05)] z-50 md:z-10 transition-transform duration-300 ${isSurahListOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0`}
+        className={`fixed md:static inset-y-0 left-0 w-80 h-full overflow-y-auto overflow-x-hidden bg-[var(--background)] text-[var(--foreground)] flex flex-col flex-shrink-0 shadow-[5px_0px_15px_-5px_rgba(0,0,0,0.05)] z-50 md:z-10 transition-transform duration-300 ${isSurahListOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0`}
       >
         <div className="p-4 border-b border-gray-200/80">
           <div className="flex bg-gray-200 rounded-full p-1">

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -60,7 +60,7 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 rounded-l-[20px] ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 rounded-l-[20px] ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <header className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button


### PR DESCRIPTION
## Summary
- hide horizontal overflow on sidebar containers
- update SettingsSidebar test to target correct Back button

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6883b968ad54832ba3a95f839f377cd1