### PR TITLE
Normalize word language keys

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -47,8 +47,9 @@ export default function JuzPage({ params }: JuzPageProps) {
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
     (wordTranslationOptionsData || []).forEach((o) => {
-      if (!map[o.language_name]) {
-        map[o.language_name] = o.id;
+      const name = o.language_name.toLowerCase();
+      if (!map[name]) {
+        map[name] = o.id;
       }
     });
     return map;
@@ -210,7 +211,7 @@ export default function JuzPage({ params }: JuzPageProps) {
           setSettings({
             ...settings,
             wordLang: 'en',
-            wordTranslationId: wordLanguageMap['English'] ?? DEFAULT_WORD_TRANSLATION_ID,
+            wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
           });
         }}
       />

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -40,8 +40,9 @@ export default function QuranPage({ params }: QuranPageProps) {
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
     (wordTranslationOptionsData || []).forEach((o) => {
-      if (!map[o.language_name]) {
-        map[o.language_name] = o.id;
+      const name = o.language_name.toLowerCase();
+      if (!map[name]) {
+        map[name] = o.id;
       }
     });
     return map;
@@ -182,7 +183,7 @@ export default function QuranPage({ params }: QuranPageProps) {
           setSettings({
             ...settings,
             wordLang: 'en',
-            wordTranslationId: wordLanguageMap['English'] ?? DEFAULT_WORD_TRANSLATION_ID,
+            wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
           });
         }}
       />

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -41,8 +41,9 @@ export default function SurahPage({ params }: SurahPageProps) {
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
     (wordTranslationOptionsData || []).forEach((o) => {
-      if (!map[o.language_name]) {
-        map[o.language_name] = o.id;
+      const name = o.language_name.toLowerCase();
+      if (!map[name]) {
+        map[name] = o.id;
       }
     });
     return map;
@@ -187,7 +188,7 @@ export default function SurahPage({ params }: SurahPageProps) {
           setSettings({
             ...settings,
             wordLang: 'en',
-            wordTranslationId: wordLanguageMap['English'] ?? DEFAULT_WORD_TRANSLATION_ID,
+            wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
           });
         }}
       />

--- a/lib/wordLanguages.ts
+++ b/lib/wordLanguages.ts
@@ -1,10 +1,10 @@
 export const WORD_LANGUAGE_LABELS: Record<string, string> = {
-  English: 'English',
-  Bengali: 'Bangla',
-  Urdu: 'Urdu',
-  Hindi: 'Hindi',
-  Indonesian: 'Bahasa Indonesia',
-  Persian: 'Persian',
-  Turkish: 'Turkish',
-  Tamil: 'Tamil',
+  english: 'English',
+  bengali: 'Bangla',
+  urdu: 'Urdu',
+  hindi: 'Hindi',
+  indonesian: 'Bahasa Indonesia',
+  persian: 'Persian',
+  turkish: 'Turkish',
+  tamil: 'Tamil',
 };


### PR DESCRIPTION
## Summary
- use lowercase keys for the word language map
- map word languages by lowercase name in Juz, Surah and Page pages
- reset word translation using the lowercase "english" key

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68851ae2848c832bb49a72edb922c598