### PR TITLE
Implement modern tafsir page

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -94,7 +94,9 @@ describe('SettingsSidebar interactions', () => {
           <SettingsSidebar
             onTranslationPanelOpen={() => setOpen(true)}
             onWordLanguagePanelOpen={() => {}}
+            onTafsirPanelOpen={() => {}}
             selectedTranslationName="English"
+            selectedTafsirName="English"
             selectedWordLanguageName="English"
           />
           <TranslationPanel

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/AyahNavigation.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/AyahNavigation.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { FaChevronDown } from '@/app/components/common/SvgIcons';
+
+interface AyahNavigationProps {
+  surahName: string;
+  verseNumber: number;
+  onPrev: () => void;
+  onNext: () => void;
+  prevDisabled?: boolean;
+  nextDisabled?: boolean;
+}
+
+export default function AyahNavigation({
+  surahName,
+  verseNumber,
+  onPrev,
+  onNext,
+  prevDisabled,
+  nextDisabled,
+}: AyahNavigationProps) {
+  return (
+    <div className="flex items-center justify-between p-4 bg-white rounded-md border shadow">
+      <button
+        onClick={onPrev}
+        disabled={prevDisabled}
+        aria-label="Previous"
+        className="p-2 text-gray-500 hover:text-emerald-600 disabled:opacity-50"
+      >
+        <FaChevronDown className="rotate-90" />
+      </button>
+      <div className="text-center">
+        <p className="font-bold text-lg text-gray-800">{surahName}</p>
+        <p className="text-sm text-gray-500">Verse {verseNumber}</p>
+      </div>
+      <button
+        onClick={onNext}
+        disabled={nextDisabled}
+        aria-label="Next"
+        className="p-2 text-gray-500 hover:text-emerald-600 disabled:opacity-50"
+      >
+        <FaChevronDown className="-rotate-90" />
+      </button>
+    </div>
+  );
+}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Spinner from '@/app/components/common/Spinner';
+import { getTafsirCached } from '@/lib/tafsirCache';
+
+interface TabInfo {
+  id: number;
+  name: string;
+}
+
+interface TafsirTabsProps {
+  verseKey: string;
+  tabs: TabInfo[];
+}
+
+export default function TafsirTabs({ verseKey, tabs }: TafsirTabsProps) {
+  const [activeId, setActiveId] = useState(tabs[0]?.id);
+  const [contents, setContents] = useState<Record<number, string>>({});
+  const [loading, setLoading] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    if (!activeId) return;
+    if (contents[activeId]) return;
+    setLoading((l) => ({ ...l, [activeId]: true }));
+    getTafsirCached(verseKey, activeId)
+      .then((text) => setContents((c) => ({ ...c, [activeId]: text })))
+      .catch(() => setContents((c) => ({ ...c, [activeId]: 'Error loading tafsir.' })))
+      .finally(() => setLoading((l) => ({ ...l, [activeId]: false })));
+  }, [activeId, verseKey, contents]);
+
+  if (!tabs.length) return null;
+
+  return (
+    <div className="bg-white rounded-md border shadow">
+      <div className="p-4 border-b">
+        <h2 className="font-bold text-lg text-gray-800">Tafsir</h2>
+        <p className="text-sm text-gray-500">Commentary and explanation of the verse.</p>
+      </div>
+      <div className="flex border-b">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setActiveId(t.id)}
+            className={`flex-1 p-3 text-sm font-medium focus:outline-none ${activeId === t.id ? 'border-b-2 border-emerald-600 text-emerald-600' : 'text-gray-500'}`}
+          >
+            {t.name}
+          </button>
+        ))}
+      </div>
+      <div className="p-4">
+        {loading[activeId] ? (
+          <div className="flex justify-center py-4">
+            <Spinner className="h-5 w-5 text-emerald-600" />
+          </div>
+        ) : (
+          <div
+            className="prose max-w-none"
+            dangerouslySetInnerHTML={{ __html: contents[activeId] || '' }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -1,0 +1,126 @@
+'use client';
+import {
+  FaPlay,
+  FaPause,
+  FaBookmark,
+  FaRegBookmark,
+  FaShare,
+} from '@/app/components/common/SvgIcons';
+import { Verse as VerseType, Translation, Word } from '@/types';
+import { useAudio } from '@/app/context/AudioContext';
+import { useSettings } from '@/app/context/SettingsContext';
+import Spinner from '@/app/components/common/Spinner';
+import { applyTajweed } from '@/lib/tajweed';
+
+interface VerseCardProps {
+  verse: VerseType;
+}
+
+export default function VerseCard({ verse }: VerseCardProps) {
+  const { playingId, setPlayingId, loadingId } = useAudio();
+  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
+
+  const showByWords = settings.showByWords ?? false;
+  const wordLang = settings.wordLang ?? 'en';
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
+
+  const handleShare = () => {
+    const url = typeof window !== 'undefined' ? window.location.href : '';
+    if (navigator.share) {
+      navigator.share({ title: 'Quran', url }).catch(() => {});
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(url).catch(() => {});
+    }
+  };
+
+  return (
+    <div className="relative flex bg-white rounded-md border shadow p-6">
+      <span className="absolute -top-3 left-4 bg-slate-100 text-xs px-3 py-0.5 rounded-full">
+        {verse.verse_key}
+      </span>
+      <div className="w-14 flex flex-col items-center space-y-2 mr-4 pt-2 text-gray-500">
+        <button
+          aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
+          onClick={() => setPlayingId((id) => (id === verse.id ? null : verse.id))}
+          className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-emerald-600' : 'hover:text-emerald-600'}`}
+        >
+          {isLoadingAudio ? (
+            <Spinner className="h-4 w-4 text-emerald-600" />
+          ) : isPlaying ? (
+            <FaPause size={18} />
+          ) : (
+            <FaPlay size={18} />
+          )}
+        </button>
+        <button
+          aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
+          onClick={() => toggleBookmark(String(verse.id))}
+          className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isBookmarked ? 'text-emerald-600' : 'hover:text-emerald-600'}`}
+        >
+          {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
+        </button>
+        <button
+          aria-label="Share"
+          onClick={handleShare}
+          className="p-1.5 rounded-full hover:bg-gray-100 hover:text-emerald-600 transition"
+        >
+          <FaShare size={18} />
+        </button>
+      </div>
+      <div className="flex-grow space-y-6">
+        <p
+          className="text-right leading-loose"
+          style={{
+            fontFamily: settings.arabicFontFace,
+            fontSize: `${settings.arabicFontSize}px`,
+            lineHeight: 2.2,
+          }}
+        >
+          {verse.words && verse.words.length > 0 ? (
+            <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
+              {verse.words.map((word: Word) => (
+                <span key={word.id} className="text-center">
+                  <span className="relative group cursor-pointer">
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
+                      }}
+                    />
+                    {!showByWords && (
+                      <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
+                        {word[wordLang] as string}
+                      </span>
+                    )}
+                  </span>
+                  {showByWords && (
+                    <span
+                      className="block mt-1 text-gray-500"
+                      style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
+                    >
+                      {word[wordLang] as string}
+                    </span>
+                  )}
+                </span>
+              ))}
+            </span>
+          ) : settings.tajweed ? (
+            <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+          ) : (
+            verse.text_uthmani
+          )}
+        </p>
+        {verse.translations?.map((t: Translation) => (
+          <div key={t.resource_id}>
+            <p
+              className="text-left leading-relaxed"
+              style={{ fontSize: `${settings.translationFontSize}px` }}
+              dangerouslySetInnerHTML={{ __html: t.text }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -1,49 +1,24 @@
 'use client';
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useTranslation } from 'react-i18next';
-import { Verse as VerseComponent } from '@/app/features/surah/[surahId]/_components/Verse';
-import { CollapsibleSection } from '@/app/features/surah/[surahId]/_components/CollapsibleSection';
-import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
-import { TranslationPanel } from '@/app/features/surah/[surahId]/_components/TranslationPanel';
-import { TafsirPanel } from '@/app/features/surah/[surahId]/_components/TafsirPanel';
-import { WordLanguagePanel } from '@/app/features/surah/[surahId]/_components/WordLanguagePanel';
-import {
-  getVersesByChapter,
-  getTranslations,
-  getWordTranslations,
-  getTafsirResources,
-  getTafsirByVerse,
-} from '@/lib/api';
-import { Verse as VerseType, TranslationResource, TafsirResource } from '@/types';
+import AyahNavigation from './_components/AyahNavigation';
+import VerseCard from './_components/VerseCard';
+import TafsirTabs from './_components/TafsirTabs';
+import { getVersesByChapter, getTafsirResources } from '@/lib/api';
+import { Verse as VerseType, TafsirResource } from '@/types';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useSidebar } from '@/app/context/SidebarContext';
-import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
-import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import useSWR from 'swr';
 import surahs from '@/data/surahs.json';
-
-const DEFAULT_WORD_TRANSLATION_ID = 85;
 
 export default function TafsirVersePage() {
   const params = useParams<{ surahId: string; ayahId: string }>();
   const router = useRouter();
-  const { t } = useTranslation();
-  const { settings, setSettings } = useSettings();
+  const { settings } = useSettings();
   const { setSurahListOpen } = useSidebar();
   const surahId = params.surahId;
   const ayahId = params.ayahId;
-  const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
-  const [translationSearchTerm, setTranslationSearchTerm] = useState('');
-  const [isTafsirPanelOpen, setIsTafsirPanelOpen] = useState(false);
-  const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
-  const [wordTranslationSearchTerm, setWordTranslationSearchTerm] = useState('');
-
-  const { data: translationOptionsData } = useSWR('translations', getTranslations);
-  const translationOptions: TranslationResource[] = useMemo(
-    () => translationOptionsData || [],
-    [translationOptionsData]
-  );
+  // state for translation ID selection if needed in future
 
   const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
   const tafsirOptions: TafsirResource[] = useMemo(
@@ -51,70 +26,8 @@ export default function TafsirVersePage() {
     [tafsirOptionsData]
   );
 
-  const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
-  const wordLanguageMap = useMemo(() => {
-    const map: Record<string, number> = {};
-    (wordTranslationOptionsData || []).forEach((o) => {
-      const name = o.language_name.toLowerCase();
-      if (!map[name]) {
-        map[name] = o.id;
-      }
-    });
-    return map;
-  }, [wordTranslationOptionsData]);
-  const wordLanguageOptions = useMemo(
-    () =>
-      Object.keys(wordLanguageMap)
-        .filter((name) => WORD_LANGUAGE_LABELS[name])
-        .map((name) => ({ name: WORD_LANGUAGE_LABELS[name], id: wordLanguageMap[name] })),
-    [wordLanguageMap]
-  );
-
-  const selectedTranslationName = useMemo(
-    () =>
-      translationOptions.find((o) => o.id === settings.translationId)?.name ||
-      t('select_translation'),
-    [settings.translationId, translationOptions, t]
-  );
-  const selectedTafsirName = useMemo(
-    () => tafsirOptions.find((o) => o.id === settings.tafsirId)?.name || t('select_tafsir'),
-    [settings.tafsirId, tafsirOptions, t]
-  );
-  const selectedWordLanguageName = useMemo(
-    () =>
-      wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)
-        ?.name || t('select_word_translation'),
-    [settings.wordLang, wordLanguageOptions, t]
-  );
-
-  const groupedTranslations = useMemo(
-    () =>
-      translationOptions
-        .filter((o) => o.name.toLowerCase().includes(translationSearchTerm.toLowerCase()))
-        .reduce<Record<string, TranslationResource[]>>((acc, t) => {
-          (acc[t.language_name] ||= []).push(t);
-          return acc;
-        }, {}),
-    [translationOptions, translationSearchTerm]
-  );
-  const filteredWordLanguages = useMemo(
-    () =>
-      wordLanguageOptions.filter((o) =>
-        o.name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
-      ),
-    [wordLanguageOptions, wordTranslationSearchTerm]
-  );
-
-  const [translationId, setTranslationId] = useState(settings.translationId);
-
-  useEffect(() => {
-    setTranslationId(settings.translationId);
-  }, [settings.translationId]);
-
-  const tafsirResource = useMemo(
-    () => tafsirOptions.find((t) => t.id === settings.tafsirId),
-    [tafsirOptions, settings.tafsirId]
-  );
+  // translation id from settings
+  const translationId = settings.translationId;
 
   const { data: verseData } = useSWR(
     surahId && ayahId ? ['verse', surahId, ayahId, translationId, settings.wordLang] : null,
@@ -122,11 +35,6 @@ export default function TafsirVersePage() {
       getVersesByChapter(s, trId, Number(a), 1, wordLang).then((d) => d.verses[0])
   );
   const verse: VerseType | undefined = verseData;
-
-  const { data: tafsirText } = useSWR(
-    verse && tafsirResource ? ['tafsir', verse.verse_key, tafsirResource.id] : null,
-    ([, key, id]) => getTafsirByVerse(key as string, id as number)
-  );
 
   const totalSurahs = (surahs as { number: number; verses: number }[]).length;
   const currentSurahIndex = Number(surahId) - 1;
@@ -152,91 +60,31 @@ export default function TafsirVersePage() {
     router.push(`/features/tafsir/${target.surahId}/${target.ayahId}`);
   };
 
+  const tabInfos = useMemo(() => {
+    const selected = tafsirOptions.filter((t) => [settings.tafsirId].includes(t.id)).slice(0, 3);
+    return selected.map((t) => ({ id: t.id, name: t.name }));
+  }, [tafsirOptions, settings.tafsirId]);
+
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] overflow-hidden">
-      <div className="flex-grow overflow-y-auto p-6 lg:p-10">
-        <div className="w-full space-y-6">
-          <div className="flex justify-between">
-            <button
-              disabled={!prev}
-              onClick={() => navigate(prev)}
-              className="px-3 py-1 rounded bg-teal-600 text-white disabled:opacity-50"
-            >
-              {t('previous_ayah')}
-            </button>
-            <button
-              disabled={!next}
-              onClick={() => navigate(next)}
-              className="px-3 py-1 rounded bg-teal-600 text-white disabled:opacity-50"
-            >
-              {t('next_ayah')}
-            </button>
-          </div>
+    <div className="flex flex-grow bg-slate-50 overflow-auto">
+      <div className="flex-grow p-6 lg:p-10">
+        <div className="max-w-4xl mx-auto space-y-6">
+          <AyahNavigation
+            surahName={surahs[currentSurahIndex].name}
+            verseNumber={currentAyahNum}
+            onPrev={() => navigate(prev)}
+            onNext={() => navigate(next)}
+            prevDisabled={!prev}
+            nextDisabled={!next}
+          />
 
-          <div className="space-y-4">
-            <div className="flex flex-wrap gap-4">
-              <select
-                className="border p-2 rounded"
-                value={translationId}
-                onChange={(e) => setTranslationId(Number(e.target.value))}
-              >
-                {translationOptions.map((t) => (
-                  <option key={t.id} value={t.id}>
-                    {t.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+          {verse && <VerseCard verse={verse} />}
 
-            {verse && <VerseComponent verse={verse} />}
-
-            {tafsirResource && (
-              <CollapsibleSection
-                key={verse?.verse_key}
-                title={tafsirResource.name}
-                icon={<></>}
-                isLast
-              >
-                <div
-                  className="prose max-w-none"
-                  dangerouslySetInnerHTML={{ __html: tafsirText || '' }}
-                />
-              </CollapsibleSection>
-            )}
-          </div>
+          {verse && tabInfos.length > 0 && (
+            <TafsirTabs verseKey={verse.verse_key} tabs={tabInfos} />
+          )}
         </div>
       </div>
-      <SettingsSidebar
-        onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
-        onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
-        onTafsirPanelOpen={() => setIsTafsirPanelOpen(true)}
-        selectedTranslationName={selectedTranslationName}
-        selectedTafsirName={selectedTafsirName}
-        selectedWordLanguageName={selectedWordLanguageName}
-      />
-      <TranslationPanel
-        isOpen={isTranslationPanelOpen}
-        onClose={() => setIsTranslationPanelOpen(false)}
-        groupedTranslations={groupedTranslations}
-        searchTerm={translationSearchTerm}
-        onSearchTermChange={setTranslationSearchTerm}
-      />
-      <WordLanguagePanel
-        isOpen={isWordPanelOpen}
-        onClose={() => setIsWordPanelOpen(false)}
-        languages={filteredWordLanguages}
-        searchTerm={wordTranslationSearchTerm}
-        onSearchTermChange={setWordTranslationSearchTerm}
-        onReset={() => {
-          setWordTranslationSearchTerm('');
-          setSettings({
-            ...settings,
-            wordLang: 'en',
-            wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
-          });
-        }}
-      />
-      <TafsirPanel isOpen={isTafsirPanelOpen} onClose={() => setIsTafsirPanelOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add AyahNavigation component for previous/next controls
- add VerseCard component to display ayah with action icons
- implement TafsirTabs with dynamic tabs and cached loading
- redesign tafsir verse page to use new components
- fix SettingsSidebar test to include new props

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6887468835e4832b931d57fa06a441c7