### PR TITLE
Refine word translations type

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -12,6 +12,7 @@ import { Verse as VerseType, TranslationResource, Juz } from '@/types';
 import { getTranslations, getWordTranslations, getVersesByJuz, getJuz } from '@/lib/api';
 import { getTafsirResources } from '@/lib/api';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
+import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
@@ -111,8 +112,11 @@ export default function JuzPage({ params }: JuzPageProps) {
   }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
-      wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)
-        ?.name || t('select_word_translation'),
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
     [settings.wordLang, wordLanguageOptions, t]
   );
   const groupedTranslations = useMemo(

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -15,6 +15,7 @@ import {
   getTafsirResources,
 } from '@/lib/api';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
+import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
@@ -107,8 +108,11 @@ export default function QuranPage({ params }: QuranPageProps) {
   }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
-      wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)
-        ?.name || t('select_word_translation'),
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
     [settings.wordLang, wordLanguageOptions, t]
   );
   const groupedTranslations = useMemo(

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/app/components/common/SvgIcons';
 import { useRouter } from 'next/navigation';
 import { Verse as VerseType, Translation, Word } from '@/types';
+import type { LanguageCode } from '@/lib/languageCodes';
 import { useAudio } from '@/app/context/AudioContext';
 import Spinner from '@/app/components/common/Spinner';
 import { useSettings } from '@/app/context/SettingsContext';
@@ -105,7 +106,7 @@ export const Verse = ({ verse }: VerseProps) => {
                       {/* Tooltip translation (when not showByWords) */}
                       {!showByWords && (
                         <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
-                          {word[wordLang] as string}
+                          {word[wordLang as LanguageCode] as string}
                         </span>
                       )}
                     </span>
@@ -115,7 +116,7 @@ export const Verse = ({ verse }: VerseProps) => {
                         className="block mt-1 text-gray-500"
                         style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                       >
-                        {word[wordLang] as string}
+                        {word[wordLang as LanguageCode] as string}
                       </span>
                     )}
                   </span>

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -3,6 +3,7 @@ import { FaArrowLeft, FaSearch } from '@/app/components/common/SvgIcons';
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '@/app/context/SettingsContext';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
+import type { LanguageCode } from '@/lib/languageCodes';
 
 interface LanguageOption {
   name: string;
@@ -72,11 +73,16 @@ export const WordLanguagePanel = ({
               type="radio"
               name="wordLanguage"
               className="form-radio h-4 w-4 text-teal-600"
-              checked={settings.wordLang === LANGUAGE_CODES[lang.name.toLowerCase()]}
+              checked={
+                settings.wordLang ===
+                (LANGUAGE_CODES as Record<string, LanguageCode>)[lang.name.toLowerCase()]
+              }
               onChange={() => {
                 setSettings({
                   ...settings,
-                  wordLang: LANGUAGE_CODES[lang.name.toLowerCase()] ?? settings.wordLang,
+                  wordLang:
+                    (LANGUAGE_CODES as Record<string, LanguageCode>)[lang.name.toLowerCase()] ??
+                    settings.wordLang,
                   wordTranslationId: lang.id,
                 });
                 onClose();

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -11,6 +11,7 @@ import { Verse as VerseType, TranslationResource } from '@/types';
 import { getTranslations, getWordTranslations, getVersesByChapter } from '@/lib/api';
 import { getTafsirResources } from '@/lib/api';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
+import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
@@ -109,8 +110,11 @@ export default function SurahPage({ params }: SurahPageProps) {
   }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
-      wordLanguageOptions.find((o) => LANGUAGE_CODES[o.name.toLowerCase()] === settings.wordLang)
-        ?.name || t('select_word_translation'),
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
     [settings.wordLang, wordLanguageOptions, t]
   );
   const groupedTranslations = useMemo(

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -8,6 +8,7 @@ import {
   FaChevronDown,
 } from '@/app/components/common/SvgIcons';
 import { Verse as VerseType, Translation, Word } from '@/types';
+import type { LanguageCode } from '@/lib/languageCodes';
 import { useAudio } from '@/app/context/AudioContext';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useState } from 'react';
@@ -118,7 +119,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                       />
                       {!showByWords && (
                         <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
-                          {word[wordLang] as string}
+                          {word[wordLang as LanguageCode] as string}
                         </span>
                       )}
                     </span>
@@ -127,7 +128,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                         className="block mt-1 text-gray-500"
                         style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                       >
-                        {word[wordLang] as string}
+                        {word[wordLang as LanguageCode] as string}
                       </span>
                     )}
                   </span>

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -7,6 +7,7 @@ import {
   FaShare,
 } from '@/app/components/common/SvgIcons';
 import { Verse as VerseType, Translation, Word } from '@/types';
+import type { LanguageCode } from '@/lib/languageCodes';
 import { useAudio } from '@/app/context/AudioContext';
 import { useSettings } from '@/app/context/SettingsContext';
 import Spinner from '@/app/components/common/Spinner';
@@ -90,7 +91,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
                     />
                     {!showByWords && (
                       <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
-                        {word[wordLang] as string}
+                        {word[wordLang as LanguageCode] as string}
                       </span>
                     )}
                   </span>
@@ -99,7 +100,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
                       className="block mt-1 text-gray-500"
                       style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                     >
-                      {word[wordLang] as string}
+                      {word[wordLang as LanguageCode] as string}
                     </span>
                   )}
                 </span>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,7 @@
 const API_BASE_URL = process.env.QURAN_API_BASE_URL ?? 'https://api.quran.com/api/v4';
 
 import { Chapter, TranslationResource, Verse, Juz, Word } from '@/types';
+import type { LanguageCode } from '@/lib/languageCodes';
 
 // Caching tafsir responses for efficiency
 const tafsirCache = new Map<string, string>();
@@ -20,14 +21,16 @@ interface ApiVerse extends Omit<Verse, 'words'> {
 }
 
 // Normalize API verse to app shape
-function normalizeVerse(raw: ApiVerse, wordLang = 'en'): Verse {
+function normalizeVerse(raw: ApiVerse, wordLang: LanguageCode = 'en'): Verse {
   return {
     ...raw,
-    words: raw.words?.map((w) => ({
-      ...w,
-      uthmani: w.text_uthmani ?? w.text,
-      [wordLang]: w.translation?.text,
-    })) as Word[],
+    words: raw.words?.map(
+      (w): Word => ({
+        id: w.id,
+        uthmani: w.text_uthmani ?? w.text,
+        [wordLang]: w.translation?.text,
+      })
+    ),
   };
 }
 
@@ -108,7 +111,9 @@ export async function getVersesByChapter(
   }
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
-  const verses = (data.verses as ApiVerse[]).map((v) => normalizeVerse(v, wordLang));
+  const verses = (data.verses as ApiVerse[]).map((v) =>
+    normalizeVerse(v, wordLang as LanguageCode)
+  );
   return { verses, totalPages };
 }
 
@@ -173,7 +178,9 @@ export async function getVersesByJuz(
   }
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
-  const verses = (data.verses as ApiVerse[]).map((v) => normalizeVerse(v, wordLang));
+  const verses = (data.verses as ApiVerse[]).map((v) =>
+    normalizeVerse(v, wordLang as LanguageCode)
+  );
   return { verses, totalPages };
 }
 
@@ -192,7 +199,9 @@ export async function getVersesByPage(
   }
   const data = await res.json();
   const totalPages = data.meta?.total_pages || data.pagination?.total_pages || 1;
-  const verses = (data.verses as ApiVerse[]).map((v) => normalizeVerse(v, wordLang));
+  const verses = (data.verses as ApiVerse[]).map((v) =>
+    normalizeVerse(v, wordLang as LanguageCode)
+  );
   return { verses, totalPages };
 }
 

--- a/lib/languageCodes.ts
+++ b/lib/languageCodes.ts
@@ -1,4 +1,4 @@
-export const LANGUAGE_CODES: Record<string, string> = {
+export const LANGUAGE_CODES = {
   english: 'en',
   urdu: 'ur',
   bengali: 'bn',
@@ -71,4 +71,6 @@ export const LANGUAGE_CODES: Record<string, string> = {
   'uighur, uyghur': 'ug',
   ukrainian: 'uk',
   yoruba: 'yo',
-};
+} as const;
+
+export type LanguageCode = (typeof LANGUAGE_CODES)[keyof typeof LANGUAGE_CODES];

--- a/types/word.ts
+++ b/types/word.ts
@@ -1,6 +1,6 @@
-export interface Word {
+import type { LanguageCode } from '@/lib/languageCodes';
+
+export interface Word extends Partial<Record<Exclude<LanguageCode, 'id'>, string>> {
   id: number;
   uthmani: string;
-  en?: string;
-  [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- introduce `LanguageCode` type
- tighten `Word` interface using typed records
- adjust API normalization and components to use new typing
- cast dynamic language lookups

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_688767ff1a6c832baed7f25431590d12