### PR TITLE
fix: restore sidebar scroll position with useLayoutEffect

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useEffect, useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
@@ -86,7 +86,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     setPageScrollTop,
   } = useSidebar();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!sidebarRef.current) return;
     if (activeTab === 'Surah') sidebarRef.current.scrollTop = surahScrollTop;
     else if (activeTab === 'Juz') sidebarRef.current.scrollTop = juzScrollTop;


### PR DESCRIPTION
## Summary
- use `useLayoutEffect` to restore stored scroll positions when switching tabs

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688b4f483c78832ab26f5059605d1b45