### PR TITLE
Add unique word-by-word language picker

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -83,9 +83,7 @@ describe('SettingsSidebar interactions', () => {
   });
 
   it('opens the word translation panel and shows languages', async () => {
-    const groupedTranslations = {
-      Bengali: [{ id: 1, name: 'Bengali', language_name: 'Bengali' }],
-    };
+    const languageOptions = [{ id: 1, language_name: 'Bengali' }];
 
     const TestComponent = () => {
       const [open, setOpen] = useState(false);
@@ -101,7 +99,7 @@ describe('SettingsSidebar interactions', () => {
           <WordTranslationPanel
             isOpen={open}
             onClose={() => setOpen(false)}
-            groupedTranslations={groupedTranslations}
+            languages={languageOptions}
             searchTerm=""
             onSearchTermChange={() => {}}
             onReset={() => {}}

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -17,6 +17,11 @@ import useSWRInfinite from 'swr/infinite';
 const DEFAULT_WORD_TRANSLATION_ID = 85;
 const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
+interface LanguageOption {
+  language_name: string;
+  id: number;
+}
+
 interface JuzPageProps {
   params: { juzId: string };
 }
@@ -102,18 +107,19 @@ export default function JuzPage({ params }: JuzPageProps) {
         }, {}),
     [translationOptions, translationSearchTerm]
   );
-  const groupedWordTranslations = useMemo(
-    () =>
-      wordTranslationOptions
-        .filter((o) =>
-          o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
-        )
-        .reduce<Record<string, TranslationResource[]>>((acc, t) => {
-          (acc[t.language_name] ||= []).push(t);
-          return acc;
-        }, {}),
-    [wordTranslationOptions, wordTranslationSearchTerm]
-  );
+  const wordLanguageOptions = useMemo(() => {
+    const filtered = wordTranslationOptions.filter((o) =>
+      o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
+    );
+    const seen = new Set<string>();
+    return filtered.reduce<LanguageOption[]>((acc, t) => {
+      if (!seen.has(t.language_name)) {
+        seen.add(t.language_name);
+        acc.push({ language_name: t.language_name, id: t.id });
+      }
+      return acc;
+    }, []);
+  }, [wordTranslationOptions, wordTranslationSearchTerm]);
 
   return (
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
@@ -197,7 +203,7 @@ export default function JuzPage({ params }: JuzPageProps) {
       <WordTranslationPanel
         isOpen={isWordPanelOpen}
         onClose={() => setIsWordPanelOpen(false)}
-        groupedTranslations={groupedWordTranslations}
+        languages={wordLanguageOptions}
         searchTerm={wordTranslationSearchTerm}
         onSearchTermChange={setWordTranslationSearchTerm}
         onReset={() => {

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -16,6 +16,11 @@ import useSWRInfinite from 'swr/infinite';
 const DEFAULT_WORD_TRANSLATION_ID = 85;
 const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
+interface LanguageOption {
+  language_name: string;
+  id: number;
+}
+
 interface QuranPageProps {
   params: { pageId: string };
 }
@@ -94,18 +99,19 @@ export default function QuranPage({ params }: QuranPageProps) {
         }, {}),
     [translationOptions, translationSearchTerm]
   );
-  const groupedWordTranslations = useMemo(
-    () =>
-      wordTranslationOptions
-        .filter((o) =>
-          o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
-        )
-        .reduce<Record<string, TranslationResource[]>>((acc, t) => {
-          (acc[t.language_name] ||= []).push(t);
-          return acc;
-        }, {}),
-    [wordTranslationOptions, wordTranslationSearchTerm]
-  );
+  const wordLanguageOptions = useMemo(() => {
+    const filtered = wordTranslationOptions.filter((o) =>
+      o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
+    );
+    const seen = new Set<string>();
+    return filtered.reduce<LanguageOption[]>((acc, t) => {
+      if (!seen.has(t.language_name)) {
+        seen.add(t.language_name);
+        acc.push({ language_name: t.language_name, id: t.id });
+      }
+      return acc;
+    }, []);
+  }, [wordTranslationOptions, wordTranslationSearchTerm]);
 
   return (
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
@@ -169,7 +175,7 @@ export default function QuranPage({ params }: QuranPageProps) {
       <WordTranslationPanel
         isOpen={isWordPanelOpen}
         onClose={() => setIsWordPanelOpen(false)}
-        groupedTranslations={groupedWordTranslations}
+        languages={wordLanguageOptions}
         searchTerm={wordTranslationSearchTerm}
         onSearchTermChange={setWordTranslationSearchTerm}
         onReset={() => {

--- a/app/features/surah/[surahId]/_components/WordTranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordTranslationPanel.tsx
@@ -2,14 +2,18 @@
 'use client';
 import { FaArrowLeft, FaSearch } from '@/app/components/common/SvgIcons';
 import { useTranslation } from 'react-i18next';
-import { TranslationResource } from '@/types';
 import { useSettings } from '@/app/context/SettingsContext';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
+
+interface LanguageOption {
+  language_name: string;
+  id: number;
+}
 
 interface WordTranslationPanelProps {
   isOpen: boolean;
   onClose: () => void;
-  groupedTranslations: Record<string, TranslationResource[]>;
+  languages: LanguageOption[];
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
   onReset: () => void;
@@ -18,7 +22,7 @@ interface WordTranslationPanelProps {
 export const WordTranslationPanel = ({
   isOpen,
   onClose,
-  groupedTranslations,
+  languages,
   searchTerm,
   onSearchTermChange,
   onReset,
@@ -54,40 +58,32 @@ export const WordTranslationPanel = ({
           />
         </div>
       </div>
-      <div className="flex-grow overflow-y-auto">
-        {groupedTranslations &&
-          Object.keys(groupedTranslations).map((lang) => (
-            <div key={lang}>
-              <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm">
-                {lang}
-              </h3>
-              <div className="p-2 space-y-1">
-                {groupedTranslations[lang].map((opt) => (
-                  <label
-                    key={opt.id}
-                    className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
-                  >
-                    <input
-                      type="radio"
-                      name="wordTranslation"
-                      className="form-radio h-4 w-4 text-teal-600"
-                      checked={settings.wordTranslationId === opt.id}
-                      onChange={() => {
-                        setSettings({
-                          ...settings,
-                          wordTranslationId: opt.id,
-                          wordLang:
-                            LANGUAGE_CODES[opt.language_name.toLowerCase()] ?? settings.wordLang,
-                        });
-                        onClose();
-                      }}
-                    />
-                    <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
-                  </label>
-                ))}
-              </div>
-            </div>
-          ))}
+      <div className="flex-grow overflow-y-auto p-2 space-y-1">
+        {languages.map((opt) => (
+          <label
+            key={opt.language_name}
+            className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+          >
+            <input
+              type="radio"
+              name="wordLanguage"
+              className="form-radio h-4 w-4 text-teal-600"
+              checked={
+                settings.wordLang ===
+                (LANGUAGE_CODES[opt.language_name.toLowerCase()] ?? settings.wordLang)
+              }
+              onChange={() => {
+                setSettings({
+                  ...settings,
+                  wordTranslationId: opt.id,
+                  wordLang: LANGUAGE_CODES[opt.language_name.toLowerCase()] ?? settings.wordLang,
+                });
+                onClose();
+              }}
+            />
+            <span className="text-sm text-[var(--foreground)]">{opt.language_name}</span>
+          </label>
+        ))}
       </div>
       <div className="p-4 border-t border-gray-200/80">
         <button

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -17,6 +17,11 @@ import useSWRInfinite from 'swr/infinite';
 const DEFAULT_WORD_TRANSLATION_ID = 85;
 const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
+interface LanguageOption {
+  language_name: string;
+  id: number;
+}
+
 interface SurahPageProps {
   params: { surahId: string };
 }
@@ -95,18 +100,19 @@ export default function SurahPage({ params }: SurahPageProps) {
         }, {}),
     [translationOptions, translationSearchTerm]
   );
-  const groupedWordTranslations = useMemo(
-    () =>
-      wordTranslationOptions
-        .filter((o) =>
-          o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
-        )
-        .reduce<Record<string, TranslationResource[]>>((acc, t) => {
-          (acc[t.language_name] ||= []).push(t);
-          return acc;
-        }, {}),
-    [wordTranslationOptions, wordTranslationSearchTerm]
-  );
+  const wordLanguageOptions = useMemo(() => {
+    const filtered = wordTranslationOptions.filter((o) =>
+      o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
+    );
+    const seen = new Set<string>();
+    return filtered.reduce<LanguageOption[]>((acc, t) => {
+      if (!seen.has(t.language_name)) {
+        seen.add(t.language_name);
+        acc.push({ language_name: t.language_name, id: t.id });
+      }
+      return acc;
+    }, []);
+  }, [wordTranslationOptions, wordTranslationSearchTerm]);
 
   return (
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
@@ -174,7 +180,7 @@ export default function SurahPage({ params }: SurahPageProps) {
       <WordTranslationPanel
         isOpen={isWordPanelOpen}
         onClose={() => setIsWordPanelOpen(false)}
-        groupedTranslations={groupedWordTranslations}
+        languages={wordLanguageOptions}
         searchTerm={wordTranslationSearchTerm}
         onSearchTermChange={setWordTranslationSearchTerm}
         onReset={() => {


### PR DESCRIPTION
## Summary
- simplify `WordTranslationPanel` to list languages instead of translators
- select available word languages in feature pages
- update SettingsSidebar tests for new interface

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68849b3bea64832bae638c5d51896b3b