### PR TITLE
Fix tafsir spacing

### DIFF
--- a/app/features/surah/[surahId]/_components/TafsirModal.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirModal.tsx
@@ -38,7 +38,7 @@ export const TafsirModal = ({ verseKey, isOpen, onClose }: TafsirModalProps) => 
           </div>
         ) : (
           <div
-            className="prose max-w-none"
+            className="prose max-w-none whitespace-pre-wrap"
             style={{
               fontSize: `${settings.tafsirFontSize}px`,
               fontFamily: settings.arabicFontFace,

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -82,7 +82,7 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
           </div>
         ) : (
           <div
-            className="prose max-w-none"
+            className="prose max-w-none whitespace-pre-wrap"
             style={{
               fontSize: `${settings.tafsirFontSize}px`,
               fontFamily: settings.arabicFontFace,

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -177,7 +177,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                     </div>
                   ) : (
                     <div
-                      className="prose max-w-none text-[var(--foreground)]"
+                      className="prose max-w-none text-[var(--foreground)] whitespace-pre-wrap"
                       style={{
                         fontSize: `${settings.tafsirFontSize}px`,
                         fontFamily: settings.arabicFontFace,

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -252,7 +252,7 @@ export default function TafsirVersePage() {
                   isLast
                 >
                   <div
-                    className="prose max-w-none"
+                    className="prose max-w-none whitespace-pre-wrap"
                     style={{
                       fontSize: `${settings.tafsirFontSize}px`,
                       fontFamily: settings.arabicFontFace,


### PR DESCRIPTION
## Summary
- preserve whitespace when rendering tafsir text

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6887c62683b0832b90a1e14e96cb7f91