### PR TITLE
fix: align settings panel widths

### DIFF
--- a/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
+++ b/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
@@ -36,7 +36,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
     <>
       {/* No overlay div */}
       <div
-        className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -74,7 +74,7 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed lg:static inset-y-0 right-0 w-80 bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
+        className={`fixed lg:static inset-y-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >
         <header className="flex items-center justify-between p-4 border-b border-[var(--border-color)]">
           <button

--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -32,7 +32,7 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
 
   return (
     <div
-      className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
         <button

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -25,7 +25,7 @@ export const TranslationPanel = ({
     <>
       {/* Removed the overlay div */}
       <div
-        className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -36,7 +36,7 @@ export const WordLanguagePanel = ({
 
   return (
     <div
-      className={`fixed top-0 right-0 w-80 h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
         <button


### PR DESCRIPTION
## Summary
- match settings sidebar width with surah list
- use same width for translation, word-language, tafsir, and Arabic font panels

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688cdc990618832a99d64835954248ae