### PR TITLE
Add word-by-word language filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The application requires **Node.js 20 or higher**.
 
 You can also develop using a [Dev Container](https://containers.dev/). Open the project in a Dev Container to automatically use Node.js 20 with ESLint and Prettier extensions installed.
 
-This project supports word-by-word translations in multiple languages, including a newly added Bengali option.
+This project supports word-by-word translations in multiple languages. In addition to English, the app now offers Bengali, Indonesian, Turkish and Hindi word-by-word translations.
 
 Run `npm run format` after installing dependencies to ensure consistent code style.
 An `.editorconfig` file defines UTF-8 encoding, two-space indentation, and a newline at the end of files.

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -15,6 +15,7 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
 const DEFAULT_WORD_TRANSLATION_ID = 85;
+const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
 interface JuzPageProps {
   params: { juzId: string };
@@ -43,7 +44,10 @@ export default function JuzPage({ params }: JuzPageProps) {
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
   const wordTranslationOptions = useMemo(
-    () => wordTranslationOptionsData || [],
+    () =>
+      (wordTranslationOptionsData || []).filter((o) =>
+        ALLOWED_WORD_LANGUAGES.includes(o.language_name.toLowerCase())
+      ),
     [wordTranslationOptionsData]
   );
 

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -14,6 +14,7 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
 const DEFAULT_WORD_TRANSLATION_ID = 85;
+const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
 interface QuranPageProps {
   params: { pageId: string };
@@ -36,7 +37,10 @@ export default function QuranPage({ params }: QuranPageProps) {
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
   const wordTranslationOptions = useMemo(
-    () => wordTranslationOptionsData || [],
+    () =>
+      (wordTranslationOptionsData || []).filter((o) =>
+        ALLOWED_WORD_LANGUAGES.includes(o.language_name.toLowerCase())
+      ),
     [wordTranslationOptionsData]
   );
 

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -15,6 +15,7 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
 const DEFAULT_WORD_TRANSLATION_ID = 85;
+const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
 interface SurahPageProps {
   params: { surahId: string };
@@ -37,7 +38,10 @@ export default function SurahPage({ params }: SurahPageProps) {
 
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
   const wordTranslationOptions = useMemo(
-    () => wordTranslationOptionsData || [],
+    () =>
+      (wordTranslationOptionsData || []).filter((o) =>
+        ALLOWED_WORD_LANGUAGES.includes(o.language_name.toLowerCase())
+      ),
     [wordTranslationOptionsData]
   );
 


### PR DESCRIPTION
## Summary
- restrict word translation options to English, Bengali, Indonesian, Turkish and Hindi
- document the new languages in the README

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6884913a788c832bbbc55cbc65677962