### PR TITLE
Fix tafsir text spacing

### DIFF
--- a/app/features/surah/[surahId]/_components/TafsirModal.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirModal.tsx
@@ -41,7 +41,6 @@ export const TafsirModal = ({ verseKey, isOpen, onClose }: TafsirModalProps) => 
             className="prose max-w-none whitespace-pre-wrap"
             style={{
               fontSize: `${settings.tafsirFontSize}px`,
-              fontFamily: settings.arabicFontFace,
             }}
             dangerouslySetInnerHTML={{ __html: data || '' }}
           />

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -85,7 +85,6 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
             className="prose max-w-none whitespace-pre-wrap"
             style={{
               fontSize: `${settings.tafsirFontSize}px`,
-              fontFamily: settings.arabicFontFace,
             }}
             dangerouslySetInnerHTML={{ __html: contents[activeId] || '' }}
           />

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -180,7 +180,6 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                       className="prose max-w-none text-[var(--foreground)] whitespace-pre-wrap"
                       style={{
                         fontSize: `${settings.tafsirFontSize}px`,
-                        fontFamily: settings.arabicFontFace,
                       }}
                       dangerouslySetInnerHTML={{ __html: tafseerTexts[id] || '' }}
                     />

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -255,7 +255,6 @@ export default function TafsirVersePage() {
                     className="prose max-w-none whitespace-pre-wrap"
                     style={{
                       fontSize: `${settings.tafsirFontSize}px`,
-                      fontFamily: settings.arabicFontFace,
                     }}
                     dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
                   />


### PR DESCRIPTION
## Summary
- remove custom Arabic font from tafsir components so languages like English render with normal word spacing

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6887caaa0f08832ba469b32e515c0fb8