### PR TITLE
Disable auto scroll on sidebar links

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -141,6 +141,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <Link
                     href={`/features/surah/${chapter.id}`}
+                    scroll={false}
                     key={chapter.id}
                     data-active={isSelected}
                     onClick={() => {
@@ -195,6 +196,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <Link
                     href={`/features/juz/${j}`}
+                    scroll={false}
                     key={j}
                     data-active={isSelected}
                     onClick={() => {
@@ -237,6 +239,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <Link
                     href={`/features/page/${p}`}
+                    scroll={false}
                     key={p}
                     data-active={isSelected}
                     onClick={() => {


### PR DESCRIPTION
## Summary
- prevent automatic page scroll when navigating via sidebar

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688b404677b8832a9c00b358811f7e0f