### PR TITLE
Add tests for tafsir verse page

### DIFF
--- a/__tests__/TafsirTabs.test.tsx
+++ b/__tests__/TafsirTabs.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TafsirTabs from '@/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs';
+import { getTafsirCached } from '@/lib/tafsirCache';
+import useSWR from 'swr';
+
+jest.mock('swr');
+jest.mock('@/lib/tafsirCache');
+
+const mockUseSWR = useSWR as jest.Mock;
+const mockGetTafsirCached = getTafsirCached as jest.Mock;
+
+const resources = [
+  { id: 1, name: 'Tafsir One' },
+  { id: 2, name: 'Tafsir Two' },
+];
+
+beforeEach(() => {
+  mockUseSWR.mockReturnValue({ data: resources });
+  mockGetTafsirCached.mockImplementation((key: string, id: number) =>
+    Promise.resolve(`Text ${id}`)
+  );
+});
+
+it('shows tabs and switches content on click', async () => {
+  render(<TafsirTabs verseKey="1:1" tafsirIds={[1, 2]} />);
+  expect(screen.getByRole('button', { name: 'Tafsir One' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Tafsir Two' })).toBeInTheDocument();
+
+  expect(await screen.findByText('Text 1')).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Tafsir Two' }));
+  expect(await screen.findByText('Text 2')).toBeInTheDocument();
+  expect(mockGetTafsirCached).toHaveBeenCalledWith('1:1', 2);
+});

--- a/__tests__/TafsirVerseCard.test.tsx
+++ b/__tests__/TafsirVerseCard.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VerseCard from '@/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
+import { Verse } from '@/types';
+
+const verse: Verse = {
+  id: 1,
+  verse_key: '1:1',
+  text_uthmani: 'بِسْمِ اللَّهِ',
+  words: [
+    { id: 1, uthmani: 'بِسْمِ', en: 'In' },
+    { id: 2, uthmani: 'اللَّهِ', en: 'Allah' },
+  ],
+  translations: [{ resource_id: 20, text: 'In the name of Allah' }],
+};
+
+const renderCard = () =>
+  render(
+    <AudioProvider>
+      <SettingsProvider>
+        <VerseCard verse={verse} />
+      </SettingsProvider>
+    </AudioProvider>
+  );
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+it('renders verse key and translation', () => {
+  renderCard();
+  expect(screen.getByText('1:1')).toBeInTheDocument();
+  expect(screen.getByText('In the name of Allah')).toBeInTheDocument();
+});
+
+it('toggles play/pause on click', async () => {
+  renderCard();
+  const playButton = screen.getByRole('button', { name: 'Play audio' });
+  await userEvent.click(playButton);
+  expect(playButton).toHaveAttribute('aria-label', 'Pause audio');
+  await userEvent.click(playButton);
+  expect(playButton).toHaveAttribute('aria-label', 'Play audio');
+});
+
+it('bookmarks verse when icon clicked', async () => {
+  renderCard();
+  const bookmarkButton = screen.getByRole('button', { name: 'Add bookmark' });
+  await userEvent.click(bookmarkButton);
+  expect(bookmarkButton).toHaveAttribute('aria-label', 'Remove bookmark');
+});

--- a/__tests__/TafsirVersePage.test.tsx
+++ b/__tests__/TafsirVersePage.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TafsirVersePage from '@/app/features/tafsir/[surahId]/[ayahId]/page';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
+import { SidebarProvider } from '@/app/context/SidebarContext';
+import { ThemeProvider } from '@/app/context/ThemeContext';
+import { Verse } from '@/types';
+import useSWR from 'swr';
+import { getTafsirCached } from '@/lib/tafsirCache';
+
+jest.mock('swr');
+jest.mock('@/lib/tafsirCache');
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  useParams: jest.fn(),
+}));
+
+const mockUseSWR = useSWR as jest.Mock;
+const mockGetTafsirCached = getTafsirCached as jest.Mock;
+const useParams = require('next/navigation').useParams as jest.Mock;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+const verse: Verse = {
+  id: 1,
+  verse_key: '1:1',
+  text_uthmani: 'verse text',
+  words: [],
+  translations: [{ resource_id: 20, text: 'translation' }],
+};
+
+const resources = [
+  { id: 1, name: 'Tafsir One', language_name: 'english' },
+  { id: 2, name: 'Tafsir Two', language_name: 'english' },
+];
+
+beforeEach(() => {
+  localStorage.setItem(
+    'quranAppSettings',
+    JSON.stringify({ tafsirIds: [1, 2], translationId: 20 })
+  );
+  mockGetTafsirCached.mockImplementation((key: string, id: number) =>
+    Promise.resolve(`Text ${id}`)
+  );
+  mockUseSWR.mockImplementation((key: any) => {
+    if (key === 'tafsirs') return { data: resources };
+    if (Array.isArray(key) && key[0] === 'verse') return { data: verse };
+    return { data: undefined };
+  });
+});
+
+const renderPage = () =>
+  render(
+    <AudioProvider>
+      <SettingsProvider>
+        <ThemeProvider>
+          <SidebarProvider>
+            <TafsirVersePage />
+          </SidebarProvider>
+        </ThemeProvider>
+      </SettingsProvider>
+    </AudioProvider>
+  );
+
+test('navigates to next verse', async () => {
+  useParams.mockReturnValue({ surahId: '1', ayahId: '1' });
+  renderPage();
+  await userEvent.click(screen.getByLabelText('Next'));
+  expect(push).toHaveBeenCalledWith('/features/tafsir/1/2');
+});
+
+test('navigates to previous surah when prev pressed', async () => {
+  useParams.mockReturnValue({ surahId: '2', ayahId: '1' });
+  renderPage();
+  await userEvent.click(screen.getByLabelText('Previous'));
+  expect(push).toHaveBeenCalledWith('/features/tafsir/1/7');
+});
+
+test('switches tafsir tabs', async () => {
+  useParams.mockReturnValue({ surahId: '1', ayahId: '1' });
+  renderPage();
+  await screen.findByRole('button', { name: 'Tafsir Two' });
+  await userEvent.click(screen.getByRole('button', { name: 'Tafsir Two' }));
+  expect(await screen.findByText('Text 2')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest tests for tafsir verse components
- verify verse card actions
- test tafsir tab switching
- check navigation in tafsir verse page

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688767fe7674832bb0ce77b184b8850c