### PR TITLE
Add styling for tafsir text

### DIFF
--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -177,6 +177,10 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                   ) : (
                     <div
                       className="prose max-w-none text-[var(--foreground)]"
+                      style={{
+                        fontSize: `${settings.translationFontSize}px`,
+                        fontFamily: settings.arabicFontFace,
+                      }}
                       dangerouslySetInnerHTML={{ __html: tafseerTexts[id] || '' }}
                     />
                   )}


### PR DESCRIPTION
## Summary
- use user font settings when rendering tafsir

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688690a8cc24832b95e0ffc8a8219afe