### PR TITLE
Implement tafsir cache eviction

### DIFF
--- a/__tests__/tafsirCache.test.ts
+++ b/__tests__/tafsirCache.test.ts
@@ -1,0 +1,54 @@
+import { getTafsirCached, clearTafsirCache, CACHE_TTL, MAX_CACHE_SIZE } from '@/lib/tafsirCache';
+import { getTafsirByVerse } from '@/lib/api';
+
+jest.mock('@/lib/api', () => ({
+  getTafsirByVerse: jest.fn(),
+}));
+
+describe('getTafsirCached', () => {
+  beforeEach(() => {
+    clearTafsirCache();
+    jest.resetAllMocks();
+  });
+
+  it('returns cached promise within TTL', async () => {
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('text1');
+    jest.spyOn(Date, 'now').mockReturnValue(0);
+    const p1 = getTafsirCached('1:1', 1);
+    const p2 = getTafsirCached('1:1', 1);
+    expect(p2).toBe(p1);
+    await p1;
+    expect(getTafsirByVerse).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts entry after TTL expires', async () => {
+    const spy = jest.spyOn(Date, 'now');
+    spy.mockReturnValue(0);
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('text1');
+    await getTafsirCached('1:1', 1);
+
+    spy.mockReturnValue(CACHE_TTL + 1);
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('text2');
+    await getTafsirCached('1:1', 1);
+
+    expect(getTafsirByVerse).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  it('removes oldest when max size exceeded', async () => {
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(0);
+    for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+      (getTafsirByVerse as jest.Mock).mockResolvedValue(String(i));
+      await getTafsirCached(`1:${i}`, 1);
+    }
+
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('new');
+    await getTafsirCached('1:new', 1);
+
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('again');
+    await getTafsirCached('1:0', 1);
+
+    expect(getTafsirByVerse).toHaveBeenCalledTimes(MAX_CACHE_SIZE + 2);
+    spy.mockRestore();
+  });
+});

--- a/lib/tafsirCache.ts
+++ b/lib/tafsirCache.ts
@@ -1,11 +1,50 @@
 import { getTafsirByVerse } from './api';
 
-const cache: Record<string, Promise<string>> = {};
+export const CACHE_TTL = 60 * 60 * 1000; // 1 hour in ms
+export const MAX_CACHE_SIZE = 50;
 
+interface CacheEntry {
+  value: Promise<string>;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Fetch tafsir content with an in-memory cache. Entries expire after an hour
+ * and the cache is capped at a fixed size. When the limit is reached, the
+ * oldest entries are removed before inserting new ones.
+ */
 export function getTafsirCached(verseKey: string, tafsirId = 169): Promise<string> {
   const key = `${tafsirId}-${verseKey}`;
-  if (!cache[key]) {
-    cache[key] = getTafsirByVerse(verseKey, tafsirId);
+  const now = Date.now();
+
+  const cached = cache.get(key);
+  if (cached && now - cached.timestamp < CACHE_TTL) {
+    return cached.value;
   }
-  return cache[key];
+
+  // Clean expired entries
+  for (const [k, entry] of cache) {
+    if (now - entry.timestamp >= CACHE_TTL) {
+      cache.delete(k);
+    }
+  }
+
+  // Evict oldest if size limit exceeded
+  if (cache.size >= MAX_CACHE_SIZE) {
+    const oldest = [...cache.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp);
+    const removeCount = cache.size - MAX_CACHE_SIZE + 1;
+    for (let i = 0; i < removeCount; i++) {
+      cache.delete(oldest[i][0]);
+    }
+  }
+
+  const value = getTafsirByVerse(verseKey, tafsirId);
+  cache.set(key, { value, timestamp: now });
+  return value;
+}
+
+export function clearTafsirCache() {
+  cache.clear();
 }


### PR DESCRIPTION
## Summary
- add an in-memory cache with TTL and size limit
- expose helper to clear the tafsir cache
- test cache expiration and eviction behaviour

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_688767fe7508832b8686b5be3a66cd16