### PR TITLE
Fix header layout shift on page refresh

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -21,7 +21,7 @@ const Header = () => {
 
   return (
     // Adjusted background, padding, and grid layout for cleaner look
-    <header className="h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 bg-[var(--background)] text-[var(--foreground)] shadow-sm sticky top-0 z-30">
+    <header className="fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 bg-[var(--background)] text-[var(--foreground)] shadow-sm z-30">
       {/* Column 1: Title & Surah List Toggle */}
       <div className="flex items-center gap-2">
         <button

--- a/app/features/juz/[juzId]/layout.tsx
+++ b/app/features/juz/[juzId]/layout.tsx
@@ -7,8 +7,8 @@ import { AudioProvider } from '@/app/context/AudioContext';
 export default function JuzLayout({ children }: { children: React.ReactNode }) {
   return (
     <AudioProvider>
-      <div className="h-screen flex flex-col">
-        <Header />
+      <Header />
+      <div className="h-screen flex flex-col pt-16">
         <div className="flex flex-grow overflow-hidden">
           <IconSidebar />
           <SurahListSidebar />

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -189,6 +189,7 @@ export default function JuzPage({ params }: JuzPageProps) {
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
+        onReadingPanelOpen={() => {}}
         selectedTranslationName={selectedTranslationName}
         selectedWordLanguageName={selectedWordLanguageName}
       />

--- a/app/features/page/[pageId]/layout.tsx
+++ b/app/features/page/[pageId]/layout.tsx
@@ -7,8 +7,8 @@ import { AudioProvider } from '@/app/context/AudioContext';
 export default function PageLayout({ children }: { children: React.ReactNode }) {
   return (
     <AudioProvider>
-      <div className="h-screen flex flex-col">
-        <Header />
+      <Header />
+      <div className="h-screen flex flex-col pt-16">
         <div className="flex flex-grow overflow-hidden">
           <IconSidebar />
           <SurahListSidebar />

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -161,6 +161,7 @@ export default function QuranPage({ params }: QuranPageProps) {
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
+        onReadingPanelOpen={() => {}}
         selectedTranslationName={selectedTranslationName}
         selectedWordLanguageName={selectedWordLanguageName}
       />

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '@/app/context/ThemeContext';
 interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
   onWordLanguagePanelOpen: () => void;
-  onReadingPanelOpen: () => void;
+  onReadingPanelOpen?: () => void;
   selectedTranslationName: string;
   selectedWordLanguageName: string;
 }
@@ -53,7 +53,7 @@ export const SettingsSidebar = ({
     if (tab === 'translation') {
       onTranslationPanelOpen();
     } else {
-      onReadingPanelOpen();
+      onReadingPanelOpen?.();
     }
   };
 

--- a/app/features/surah/[surahId]/layout.tsx
+++ b/app/features/surah/[surahId]/layout.tsx
@@ -8,8 +8,8 @@ import { AudioProvider } from '@/app/context/AudioContext';
 export default function SurahLayout({ children }: { children: React.ReactNode }) {
   return (
     <AudioProvider>
-      <div className="h-screen flex flex-col">
-        <Header />
+      <Header />
+      <div className="h-screen flex flex-col pt-16">
         <div className="flex flex-grow overflow-hidden">
           <nav aria-label="Primary navigation">
             <IconSidebar />

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -166,6 +166,7 @@ export default function SurahPage({ params }: SurahPageProps) {
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
+        onReadingPanelOpen={() => {}}
         selectedTranslationName={selectedTranslationName}
         selectedWordLanguageName={selectedWordLanguageName}
       />


### PR DESCRIPTION
## Summary
- keep the header fixed so it doesn't push content during hydration
- offset content with padding in feature layouts
- allow optional `onReadingPanelOpen` in `SettingsSidebar`
- update pages to pass a no-op function

## Testing
- `npm run lint`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_688529a3e2f4832b8f371ff35c3c12bc