### PR TITLE
Remove tap scaling from sidebar links

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -147,7 +147,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                     key={chapter.id}
                     data-active={isSelected}
                     whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
                     onClick={() => {
                       setSelectedSurahId(String(chapter.id));
                       setSurahListScrollTop(sidebarRef.current?.scrollTop ?? 0);
@@ -204,7 +203,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                     key={j}
                     data-active={isSelected}
                     whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
                     onClick={() => {
                       setSelectedJuzId(String(j));
                       setSurahListScrollTop(sidebarRef.current?.scrollTop ?? 0);
@@ -249,7 +247,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                     key={p}
                     data-active={isSelected}
                     whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
                     onClick={() => {
                       setSelectedPageId(String(p));
                       setSurahListScrollTop(sidebarRef.current?.scrollTop ?? 0);


### PR DESCRIPTION
## Summary
- drop whileTap from Surah, Juz, and Page sidebar links to prevent shrink-on-tap

## Testing
- `npm audit --omit=dev`
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b2c583f84832abe7ef439e62e0654