### PR TITLE
Support multiple tafsir selections

### DIFF
--- a/__tests__/SettingsContext.test.tsx
+++ b/__tests__/SettingsContext.test.tsx
@@ -22,6 +22,7 @@ const SettingsTest = () => {
       >
         Update
       </button>
+      <button onClick={() => setSettings({ ...settings, tafsirIds: [1, 2, 3] })}>Tafsirs</button>
     </div>
   );
 };
@@ -74,7 +75,7 @@ describe('SettingsContext settings state', () => {
 
   const defaultSettings = {
     translationId: 20,
-    tafsirId: 169,
+    tafsirIds: [169],
     arabicFontSize: 28,
     translationFontSize: 16,
     arabicFontFace: '"KFGQPC-Uthman-Taha", serif',
@@ -114,6 +115,20 @@ describe('SettingsContext settings state', () => {
       expect(screen.getByTestId('settings').textContent).toBe(
         JSON.stringify({ ...defaultSettings, arabicFontSize: 30 })
       );
+    });
+  });
+
+  it('saves multiple tafsir selections', async () => {
+    render(
+      <SettingsProvider>
+        <SettingsTest />
+      </SettingsProvider>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Tafsirs' }));
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('quranAppSettings') || '{}').tafsirIds).toEqual([
+        1, 2, 3,
+      ]);
     });
   });
 });

--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -57,7 +57,7 @@ describe('SettingsSidebar interactions', () => {
           onWordLanguagePanelOpen={() => {}}
           onTafsirPanelOpen={() => {}}
           selectedTranslationName="English"
-          selectedTafsirName="English"
+          selectedTafsirName="English, Urdu"
           selectedWordLanguageName="English"
         />
       </Wrapper>
@@ -96,7 +96,7 @@ describe('SettingsSidebar interactions', () => {
             onWordLanguagePanelOpen={() => {}}
             onTafsirPanelOpen={() => {}}
             selectedTranslationName="English"
-            selectedTafsirName="English"
+            selectedTafsirName="English, Urdu"
             selectedWordLanguageName="English"
           />
           <TranslationPanel
@@ -132,7 +132,7 @@ describe('SettingsSidebar interactions', () => {
             onWordLanguagePanelOpen={() => setOpen(true)}
             onTafsirPanelOpen={() => {}}
             selectedTranslationName="English"
-            selectedTafsirName="English"
+            selectedTafsirName="English, Urdu"
             selectedWordLanguageName="Bangla"
           />
           <WordLanguagePanel

--- a/app/context/SettingsContext.tsx
+++ b/app/context/SettingsContext.tsx
@@ -18,7 +18,7 @@ export const ARABIC_FONTS = [
 // Define default settings
 const defaultSettings: Settings = {
   translationId: 20,
-  tafsirId: 169,
+  tafsirIds: [169],
   arabicFontSize: 28,
   translationFontSize: 16,
   arabicFontFace: ARABIC_FONTS[0].value,
@@ -38,7 +38,7 @@ interface SettingsContextType {
   setTajweed: (val: boolean) => void;
   setWordLang: (lang: string) => void;
   setWordTranslationId: (id: number) => void;
-  setTafsirId: (id: number) => void;
+  setTafsirIds: (ids: number[]) => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -54,6 +54,10 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
       if (savedSettings) {
         try {
           const parsed = JSON.parse(savedSettings);
+          if (parsed.tafsirId && !parsed.tafsirIds) {
+            parsed.tafsirIds = [parsed.tafsirId];
+            delete parsed.tafsirId;
+          }
           setSettings({ ...defaultSettings, ...parsed });
         } catch (error) {
           console.error('Error parsing settings from localStorage:', error);
@@ -99,7 +103,7 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
   const setWordTranslationId = (id: number) =>
     setSettings((prev) => ({ ...prev, wordTranslationId: id }));
 
-  const setTafsirId = (id: number) => setSettings((prev) => ({ ...prev, tafsirId: id }));
+  const setTafsirIds = (ids: number[]) => setSettings((prev) => ({ ...prev, tafsirIds: ids }));
 
   return (
     <SettingsContext.Provider
@@ -113,7 +117,7 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
         setTajweed,
         setWordLang,
         setWordTranslationId,
-        setTafsirId,
+        setTafsirIds,
       }}
     >
       {children}

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -102,10 +102,13 @@ export default function JuzPage({ params }: JuzPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedTafsirName = useMemo(
-    () => tafsirOptions.find((o) => o.id === settings.tafsirId)?.name || t('select_tafsir'),
-    [settings.tafsirId, tafsirOptions, t]
-  );
+  const selectedTafsirName = useMemo(() => {
+    const names = settings.tafsirIds
+      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
+      .filter(Boolean)
+      .slice(0, 3);
+    return names.length ? names.join(', ') : t('select_tafsir');
+  }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
       wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -98,10 +98,13 @@ export default function QuranPage({ params }: QuranPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedTafsirName = useMemo(
-    () => tafsirOptions.find((o) => o.id === settings.tafsirId)?.name || t('select_tafsir'),
-    [settings.tafsirId, tafsirOptions, t]
-  );
+  const selectedTafsirName = useMemo(() => {
+    const names = settings.tafsirIds
+      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
+      .filter(Boolean)
+      .slice(0, 3);
+    return names.length ? names.join(', ') : t('select_tafsir');
+  }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
       wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)

--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -70,13 +70,17 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
                   className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
                 >
                   <input
-                    type="radio"
-                    name="tafsir"
-                    className="form-radio h-4 w-4 text-teal-600"
-                    checked={settings.tafsirId === opt.id}
+                    type="checkbox"
+                    className="form-checkbox h-4 w-4 text-teal-600"
+                    checked={settings.tafsirIds.includes(opt.id)}
                     onChange={() => {
-                      setSettings({ ...settings, tafsirId: opt.id });
-                      onClose();
+                      const exists = settings.tafsirIds.includes(opt.id);
+                      const ids = exists
+                        ? settings.tafsirIds.filter((id) => id !== opt.id)
+                        : settings.tafsirIds.length < 3
+                          ? [...settings.tafsirIds, opt.id]
+                          : settings.tafsirIds;
+                      setSettings({ ...settings, tafsirIds: ids });
                     }}
                   />
                   <span className="text-sm text-[var(--foreground)]">{opt.name}</span>

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -100,10 +100,13 @@ export default function SurahPage({ params }: SurahPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedTafsirName = useMemo(
-    () => tafsirOptions.find((o) => o.id === settings.tafsirId)?.name || t('select_tafsir'),
-    [settings.tafsirId, tafsirOptions, t]
-  );
+  const selectedTafsirName = useMemo(() => {
+    const names = settings.tafsirIds
+      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
+      .filter(Boolean)
+      .slice(0, 3);
+    return names.length ? names.join(', ') : t('select_tafsir');
+  }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
       wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -1,19 +1,25 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import Spinner from '@/app/components/common/Spinner';
 import { getTafsirCached } from '@/lib/tafsirCache';
-
-interface TabInfo {
-  id: number;
-  name: string;
-}
+import { getTafsirResources } from '@/lib/api';
+import useSWR from 'swr';
 
 interface TafsirTabsProps {
   verseKey: string;
-  tabs: TabInfo[];
+  tafsirIds: number[];
 }
 
-export default function TafsirTabs({ verseKey, tabs }: TafsirTabsProps) {
+export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
+  const { data } = useSWR('tafsirs', getTafsirResources);
+  const tabs = useMemo(() => {
+    const resources = data || [];
+    return tafsirIds
+      .map((id) => resources.find((r) => r.id === id))
+      .filter(Boolean)
+      .slice(0, 3) as { id: number; name: string }[];
+  }, [tafsirIds, data]);
+
   const [activeId, setActiveId] = useState(tabs[0]?.id);
   const [contents, setContents] = useState<Record<number, string>>({});
   const [loading, setLoading] = useState<Record<number, boolean>>({});

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -1,11 +1,13 @@
 'use client';
-import React, { useMemo } from 'react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams, useRouter } from 'next/navigation';
 import AyahNavigation from './_components/AyahNavigation';
 import VerseCard from './_components/VerseCard';
 import TafsirTabs from './_components/TafsirTabs';
-import { getVersesByChapter, getTafsirResources } from '@/lib/api';
-import { Verse as VerseType, TafsirResource } from '@/types';
+import { TafsirPanel } from '@/app/features/surah/[surahId]/_components/TafsirPanel';
+import { getVersesByChapter } from '@/lib/api';
+import { Verse as VerseType } from '@/types';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useSidebar } from '@/app/context/SidebarContext';
 import useSWR from 'swr';
@@ -16,15 +18,11 @@ export default function TafsirVersePage() {
   const router = useRouter();
   const { settings } = useSettings();
   const { setSurahListOpen } = useSidebar();
+  const { t } = useTranslation();
   const surahId = params.surahId;
   const ayahId = params.ayahId;
   // state for translation ID selection if needed in future
-
-  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
-  const tafsirOptions: TafsirResource[] = useMemo(
-    () => tafsirOptionsData || [],
-    [tafsirOptionsData]
-  );
+  const [isTafsirPanelOpen, setIsTafsirPanelOpen] = useState(false);
 
   // translation id from settings
   const translationId = settings.translationId;
@@ -60,11 +58,6 @@ export default function TafsirVersePage() {
     router.push(`/features/tafsir/${target.surahId}/${target.ayahId}`);
   };
 
-  const tabInfos = useMemo(() => {
-    const selected = tafsirOptions.filter((t) => [settings.tafsirId].includes(t.id)).slice(0, 3);
-    return selected.map((t) => ({ id: t.id, name: t.name }));
-  }, [tafsirOptions, settings.tafsirId]);
-
   return (
     <div className="flex flex-grow bg-slate-50 overflow-auto">
       <div className="flex-grow p-6 lg:p-10">
@@ -79,12 +72,19 @@ export default function TafsirVersePage() {
           />
 
           {verse && <VerseCard verse={verse} />}
+          <button
+            onClick={() => setIsTafsirPanelOpen(true)}
+            className="text-sm text-emerald-600 underline"
+          >
+            {t('select_tafsir')}
+          </button>
 
-          {verse && tabInfos.length > 0 && (
-            <TafsirTabs verseKey={verse.verse_key} tabs={tabInfos} />
+          {verse && settings.tafsirIds.length > 0 && (
+            <TafsirTabs verseKey={verse.verse_key} tafsirIds={settings.tafsirIds} />
           )}
         </div>
       </div>
+      <TafsirPanel isOpen={isTafsirPanelOpen} onClose={() => setIsTafsirPanelOpen(false)} />
     </div>
   );
 }

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,6 +1,6 @@
 export interface Settings {
   translationId: number;
-  tafsirId: number;
+  tafsirIds: number[];
   arabicFontSize: number;
   translationFontSize: number;
   arabicFontFace: string;


### PR DESCRIPTION
## Summary
- allow saving multiple tafsir selections in settings
- show comma-separated tafsir names in sidebar
- switch tafsir panel to checkboxes
- render multiple tafsir tabs
- add button on tafsir page to change selections
- adjust tests for new settings shape

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68874ed82134832b99960ec40dc4426c