### PR TITLE
Underline word-by-word translations

### DIFF
--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -96,7 +96,7 @@ export const Verse = ({ verse }: VerseProps) => {
               <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">
-                    <span className="relative group cursor-pointer">
+                    <span className="relative group cursor-pointer inline-block border-b border-gray-300">
                       {/* Tajweed coloring for each word */}
                       <span
                         dangerouslySetInnerHTML={{
@@ -113,7 +113,7 @@ export const Verse = ({ verse }: VerseProps) => {
                     {/* Inline translation below the word (when showByWords) */}
                     {showByWords && (
                       <span
-                        className="block mt-1 text-gray-500"
+                        className="mt-1 inline-block text-gray-500 border-b border-gray-300"
                         style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                       >
                         {word[wordLang as LanguageCode] as string}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -112,7 +112,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
               <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">
-                    <span className="relative group cursor-pointer">
+                    <span className="relative group cursor-pointer inline-block border-b border-gray-300">
                       <span
                         dangerouslySetInnerHTML={{
                           __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
@@ -126,7 +126,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                     </span>
                     {showByWords && (
                       <span
-                        className="block mt-1 text-gray-500"
+                        className="mt-1 inline-block text-gray-500 border-b border-gray-300"
                         style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                       >
                         {word[wordLang as LanguageCode] as string}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -83,7 +83,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
             <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
               {verse.words.map((word: Word) => (
                 <span key={word.id} className="text-center">
-                  <span className="relative group cursor-pointer">
+                  <span className="relative group cursor-pointer inline-block border-b border-gray-300">
                     <span
                       dangerouslySetInnerHTML={{
                         __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
@@ -97,7 +97,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
                   </span>
                   {showByWords && (
                     <span
-                      className="block mt-1 text-gray-500"
+                      className="mt-1 inline-block text-gray-500 border-b border-gray-300"
                       style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                     >
                       {word[wordLang as LanguageCode] as string}


### PR DESCRIPTION
## Summary
- add subtle grey underline beneath each Arabic word and its translation when word-by-word view is enabled
- apply consistent styling across verse components to clarify word relationships

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688cdcc7d1e0832aa7ad221062be6be2