### PR TITLE
Fix settings sidebar UI

### DIFF
--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -60,68 +60,171 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex flex-col overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 rounded-l-[20px] ${
-          isSettingsOpen ? 'translate-x-0' : 'translate-x-full lg:translate-x-0'
-        } lg:static lg:block`}
+        className={`fixed lg:static inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >
-        <header className="p-4 border-b border-gray-200/80">
-          <div className="flex items-center justify-between">
+        <header className="flex items-center justify-between p-4 border-b border-gray-200/80">
+          <button
+            aria-label="Back"
+            onClick={() => setSettingsOpen(false)}
+            className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            <FaArrowLeft size={18} />
+          </button>
+          <div className="flex space-x-4">
             <button
-              aria-label="Back"
-              onClick={() => setSettingsOpen(false)}
-              className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+              onClick={() => setActiveTab('translation')}
+              className={`text-sm font-semibold pb-1 border-b-2 transition-colors ${activeTab === 'translation' ? 'text-teal-600 border-teal-600' : 'text-gray-500 border-transparent'}`}
             >
-              <FaArrowLeft size={18} />
+              Translation
             </button>
-            <h2 className="text-lg font-semibold">{t('settings')}</h2>
-            <div className="w-8" />
+            <button
+              onClick={() => setActiveTab('reading')}
+              className={`text-sm font-semibold pb-1 border-b-2 transition-colors ${activeTab === 'reading' ? 'text-teal-600 border-teal-600' : 'text-gray-500 border-transparent'}`}
+            >
+              Reading
+            </button>
           </div>
-          <div className="mt-4 flex justify-center">
-            <div className="flex items-center p-1 rounded-full bg-gray-100 dark:bg-slate-800/60">
-              <button
-                onClick={() => setActiveTab('translation')}
-                className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
-                  activeTab === 'translation'
-                    ? 'bg-white shadow text-slate-900 dark:bg-slate-700 dark:text-white'
-                    : 'text-slate-400 hover:text-white'
-                }`}
-              >
-                Translation
-              </button>
-              <button
-                onClick={() => setActiveTab('reading')}
-                className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
-                  activeTab === 'reading'
-                    ? 'bg-white shadow text-slate-900 dark:bg-slate-700 dark:text-white'
-                    : 'text-slate-400 hover:text-white'
-                }`}
-              >
-                Reading
-              </button>
-            </div>
-          </div>
+          <div className="w-8" />
         </header>
         <div className="flex-grow">
-          {activeTab === 'translation' ? (
-            <>
-              <CollapsibleSection
-                title={t('reading_setting')}
-                icon={<FaBookReader size={20} className="text-teal-700" />}
-              >
-                {/* Translation settings content */}
-                {/* ... unchanged content ... */}
-              </CollapsibleSection>
-              <CollapsibleSection
-                title={t('font_setting')}
-                icon={<FaFontSetting size={20} className="text-teal-700" />}
-              >
-                {/* Font settings content */}
-                {/* ... unchanged content ... */}
-              </CollapsibleSection>
-            </>
-          ) : (
-            <div className="p-4 text-center text-sm text-gray-500">Coming Soon</div>
-          )}
+          <CollapsibleSection
+            title={t('reading_setting')}
+            icon={<FaBookReader size={20} className="text-teal-700" />}
+          >
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-[var(--foreground)]">
+                  {t('translations')}
+                </label>
+                <button
+                  onClick={onTranslationPanelOpen}
+                  className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
+                >
+                  <span className="truncate text-[var(--foreground)]">
+                    {selectedTranslationName}
+                  </span>
+                  <FaChevronDown className="text-gray-500" />
+                </button>
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-[var(--foreground)]">
+                  {t('word_by_word_translation')}
+                </label>
+                <button
+                  onClick={onWordTranslationPanelOpen}
+                  className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
+                >
+                  <span className="truncate text-[var(--foreground)]">
+                    {selectedWordTranslationName}
+                  </span>
+                  <FaChevronDown className="text-gray-500" />
+                </button>
+              </div>
+
+              <div className="flex items-center justify-between pt-2">
+                <span className="text-sm text-[var(--foreground)]">{t('show_word_by_word')}</span>
+                <button
+                  onClick={() => setSettings({ ...settings, showByWords: !settings.showByWords })}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.showByWords ? 'bg-teal-600' : 'bg-gray-200'}`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.showByWords ? 'translate-x-6' : 'translate-x-1'}`}
+                  />
+                </button>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-[var(--foreground)]">{t('apply_tajweed')}</span>
+                <button
+                  onClick={() => setSettings({ ...settings, tajweed: !settings.tajweed })}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.tajweed ? 'bg-teal-600' : 'bg-gray-200'}`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.tajweed ? 'translate-x-6' : 'translate-x-1'}`}
+                  />
+                </button>
+              </div>
+            </div>
+          </CollapsibleSection>
+          <CollapsibleSection
+            title={t('font_setting')}
+            icon={<FaFontSetting size={20} className="text-teal-700" />}
+          >
+            <div className="space-y-4">
+              <div>
+                <div className="flex justify-between mb-1 text-sm">
+                  <label className="text-[var(--foreground)]">{t('arabic_font_size')}</label>
+                  <span className="font-semibold text-teal-700">{settings.arabicFontSize}</span>
+                </div>
+                <input
+                  type="range"
+                  min="16"
+                  max="48"
+                  value={settings.arabicFontSize}
+                  onChange={(e) => setSettings({ ...settings, arabicFontSize: +e.target.value })}
+                  style={{ '--value-percent': `${arabicSizePercent}%` } as React.CSSProperties}
+                />
+              </div>
+              <div>
+                <div className="flex justify-between mb-1 text-sm">
+                  <label className="text-[var(--foreground)]">{t('translation_font_size')}</label>
+                  <span className="font-semibold text-teal-700">
+                    {settings.translationFontSize}
+                  </span>
+                </div>
+                <input
+                  type="range"
+                  min="12"
+                  max="28"
+                  value={settings.translationFontSize}
+                  onChange={(e) =>
+                    setSettings({ ...settings, translationFontSize: +e.target.value })
+                  }
+                  style={{ '--value-percent': `${translationSizePercent}%` } as React.CSSProperties}
+                />
+              </div>
+              {/* Arabic Font Face Selection Button */}
+              <div>
+                <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+                  {t('arabic_font_face')}
+                </label>
+                <button
+                  onClick={() => setIsArabicFontPanelOpen(true)}
+                  className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
+                >
+                  <span className="truncate text-[var(--foreground)]">{selectedArabicFont}</span>
+                  <FaChevronDown className="text-gray-500" />
+                </button>
+              </div>
+              <div className="pt-2">
+                <div
+                  className={`flex items-center p-1 rounded-full ${theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'}`}
+                >
+                  <button
+                    onClick={() => setTheme('light')}
+                    className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+                      theme === 'light'
+                        ? 'bg-white shadow text-slate-900'
+                        : 'text-slate-400 hover:text-white'
+                    }`}
+                  >
+                    {t('light_mode')}
+                  </button>
+                  <button
+                    onClick={() => setTheme('dark')}
+                    className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+                      theme === 'dark'
+                        ? 'bg-slate-700 text-white shadow'
+                        : 'text-slate-400 hover:text-white'
+                    }`}
+                  >
+                    {t('dark_mode')}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </CollapsibleSection>
         </div>
         {/* Arabic Font Panel */}
         <ArabicFontPanel


### PR DESCRIPTION
## Summary
- restore full settings sidebar options
- add header with tab switch and theme toggle

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6883e78941ac832bb142216b55d662b6