### PR TITLE
Wrap Header tests with ThemeProvider

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import Header from '@/app/components/common/Header';
 import { SidebarProvider } from '@/app/context/SidebarContext';
+import { ThemeProvider } from '@/app/context/ThemeContext';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider>
+    <SidebarProvider>{children}</SidebarProvider>
+  </ThemeProvider>
+);
 
 // Mock the useTranslation hook
 jest.mock('react-i18next', () => ({
@@ -13,12 +20,28 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
 describe('Header', () => {
   it('renders the title', () => {
     render(
-      <SidebarProvider>
+      <Wrapper>
         <Header />
-      </SidebarProvider>
+      </Wrapper>
     );
     // The component uses t('title'), so we expect 'title' to be in the document.
     expect(screen.getByText('title')).toBeInTheDocument();
@@ -26,9 +49,9 @@ describe('Header', () => {
 
   it('renders the search placeholder', () => {
     render(
-      <SidebarProvider>
+      <Wrapper>
         <Header />
-      </SidebarProvider>
+      </Wrapper>
     );
     // The component uses t('search_placeholder'), so we check for that key.
     expect(screen.getByPlaceholderText('search_placeholder')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- provide a wrapper around `<Header />` using `ThemeProvider`
- stub `window.matchMedia` in Header tests

## Testing
- `npm test`
- `npm run check` *(fails: app/features/surah/[surahId]/page.tsx:125:15 - Property 'theme' does not exist on type 'IntrinsicAttributes')*

------
https://chatgpt.com/codex/tasks/task_b_688623d13744832b901566ca90016ad3