### PR TITLE
Add ClientProviders wrapper

### DIFF
--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -10,9 +10,15 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  // Initialize theme with a default value
-  const [theme, setTheme] = useState<Theme>('light');
+export const ThemeProvider = ({
+  children,
+  initialTheme = 'light',
+}: {
+  children: React.ReactNode;
+  initialTheme?: Theme;
+}) => {
+  // Initialize theme with a default value or provided value
+  const [theme, setTheme] = useState<Theme>(initialTheme);
 
   // Effect to load theme from localStorage on the client side after initial render
   useEffect(() => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,9 +2,7 @@
 import './globals.css';
 import './fonts.css';
 import TranslationProvider from './providers/TranslationProvider';
-import { ThemeProvider } from './context/ThemeContext';
-import { SettingsProvider } from './context/SettingsContext'; // Import SettingsProvider
-import { SidebarProvider } from './context/SidebarContext'; // Import SidebarProvider
+import ClientProviders from './providers/ClientProviders';
 import localFont from 'next/font/local';
 import { Inter, Noto_Sans_Arabic, Noto_Sans_Bengali } from 'next/font/google';
 import { cookies } from 'next/headers';
@@ -66,17 +64,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${arabic.variable} ${bengali.variable} ${inter.className}`}
       >
         <TranslationProvider>
-          <ThemeProvider>
-            <SettingsProvider>
-              {' '}
-              {/* Wrap with SettingsProvider */}
-              <SidebarProvider>
-                {' '}
-                {/* Wrap with SidebarProvider */}
-                {children}
-              </SidebarProvider>
-            </SettingsProvider>
-          </ThemeProvider>
+          <ClientProviders initialTheme={theme}>{children}</ClientProviders>
         </TranslationProvider>
       </body>
     </html>

--- a/app/providers/ClientProviders.tsx
+++ b/app/providers/ClientProviders.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React from 'react';
+import { ThemeProvider, Theme } from '../context/ThemeContext';
+import { SettingsProvider } from '../context/SettingsContext';
+import { SidebarProvider } from '../context/SidebarContext';
+
+export default function ClientProviders({
+  children,
+  initialTheme,
+}: {
+  children: React.ReactNode;
+  initialTheme: Theme;
+}) {
+  return (
+    <ThemeProvider initialTheme={initialTheme}>
+      <SettingsProvider>
+        <SidebarProvider>{children}</SidebarProvider>
+      </SettingsProvider>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `ClientProviders` component to group client contexts
- pass `initialTheme` through `layout.tsx`
- allow `ThemeProvider` to accept an `initialTheme` prop

## Testing
- `npm run check`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688909442dcc832bb049e4af2619e471