### PR TITLE
Remove layout animation from surah sidebar

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -142,7 +142,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 const isSelected = selectedSurahId === String(chapter.id);
                 return (
                   <MotionLink
-                    layout
                     href={`/features/surah/${chapter.id}`}
                     key={chapter.id}
                     data-active={isSelected}
@@ -198,7 +197,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 const isSelected = selectedJuzId === String(j);
                 return (
                   <MotionLink
-                    layout
                     href={`/features/juz/${j}`}
                     key={j}
                     data-active={isSelected}
@@ -242,7 +240,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 const isSelected = selectedPageId === String(p);
                 return (
                   <MotionLink
-                    layout
                     href={`/features/page/${p}`}
                     key={p}
                     data-active={isSelected}


### PR DESCRIPTION
## Summary
- remove layout animation from surah list sidebar links to stop bounce on selection
- keep hover scaling animation intact

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688b3089320c832abc03edfb2fcde219