### PR TITLE
Fix settings sidebar arrow

### DIFF
--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -66,7 +66,7 @@ export const SettingsSidebar = ({
           <button
             aria-label="Back"
             onClick={() => setSettingsOpen(false)}
-            className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+            className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 lg:hidden"
           >
             <FaArrowLeft size={18} />
           </button>


### PR DESCRIPTION
## Summary
- hide back arrow in settings panel on larger screens

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6883ebd04794832bb5932ea795a28902