### PR TITLE
Fix word translation labels

### DIFF
--- a/app/features/surah/[surahId]/_components/WordTranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordTranslationPanel.tsx
@@ -81,7 +81,7 @@ export const WordTranslationPanel = ({
                         onClose();
                       }}
                     />
-                    <span className="text-sm text-[var(--foreground)]">{opt.language_name}</span>
+                    <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
                   </label>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- fix duplicate word translation entries by displaying `opt.name`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688419283ce4832b8dd116c5adeb0c64