### PR TITLE
Center active item in Surah sidebar

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -85,13 +85,58 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     pageScrollTop,
     setPageScrollTop,
   } = useSidebar();
+  const shouldCenterRef = useRef<Record<'Surah' | 'Juz' | 'Page', boolean>>({
+    Surah: true,
+    Juz: true,
+    Page: true,
+  });
+
+  useEffect(() => {
+    shouldCenterRef.current[activeTab] = true;
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (activeTab !== 'Surah') shouldCenterRef.current.Surah = true;
+  }, [selectedSurahId, activeTab]);
+
+  useEffect(() => {
+    if (activeTab !== 'Juz') shouldCenterRef.current.Juz = true;
+  }, [selectedJuzId, activeTab]);
+
+  useEffect(() => {
+    if (activeTab !== 'Page') shouldCenterRef.current.Page = true;
+  }, [selectedPageId, activeTab]);
 
   useLayoutEffect(() => {
     if (!sidebarRef.current) return;
-    if (activeTab === 'Surah') sidebarRef.current.scrollTop = surahScrollTop;
-    else if (activeTab === 'Juz') sidebarRef.current.scrollTop = juzScrollTop;
-    else if (activeTab === 'Page') sidebarRef.current.scrollTop = pageScrollTop;
-  }, [activeTab, surahScrollTop, juzScrollTop, pageScrollTop]);
+    const sidebar = sidebarRef.current;
+
+    let top = 0;
+    if (activeTab === 'Surah') top = surahScrollTop;
+    else if (activeTab === 'Juz') top = juzScrollTop;
+    else if (activeTab === 'Page') top = pageScrollTop;
+
+    sidebar.scrollTop = top;
+
+    const activeEl = sidebar.querySelector<HTMLElement>('[data-active="true"]');
+    if (activeEl) {
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const activeRect = activeEl.getBoundingClientRect();
+      const isOutside = activeRect.top < sidebarRect.top || activeRect.bottom > sidebarRect.bottom;
+      if (shouldCenterRef.current[activeTab] && (top === 0 || isOutside)) {
+        activeEl.scrollIntoView({ block: 'center' });
+      }
+    }
+    shouldCenterRef.current[activeTab] = false;
+  }, [
+    activeTab,
+    surahScrollTop,
+    juzScrollTop,
+    pageScrollTop,
+    selectedSurahId,
+    selectedJuzId,
+    selectedPageId,
+  ]);
 
   const filteredChapters = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- ensure selected item is centered only once after switching tabs
- keep sidebar scroll restoration in sync with selection changes

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b53fb6934832a84704d2496fe6884