### PR TITLE
Fix sidebar scroll reset on first tab change

### DIFF
--- a/app/context/SidebarContext.tsx
+++ b/app/context/SidebarContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 interface SidebarContextType {
   isSurahListOpen: boolean;
@@ -19,28 +19,31 @@ const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 export const SidebarProvider = ({ children }: { children: React.ReactNode }) => {
   const [isSurahListOpen, setSurahListOpen] = useState(false);
   const [isSettingsOpen, setSettingsOpen] = useState(false);
-  const [surahScrollTop, setSurahScrollTop] = useState(() => {
+  const [surahScrollTop, _setSurahScrollTop] = useState(() => {
     const stored = sessionStorage.getItem('surahScrollTop');
     return stored ? Number(stored) : 0;
   });
-  const [juzScrollTop, setJuzScrollTop] = useState(() => {
+  const [juzScrollTop, _setJuzScrollTop] = useState(() => {
     const stored = sessionStorage.getItem('juzScrollTop');
     return stored ? Number(stored) : 0;
   });
-  const [pageScrollTop, setPageScrollTop] = useState(() => {
+  const [pageScrollTop, _setPageScrollTop] = useState(() => {
     const stored = sessionStorage.getItem('pageScrollTop');
     return stored ? Number(stored) : 0;
   });
 
-  useEffect(() => {
-    sessionStorage.setItem('surahScrollTop', surahScrollTop.toString());
-  }, [surahScrollTop]);
-  useEffect(() => {
-    sessionStorage.setItem('juzScrollTop', juzScrollTop.toString());
-  }, [juzScrollTop]);
-  useEffect(() => {
-    sessionStorage.setItem('pageScrollTop', pageScrollTop.toString());
-  }, [pageScrollTop]);
+  const setSurahScrollTop = (top: number) => {
+    _setSurahScrollTop(top);
+    sessionStorage.setItem('surahScrollTop', top.toString());
+  };
+  const setJuzScrollTop = (top: number) => {
+    _setJuzScrollTop(top);
+    sessionStorage.setItem('juzScrollTop', top.toString());
+  };
+  const setPageScrollTop = (top: number) => {
+    _setPageScrollTop(top);
+    sessionStorage.setItem('pageScrollTop', top.toString());
+  };
 
   return (
     <SidebarContext.Provider

--- a/types/chapter.ts
+++ b/types/chapter.ts
@@ -4,4 +4,5 @@ export interface Chapter {
   name_arabic: string;
   revelation_place: string;
   verses_count: number;
+  pages?: [number, number];
 }


### PR DESCRIPTION
## Summary
- add juz start page mapping to link Surah, Juz, and Page tabs
- remove route-param tab reset to avoid initial sidebar flicker
- extend Chapter type with page range metadata

## Testing
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688b43b67e6c832a82892ea92341d932