### PR TITLE
Add language selection in settings

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -155,7 +155,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                   >
                     <div
                       className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg transition-colors shadow group-hover:bg-gray-100 dark:group-hover:bg-gray-700 group-hover:text-teal-600 transition`}
-                       style={{ backgroundColor: bgColor, color: textColor }}
+                      style={{ backgroundColor: bgColor, color: textColor }}
                     >
                       <span>{chapter.id}</span>
                     </div>

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -118,6 +118,38 @@ export const SettingsSidebar = ({
                   />
                 </button>
               </div>
+
+              {/* Translation selection */}
+              <div>
+                <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+                  {t('translations')}
+                </label>
+                <button
+                  onClick={onTranslationPanelOpen}
+                  className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
+                >
+                  <span className="truncate text-[var(--foreground)]">
+                    {selectedTranslationName}
+                  </span>
+                  <FaChevronDown className="text-gray-500" />
+                </button>
+              </div>
+
+              {/* Word-by-word language selection */}
+              <div>
+                <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+                  {t('word_by_word_language')}
+                </label>
+                <button
+                  onClick={onWordTranslationPanelOpen}
+                  className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
+                >
+                  <span className="truncate text-[var(--foreground)]">
+                    {selectedWordTranslationName}
+                  </span>
+                  <FaChevronDown className="text-gray-500" />
+                </button>
+              </div>
             </div>
           </CollapsibleSection>
           <CollapsibleSection


### PR DESCRIPTION
## Summary
- open TranslationPanel from Reading Settings
- open Word-by-Word language panel from Reading Settings
- fix Prettier spacing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68840a847498832bb096b182ba358a6a