### PR TITLE
Add Arabic font support in tafsir

### DIFF
--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useMemo } from 'react';
 import Spinner from '@/app/components/common/Spinner';
 import { getTafsirCached } from '@/lib/tafsirCache';
 import { getTafsirResources } from '@/lib/api';
+import { applyArabicFont } from '@/lib/applyArabicFont';
 import useSWR from 'swr';
 import { useTheme } from '@/app/context/ThemeContext';
 import { useSettings } from '@/app/context/SettingsContext';
@@ -86,7 +87,9 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
             style={{
               fontSize: `${settings.tafsirFontSize}px`,
             }}
-            dangerouslySetInnerHTML={{ __html: contents[activeId] || '' }}
+            dangerouslySetInnerHTML={{
+              __html: applyArabicFont(contents[activeId] || '', settings.arabicFontFace),
+            }}
           />
         )}
       </div>

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import Spinner from '@/app/components/common/Spinner';
 import { applyTajweed } from '@/lib/tajweed';
 import { getTafsirCached } from '@/lib/tafsirCache';
+import { applyArabicFont } from '@/lib/applyArabicFont';
 
 interface TafsirVerseProps {
   verse: VerseType;
@@ -181,7 +182,9 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                       style={{
                         fontSize: `${settings.tafsirFontSize}px`,
                       }}
-                      dangerouslySetInnerHTML={{ __html: tafseerTexts[id] || '' }}
+                      dangerouslySetInnerHTML={{
+                        __html: applyArabicFont(tafseerTexts[id] || '', settings.arabicFontFace),
+                      }}
                     />
                   )}
                 </div>

--- a/lib/applyArabicFont.ts
+++ b/lib/applyArabicFont.ts
@@ -1,0 +1,3 @@
+export function applyArabicFont(html: string, font: string): string {
+  return html.replace(/([\u0600-\u06FF]+)/g, `<span style="font-family:${font};">$1</span>`);
+}


### PR DESCRIPTION
## Summary
- add helper to wrap Arabic characters with a font span
- use helper in `TafsirVerse` and `TafsirTabs`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6887d83f7f04832b815a6e1e1d396e8f