### PR TITLE
Add project architecture docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Copy `.env.example` to `.env` and adjust the values if necessary. The default co
 
 An `.nvmrc` file pins Node.js to version **20**. Run `nvm use` to match this version before contributing.
 
+For a directory overview see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 This project also provides an `.editorconfig` file. Ensure your editor respects
 it so that files use UTF-8 encoding, two spaces for indentation, and always end
 with a newline.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+For an overview of the folder structure see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 ## Setup
 
 Copy `.env.example` to `.env` and adjust the values if necessary. The default configuration includes the Quran API base URL.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,26 @@
+# Architecture Overview
+
+This document explains the main folders in the repository and how pages use the React contexts provided in `app/context`. It also lists steps for adding new features.
+
+## Directory Purpose
+
+- **`app/`** – Next.js app directory with route segments, shared components and context providers. Feature pages live under `app/features/*`.
+- **`lib/`** – Utility modules and API helpers.
+- **`types/`** – TypeScript type definitions shared across the project.
+- **`scripts/`** – Stand-alone Node.js scripts such as `fetchData.ts` used for data preparation.
+- **`__tests__/`** – Test suite powered by Jest and React Testing Library.
+
+## Feature Pages and Contexts
+
+Pages inside `app/features/` define user-facing routes. Many of these routes wrap their content with providers from `app/context` such as `AudioProvider` or `SettingsProvider`. The root `app/layout.tsx` applies `ThemeProvider`, `SettingsProvider` and `SidebarProvider` so any component can access theme, settings and sidebar state via the corresponding hooks.
+
+Feature components typically reside in an `_components` subfolder. They import hooks like `useSettings`, `useAudio` or `useSidebar` to read and update context values.
+
+## Adding a New Feature
+
+1. Create a folder under `app/features/` for the route. Add `page.tsx` and optionally `layout.tsx` inside it. Use `[param]` syntax for dynamic segments.
+2. Place any feature specific components in an `_components` directory within that folder.
+3. Add new utilities to `lib/` and shared types to `types/` when appropriate.
+4. Write tests in `__tests__/` mirroring the feature name. Wrap tested components with any required providers from `app/context`.
+
+Following this structure keeps the application organized and ensures new pages work smoothly with the existing contexts.


### PR DESCRIPTION
## Summary
- document repository structure in `docs/ARCHITECTURE.md`
- link the new doc from the README and CONTRIBUTING guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688530f4b010832b9e9d53d2284542bc