### PR TITLE
Improve font styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -33,6 +33,25 @@
     @apply bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-200;
     font-family: Inter, sans-serif;
     margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  p {
+    line-height: 1.6;
+    margin-bottom: 1rem;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  [lang='ar'] {
+    font-family: var(--font-noto-sans-arabic);
+  }
+
+  [lang='bn'] {
+    font-family: var(--font-noto-sans-bengali);
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { SettingsProvider } from './context/SettingsContext'; // Import SettingsProvider
 import { SidebarProvider } from './context/SidebarContext'; // Import SidebarProvider
 import localFont from 'next/font/local';
-import { Inter } from 'next/font/google';
+import { Inter, Noto_Sans_Arabic, Noto_Sans_Bengali } from 'next/font/google';
 import { cookies } from 'next/headers';
 
 const kfgqpc = localFont({
@@ -33,6 +33,20 @@ const inter = Inter({
   display: 'swap',
 });
 
+const arabic = Noto_Sans_Arabic({
+  subsets: ['arabic'],
+  weight: ['400', '700'],
+  variable: '--font-noto-sans-arabic',
+  display: 'swap',
+});
+
+const bengali = Noto_Sans_Bengali({
+  subsets: ['bengali'],
+  weight: ['400', '700'],
+  variable: '--font-noto-sans-bengali',
+  display: 'swap',
+});
+
 export const metadata = {
   title: 'Quran Mazid',
   description: 'Read, Study, and Learn The Holy Quran',
@@ -49,7 +63,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en" data-theme={theme} className={theme === 'dark' ? 'dark' : undefined}>
       <body
-        className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${inter.className}`}
+        className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${arabic.variable} ${bengali.variable} ${inter.className}`}
       >
         <TranslationProvider>
           <ThemeProvider>


### PR DESCRIPTION
## Summary
- import Noto Sans fonts for Arabic and Bengali
- use these fonts alongside Inter
- add antialiased font smoothing
- improve paragraph spacing

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688868cb9808832b8453bbfdc3ce782a