### PR TITLE
Center active item in Surah sidebar

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -40,7 +40,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
   const currentSurahId = Array.isArray(surahId) ? surahId[0] : surahId;
   const currentJuzId = Array.isArray(juzId) ? juzId[0] : juzId;
   const currentPageId = Array.isArray(pageId) ? pageId[0] : pageId;
-  const [activeTab, setActiveTab] = useState(() => {
+  const [activeTab, setActiveTab] = useState<'Surah' | 'Juz' | 'Page'>(() => {
     if (currentJuzId) return 'Juz';
     if (currentPageId) return 'Page';
     return 'Surah';
@@ -85,13 +85,72 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     pageScrollTop,
     setPageScrollTop,
   } = useSidebar();
+  const shouldCenterRef = useRef<Record<'Surah' | 'Juz' | 'Page', boolean>>({
+    Surah: true,
+    Juz: true,
+    Page: true,
+  });
+
+  useLayoutEffect(() => {
+    const surah = sessionStorage.getItem('skipCenterSurah') === '1';
+    const juz = sessionStorage.getItem('skipCenterJuz') === '1';
+    const page = sessionStorage.getItem('skipCenterPage') === '1';
+    if (surah) {
+      shouldCenterRef.current.Surah = false;
+      sessionStorage.removeItem('skipCenterSurah');
+    }
+    if (juz) {
+      shouldCenterRef.current.Juz = false;
+      sessionStorage.removeItem('skipCenterJuz');
+    }
+    if (page) {
+      shouldCenterRef.current.Page = false;
+      sessionStorage.removeItem('skipCenterPage');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeTab !== 'Surah') shouldCenterRef.current.Surah = true;
+  }, [selectedSurahId, activeTab]);
+
+  useEffect(() => {
+    if (activeTab !== 'Juz') shouldCenterRef.current.Juz = true;
+  }, [selectedJuzId, activeTab]);
+
+  useEffect(() => {
+    if (activeTab !== 'Page') shouldCenterRef.current.Page = true;
+  }, [selectedPageId, activeTab]);
 
   useLayoutEffect(() => {
     if (!sidebarRef.current) return;
-    if (activeTab === 'Surah') sidebarRef.current.scrollTop = surahScrollTop;
-    else if (activeTab === 'Juz') sidebarRef.current.scrollTop = juzScrollTop;
-    else if (activeTab === 'Page') sidebarRef.current.scrollTop = pageScrollTop;
-  }, [activeTab, surahScrollTop, juzScrollTop, pageScrollTop]);
+    const sidebar = sidebarRef.current;
+
+    let top = 0;
+    if (activeTab === 'Surah') top = surahScrollTop;
+    else if (activeTab === 'Juz') top = juzScrollTop;
+    else if (activeTab === 'Page') top = pageScrollTop;
+
+    sidebar.scrollTop = top;
+
+    const activeEl = sidebar.querySelector<HTMLElement>('[data-active="true"]');
+    if (activeEl) {
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const activeRect = activeEl.getBoundingClientRect();
+      const isOutside = activeRect.top < sidebarRect.top || activeRect.bottom > sidebarRect.bottom;
+      if (shouldCenterRef.current[activeTab] && (top === 0 || isOutside)) {
+        activeEl.scrollIntoView({ block: 'center' });
+      }
+    }
+    shouldCenterRef.current[activeTab] = false;
+  }, [
+    activeTab,
+    surahScrollTop,
+    juzScrollTop,
+    pageScrollTop,
+    selectedSurahId,
+    selectedJuzId,
+    selectedPageId,
+  ]);
 
   const filteredChapters = useMemo(
     () =>
@@ -111,7 +170,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     [pages, searchTerm]
   );
 
-  const TABS = [
+  const TABS: { key: 'Surah' | 'Juz' | 'Page'; label: string }[] = [
     { key: 'Surah', label: t('surah_tab') },
     { key: 'Juz', label: t('juz_tab') },
     { key: 'Page', label: t('page_tab') },
@@ -154,6 +213,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                   if (activeTab === 'Surah') setSurahScrollTop(top);
                   else if (activeTab === 'Juz') setJuzScrollTop(top);
                   else if (activeTab === 'Page') setPageScrollTop(top);
+                  shouldCenterRef.current[tab.key] = true;
                   setActiveTab(tab.key);
                 }}
                 className={`w-1/3 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${activeTab === tab.key ? (theme === 'light' ? 'bg-white shadow text-slate-900' : 'bg-slate-700 text-white shadow') : theme === 'light' ? 'text-slate-400 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}
@@ -195,6 +255,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                       setSelectedPageId(String(page));
                       setSelectedJuzId(String(getJuzByPage(page)));
                       setSurahScrollTop(sidebarRef.current?.scrollTop ?? 0);
+                      shouldCenterRef.current.Surah = false;
+                      sessionStorage.setItem('skipCenterSurah', '1');
                     }}
                     className={`group flex items-center gap-4 p-4 rounded-xl cursor-pointer transform hover:scale-[1.02] transition-[background-color,box-shadow,transform] duration-300 ease-in-out ${isSelected ? 'bg-emerald-500 text-white shadow-lg shadow-emerald-500/30' : theme === 'light' ? 'bg-white hover:bg-slate-50' : 'bg-slate-800 hover:bg-slate-700'}`}
                   >
@@ -254,6 +316,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                       const chapter = getSurahByPage(page, chapters);
                       if (chapter) setSelectedSurahId(String(chapter.id));
                       setJuzScrollTop(sidebarRef.current?.scrollTop ?? 0);
+                      shouldCenterRef.current.Juz = false;
+                      sessionStorage.setItem('skipCenterJuz', '1');
                     }}
                     className={`group flex items-center gap-4 p-4 rounded-xl cursor-pointer transform hover:scale-[1.02] transition-[background-color,box-shadow,transform] duration-300 ease-in-out ${isSelected ? 'bg-emerald-500 text-white shadow-lg shadow-emerald-500/30' : theme === 'light' ? 'bg-white hover:bg-slate-50' : 'bg-slate-800 hover:bg-slate-700'}`}
                   >
@@ -300,6 +364,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                       const chapter = getSurahByPage(p, chapters);
                       if (chapter) setSelectedSurahId(String(chapter.id));
                       setPageScrollTop(sidebarRef.current?.scrollTop ?? 0);
+                      shouldCenterRef.current.Page = false;
+                      sessionStorage.setItem('skipCenterPage', '1');
                     }}
                     className={`group flex items-center gap-4 p-4 rounded-xl cursor-pointer transform hover:scale-[1.02] transition-[background-color,box-shadow,transform] duration-300 ease-in-out ${isSelected ? 'bg-emerald-500 text-white shadow-lg shadow-emerald-500/30' : theme === 'light' ? 'bg-white hover:bg-slate-50' : 'bg-slate-800 hover:bg-slate-700'}`}
                   >


### PR DESCRIPTION
## Summary
- ensure selected item is centered only once after switching tabs
- keep sidebar scroll restoration in sync with selection changes

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b53fb6934832a84704d2496fe6884