### PR TITLE
Persist surah list scroll position

### DIFF
--- a/app/context/SidebarContext.tsx
+++ b/app/context/SidebarContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 interface SidebarContextType {
   isSurahListOpen: boolean;
@@ -15,7 +15,14 @@ const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 export const SidebarProvider = ({ children }: { children: React.ReactNode }) => {
   const [isSurahListOpen, setSurahListOpen] = useState(false);
   const [isSettingsOpen, setSettingsOpen] = useState(false);
-  const [surahListScrollTop, setSurahListScrollTop] = useState(0);
+  const [surahListScrollTop, setSurahListScrollTop] = useState(() => {
+    const stored = sessionStorage.getItem('surahListScrollTop');
+    return stored ? Number(stored) : 0;
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem('surahListScrollTop', surahListScrollTop.toString());
+  }, [surahListScrollTop]);
 
   return (
     <SidebarContext.Provider


### PR DESCRIPTION
## Summary
- read Surah list scroll value from sessionStorage when loading
- save the scroll position whenever it changes

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68890de8b6a8832bb7e717060bd482d3