### PR TITLE
Add tafsir font size setting

### DIFF
--- a/__tests__/SettingsContext.test.tsx
+++ b/__tests__/SettingsContext.test.tsx
@@ -78,6 +78,7 @@ describe('SettingsContext settings state', () => {
     tafsirIds: [169],
     arabicFontSize: 28,
     translationFontSize: 16,
+    tafsirFontSize: 16,
     arabicFontFace: '"KFGQPC-Uthman-Taha", serif',
     wordLang: 'en',
     wordTranslationId: 85,

--- a/__tests__/TafsirTabs.test.tsx
+++ b/__tests__/TafsirTabs.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TafsirTabs from '@/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs';
 import { ThemeProvider } from '@/app/context/ThemeContext';
+import { SettingsProvider } from '@/app/context/SettingsContext';
 import { getTafsirCached } from '@/lib/tafsirCache';
 import useSWR from 'swr';
 
@@ -41,9 +42,11 @@ beforeEach(() => {
 
 it('shows tabs and switches content on click', async () => {
   render(
-    <ThemeProvider>
-      <TafsirTabs verseKey="1:1" tafsirIds={[1, 2]} />
-    </ThemeProvider>
+    <SettingsProvider>
+      <ThemeProvider>
+        <TafsirTabs verseKey="1:1" tafsirIds={[1, 2]} />
+      </ThemeProvider>
+    </SettingsProvider>
   );
   expect(screen.getByRole('button', { name: 'Tafsir One' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Tafsir Two' })).toBeInTheDocument();

--- a/app/context/SettingsContext.tsx
+++ b/app/context/SettingsContext.tsx
@@ -21,6 +21,7 @@ const defaultSettings: Settings = {
   tafsirIds: [169],
   arabicFontSize: 28,
   translationFontSize: 16,
+  tafsirFontSize: 16,
   arabicFontFace: ARABIC_FONTS[0].value,
   wordLang: 'en',
   wordTranslationId: 85,

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -47,6 +47,7 @@ export const SettingsSidebar = ({
   // Calculate percentages for each slider
   const arabicSizePercent = getPercentage(settings.arabicFontSize, 16, 48);
   const translationSizePercent = getPercentage(settings.translationFontSize, 12, 28);
+  const tafsirSizePercent = getPercentage(settings.tafsirFontSize, 12, 28);
 
   // Find the selected Arabic font name for display
   const selectedArabicFont =
@@ -174,17 +175,33 @@ export const SettingsSidebar = ({
               icon={<FaBookReader size={20} className="text-teal-700" />}
               isLast={false}
             >
-              <div>
-                <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
-                  {t('select_tafsir')}
-                </label>
-                <button
-                  onClick={onTafsirPanelOpen}
-                  className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
-                >
-                  <span className="truncate text-[var(--foreground)]">{selectedTafsirName}</span>
-                  <FaChevronDown className="text-gray-500" />
-                </button>
+              <div className="space-y-4">
+                <div>
+                  <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+                    {t('select_tafsir')}
+                  </label>
+                  <button
+                    onClick={onTafsirPanelOpen}
+                    className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-300 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition"
+                  >
+                    <span className="truncate text-[var(--foreground)]">{selectedTafsirName}</span>
+                    <FaChevronDown className="text-gray-500" />
+                  </button>
+                </div>
+                <div>
+                  <div className="flex justify-between mb-1 text-sm">
+                    <label className="text-[var(--foreground)]">{t('tafsir_font_size')}</label>
+                    <span className="font-semibold text-teal-700">{settings.tafsirFontSize}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min="12"
+                    max="28"
+                    value={settings.tafsirFontSize}
+                    onChange={(e) => setSettings({ ...settings, tafsirFontSize: +e.target.value })}
+                    style={{ '--value-percent': `${tafsirSizePercent}%` } as React.CSSProperties}
+                  />
+                </div>
               </div>
             </CollapsibleSection>
           )}

--- a/app/features/surah/[surahId]/_components/TafsirModal.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirModal.tsx
@@ -3,6 +3,7 @@ import { FaArrowLeft } from '@/app/components/common/SvgIcons';
 import { getTafsirByVerse } from '@/lib/api';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
+import { useSettings } from '@/app/context/SettingsContext';
 
 interface TafsirModalProps {
   verseKey: string;
@@ -12,6 +13,7 @@ interface TafsirModalProps {
 
 export const TafsirModal = ({ verseKey, isOpen, onClose }: TafsirModalProps) => {
   const { t } = useTranslation();
+  const { settings } = useSettings();
   const { data, error } = useSWR(isOpen ? ['tafsir', verseKey] : null, () =>
     getTafsirByVerse(verseKey)
   );
@@ -35,7 +37,14 @@ export const TafsirModal = ({ verseKey, isOpen, onClose }: TafsirModalProps) => 
             {t('error_loading_tafsir') || 'Error loading tafsir.'}
           </div>
         ) : (
-          <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: data || '' }} />
+          <div
+            className="prose max-w-none"
+            style={{
+              fontSize: `${settings.tafsirFontSize}px`,
+              fontFamily: settings.arabicFontFace,
+            }}
+            dangerouslySetInnerHTML={{ __html: data || '' }}
+          />
         )}
       </div>
     </div>

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -5,6 +5,7 @@ import { getTafsirCached } from '@/lib/tafsirCache';
 import { getTafsirResources } from '@/lib/api';
 import useSWR from 'swr';
 import { useTheme } from '@/app/context/ThemeContext';
+import { useSettings } from '@/app/context/SettingsContext';
 
 interface TafsirTabsProps {
   verseKey: string;
@@ -13,6 +14,7 @@ interface TafsirTabsProps {
 
 export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
   const { data } = useSWR('tafsirs', getTafsirResources);
+  const { settings } = useSettings();
 
   // Compute tabs only when data or tafsirIds change
   const tabs = useMemo(() => {
@@ -81,6 +83,10 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
         ) : (
           <div
             className="prose max-w-none"
+            style={{
+              fontSize: `${settings.tafsirFontSize}px`,
+              fontFamily: settings.arabicFontFace,
+            }}
             dangerouslySetInnerHTML={{ __html: contents[activeId] || '' }}
           />
         )}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -179,7 +179,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                     <div
                       className="prose max-w-none text-[var(--foreground)]"
                       style={{
-                        fontSize: `${settings.translationFontSize}px`,
+                        fontSize: `${settings.tafsirFontSize}px`,
                         fontFamily: settings.arabicFontFace,
                       }}
                       dangerouslySetInnerHTML={{ __html: tafseerTexts[id] || '' }}

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -253,6 +253,10 @@ export default function TafsirVersePage() {
                 >
                   <div
                     className="prose max-w-none"
+                    style={{
+                      fontSize: `${settings.tafsirFontSize}px`,
+                      fontFamily: settings.arabicFontFace,
+                    }}
                     dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
                   />
                 </CollapsibleSection>

--- a/public/locales/bn/common.json
+++ b/public/locales/bn/common.json
@@ -18,6 +18,7 @@
   "font_setting": "ফন্ট সেটিং",
   "arabic_font_size": "আরবি ফন্টের আকার",
   "translation_font_size": "অনুবাদ ফন্টের আকার",
+  "tafsir_font_size": "তাফসির ফন্টের আকার",
   "arabic_font_face": "আরবি ফন্টের মুখ",
   "select_font_face": "আরবি ফন্ট নির্বাচন করুন",
   "select_font": "ফন্ট নির্বাচন করুন",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,6 +18,7 @@
   "font_setting": "Font Setting",
   "arabic_font_size": "Arabic Font Size",
   "translation_font_size": "Translation Font Size",
+  "tafsir_font_size": "Tafsir Font Size",
   "arabic_font_face": "Arabic Font Face",
   "select_font_face": "Select Arabic Font",
   "select_font": "Select font",

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -3,6 +3,7 @@ export interface Settings {
   tafsirIds: number[];
   arabicFontSize: number;
   translationFontSize: number;
+  tafsirFontSize: number;
   arabicFontFace: string;
   wordLang: string;
   wordTranslationId: number;


### PR DESCRIPTION
## Summary
- extend Settings with `tafsirFontSize`
- store new setting in context
- add slider in settings sidebar to control tafsir text size
- apply setting across tafsir components
- localize new label and adjust tests

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6887a39e6660832b9bfca9c444a083f9