### PR TITLE
Add word-by-word language selector

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Header from '@/app/components/common/Header';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
-import { WordTranslationPanel } from '@/app/features/surah/[surahId]/_components/WordTranslationPanel';
+import { WordLanguagePanel } from '@/app/features/surah/[surahId]/_components/WordLanguagePanel';
 import { SettingsProvider } from '@/app/context/SettingsContext';
 import { SidebarProvider } from '@/app/context/SidebarContext';
 import { ThemeProvider } from '@/app/context/ThemeContext';
@@ -53,9 +53,9 @@ describe('SettingsSidebar interactions', () => {
         <Header />
         <SettingsSidebar
           onTranslationPanelOpen={() => {}}
-          onWordTranslationPanelOpen={() => {}}
+          onWordLanguagePanelOpen={() => {}}
           selectedTranslationName="English"
-          selectedWordTranslationName="English"
+          selectedWordLanguageName="English"
         />
       </Wrapper>
     );
@@ -83,10 +83,6 @@ describe('SettingsSidebar interactions', () => {
   });
 
   it('opens the word translation panel and shows languages', async () => {
-    const groupedTranslations = {
-      Bengali: [{ id: 1, name: 'Bengali', language_name: 'Bengali' }],
-    };
-
     const TestComponent = () => {
       const [open, setOpen] = useState(false);
       return (
@@ -94,14 +90,14 @@ describe('SettingsSidebar interactions', () => {
           <Header />
           <SettingsSidebar
             onTranslationPanelOpen={() => {}}
-            onWordTranslationPanelOpen={() => setOpen(true)}
+            onWordLanguagePanelOpen={() => setOpen(true)}
             selectedTranslationName="English"
-            selectedWordTranslationName="Bengali"
+            selectedWordLanguageName="Bengali"
           />
-          <WordTranslationPanel
+          <WordLanguagePanel
             isOpen={open}
             onClose={() => setOpen(false)}
-            groupedTranslations={groupedTranslations}
+            languages={[{ id: 1, name: 'Bengali' }]}
             searchTerm=""
             onSearchTermChange={() => {}}
             onReset={() => {}}

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -6,16 +6,16 @@ import { useTranslation } from 'react-i18next';
 import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
 import { TranslationPanel } from '@/app/features/surah/[surahId]/_components/TranslationPanel';
-import { WordTranslationPanel } from '@/app/features/surah/[surahId]/_components/WordTranslationPanel';
+import { WordLanguagePanel } from '@/app/features/surah/[surahId]/_components/WordLanguagePanel';
 import { Verse as VerseType, TranslationResource, Juz } from '@/types';
 import { getTranslations, getWordTranslations, getVersesByJuz, getJuz } from '@/lib/api';
+import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
 const DEFAULT_WORD_TRANSLATION_ID = 85;
-const ALLOWED_WORD_LANGUAGES = ['english', 'bengali', 'indonesian', 'turkish', 'hindi'];
 
 interface JuzPageProps {
   params: { juzId: string };
@@ -43,12 +43,18 @@ export default function JuzPage({ params }: JuzPageProps) {
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
-  const wordTranslationOptions = useMemo(
-    () =>
-      (wordTranslationOptionsData || []).filter((o) =>
-        ALLOWED_WORD_LANGUAGES.includes(o.language_name.toLowerCase())
-      ),
-    [wordTranslationOptionsData]
+  const wordLanguageMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    (wordTranslationOptionsData || []).forEach((o) => {
+      if (!map[o.language_name]) {
+        map[o.language_name] = o.id;
+      }
+    });
+    return map;
+  }, [wordTranslationOptionsData]);
+  const wordLanguageOptions = useMemo(
+    () => Object.keys(wordLanguageMap).map((name) => ({ name, id: wordLanguageMap[name] })),
+    [wordLanguageMap]
   );
 
   // Infinite loading for verses
@@ -86,11 +92,11 @@ export default function JuzPage({ params }: JuzPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedWordTranslationName = useMemo(
+  const selectedWordLanguageName = useMemo(
     () =>
-      wordTranslationOptions.find((o) => o.id === settings.wordTranslationId)?.language_name ||
-      t('select_word_translation'),
-    [settings.wordTranslationId, wordTranslationOptions, t]
+      wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)
+        ?.name || t('select_word_translation'),
+    [settings.wordLang, wordLanguageOptions, t]
   );
   const groupedTranslations = useMemo(
     () =>
@@ -102,17 +108,12 @@ export default function JuzPage({ params }: JuzPageProps) {
         }, {}),
     [translationOptions, translationSearchTerm]
   );
-  const groupedWordTranslations = useMemo(
+  const filteredWordLanguages = useMemo(
     () =>
-      wordTranslationOptions
-        .filter((o) =>
-          o.language_name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
-        )
-        .reduce<Record<string, TranslationResource[]>>((acc, t) => {
-          (acc[t.language_name] ||= []).push(t);
-          return acc;
-        }, {}),
-    [wordTranslationOptions, wordTranslationSearchTerm]
+      wordLanguageOptions.filter((o) =>
+        o.name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
+      ),
+    [wordLanguageOptions, wordTranslationSearchTerm]
   );
 
   return (
@@ -182,9 +183,9 @@ export default function JuzPage({ params }: JuzPageProps) {
 
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
-        onWordTranslationPanelOpen={() => setIsWordPanelOpen(true)}
+        onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
         selectedTranslationName={selectedTranslationName}
-        selectedWordTranslationName={selectedWordTranslationName}
+        selectedWordLanguageName={selectedWordLanguageName}
       />
 
       <TranslationPanel
@@ -194,15 +195,19 @@ export default function JuzPage({ params }: JuzPageProps) {
         searchTerm={translationSearchTerm}
         onSearchTermChange={setTranslationSearchTerm}
       />
-      <WordTranslationPanel
+      <WordLanguagePanel
         isOpen={isWordPanelOpen}
         onClose={() => setIsWordPanelOpen(false)}
-        groupedTranslations={groupedWordTranslations}
+        languages={filteredWordLanguages}
         searchTerm={wordTranslationSearchTerm}
         onSearchTermChange={setWordTranslationSearchTerm}
         onReset={() => {
           setWordTranslationSearchTerm('');
-          setSettings({ ...settings, wordTranslationId: DEFAULT_WORD_TRANSLATION_ID });
+          setSettings({
+            ...settings,
+            wordLang: 'en',
+            wordTranslationId: wordLanguageMap['English'] ?? DEFAULT_WORD_TRANSLATION_ID,
+          });
         }}
       />
     </div>

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -15,23 +15,22 @@ import { useTheme } from '@/app/context/ThemeContext';
 
 interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
-  onWordTranslationPanelOpen: () => void;
+  onWordLanguagePanelOpen: () => void;
   selectedTranslationName: string;
-  selectedWordTranslationName: string;
+  selectedWordLanguageName: string;
 }
 
 export const SettingsSidebar = ({
   onTranslationPanelOpen,
-  onWordTranslationPanelOpen,
+  onWordLanguagePanelOpen,
   selectedTranslationName,
-  selectedWordTranslationName,
+  selectedWordLanguageName,
 }: SettingsSidebarProps) => {
   const { settings, setSettings, arabicFonts } = useSettings();
   const { t } = useTranslation();
   const [isArabicFontPanelOpen, setIsArabicFontPanelOpen] = useState(false);
   const { isSettingsOpen, setSettingsOpen } = useSidebar();
   const { theme, setTheme } = useTheme();
-  const [activeTab, setActiveTab] = useState<'translation' | 'reading'>('translation');
 
   // Helper function to calculate the slider's progress percentage
   const getPercentage = (value: number, min: number, max: number) => {
@@ -79,13 +78,13 @@ export const SettingsSidebar = ({
           >
             <button
               onClick={onTranslationPanelOpen}
-              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${activeTab === 'translation' ? (theme === 'light' ? 'bg-white shadow text-slate-900' : 'bg-slate-700 text-white shadow') : theme === 'light' ? 'text-slate-400 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}
+              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${theme === 'light' ? 'bg-white shadow text-slate-900' : 'bg-slate-700 text-white shadow'}`}
             >
               Translation
             </button>
             <button
-              onClick={onWordTranslationPanelOpen}
-              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${activeTab === 'reading' ? (theme === 'light' ? 'bg-white shadow text-slate-900' : 'bg-slate-700 text-white shadow') : theme === 'light' ? 'text-slate-400 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}
+              onClick={onWordLanguagePanelOpen}
+              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${theme === 'light' ? 'text-slate-400 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}
             >
               Reading
             </button>
@@ -141,11 +140,11 @@ export const SettingsSidebar = ({
                   {t('word_by_word_language')}
                 </label>
                 <button
-                  onClick={onWordTranslationPanelOpen}
+                  onClick={onWordLanguagePanelOpen}
                   className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
                 >
                   <span className="truncate text-[var(--foreground)]">
-                    {selectedWordTranslationName}
+                    {selectedWordLanguageName}
                   </span>
                   <FaChevronDown className="text-gray-500" />
                 </button>

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -1,30 +1,38 @@
-// app/features/surah/[surahId]/_components/WordTranslationPanel.tsx
 'use client';
 import { FaArrowLeft, FaSearch } from '@/app/components/common/SvgIcons';
 import { useTranslation } from 'react-i18next';
-import { TranslationResource } from '@/types';
 import { useSettings } from '@/app/context/SettingsContext';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
 
-interface WordTranslationPanelProps {
+interface LanguageOption {
+  name: string;
+  id: number;
+}
+
+interface WordLanguagePanelProps {
   isOpen: boolean;
   onClose: () => void;
-  groupedTranslations: Record<string, TranslationResource[]>;
+  languages: LanguageOption[];
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
   onReset: () => void;
 }
 
-export const WordTranslationPanel = ({
+export const WordLanguagePanel = ({
   isOpen,
   onClose,
-  groupedTranslations,
+  languages,
   searchTerm,
   onSearchTermChange,
   onReset,
-}: WordTranslationPanelProps) => {
+}: WordLanguagePanelProps) => {
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
+
+  const filtered = languages.filter((lang) =>
+    lang.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
   return (
     <div
       className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
@@ -55,39 +63,28 @@ export const WordTranslationPanel = ({
         </div>
       </div>
       <div className="flex-grow overflow-y-auto">
-        {groupedTranslations &&
-          Object.keys(groupedTranslations).map((lang) => (
-            <div key={lang}>
-              <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm">
-                {lang}
-              </h3>
-              <div className="p-2 space-y-1">
-                {groupedTranslations[lang].map((opt) => (
-                  <label
-                    key={opt.id}
-                    className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
-                  >
-                    <input
-                      type="radio"
-                      name="wordTranslation"
-                      className="form-radio h-4 w-4 text-teal-600"
-                      checked={settings.wordTranslationId === opt.id}
-                      onChange={() => {
-                        setSettings({
-                          ...settings,
-                          wordTranslationId: opt.id,
-                          wordLang:
-                            LANGUAGE_CODES[opt.language_name.toLowerCase()] ?? settings.wordLang,
-                        });
-                        onClose();
-                      }}
-                    />
-                    <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
-                  </label>
-                ))}
-              </div>
-            </div>
-          ))}
+        {filtered.map((lang) => (
+          <label
+            key={lang.id}
+            className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+          >
+            <input
+              type="radio"
+              name="wordLanguage"
+              className="form-radio h-4 w-4 text-teal-600"
+              checked={settings.wordLang === LANGUAGE_CODES[lang.name.toLowerCase()]}
+              onChange={() => {
+                setSettings({
+                  ...settings,
+                  wordLang: LANGUAGE_CODES[lang.name.toLowerCase()] ?? settings.wordLang,
+                  wordTranslationId: lang.id,
+                });
+                onClose();
+              }}
+            />
+            <span className="text-sm text-[var(--foreground)]">{lang.name}</span>
+          </label>
+        ))}
       </div>
       <div className="p-4 border-t border-gray-200/80">
         <button


### PR DESCRIPTION
## Summary
- replace WordTranslationPanel with WordLanguagePanel
- filter unique languages from API
- update settings sidebar and pages to use word language panel
- adjust tests for new component

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68849b3bea64832bae638c5d51896b3b