### PR TITLE
Display selected tafsir name above text

### DIFF
--- a/app/components/common/TafsirSwitch.tsx
+++ b/app/components/common/TafsirSwitch.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import { usePathname } from 'next/navigation';
 
 interface TafsirSwitchProps {
   tafsirs: { id: number; name: string }[];
@@ -12,7 +11,6 @@ interface TafsirSwitchProps {
 
 export default function TafsirSwitch({ tafsirs, activeId, verseKey }: TafsirSwitchProps) {
   const router = useRouter();
-  const pathname = usePathname();
 
   const handleSwitchTafsir = (id: number) => {
     const [surahId, ayahId] = verseKey.split(':');

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirTabs.tsx
@@ -53,6 +53,8 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
   const { theme } = useTheme();
   if (!tabs.length || !activeId) return null;
 
+  const activeTab = tabs.find((t) => t.id === activeId);
+
   return (
     <div>
       <div
@@ -77,6 +79,9 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
         ))}
       </div>
       <div className="p-4">
+        <h2 className="mb-4 text-center text-xl font-bold text-[var(--foreground)]">
+          {activeTab?.name}
+        </h2>
         {loading[activeId] ? (
           <div className="flex justify-center py-4">
             <Spinner className="h-5 w-5 text-emerald-600" />

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -3,7 +3,6 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { Verse as VerseComponent } from '@/app/features/surah/[surahId]/_components/Verse';
-import { CollapsibleSection } from '@/app/features/surah/[surahId]/_components/CollapsibleSection';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
 import { TranslationPanel } from '@/app/features/surah/[surahId]/_components/TranslationPanel';
 import { TafsirPanel } from '@/app/features/surah/[surahId]/_components/TafsirPanel';
@@ -169,8 +168,6 @@ export default function TafsirVersePage() {
   };
 
   const currentSurah = surahList.find((surah) => surah.number === Number(surahId));
-  const prevSurah = surahList.find((surah) => surah.number === Number(prev?.surahId));
-  const nextSurah = surahList.find((surah) => surah.number === Number(next?.surahId));
 
   return (
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] overflow-hidden">
@@ -245,12 +242,10 @@ export default function TafsirVersePage() {
               <TafsirTabs verseKey={verse.verse_key} tafsirIds={settings.tafsirIds} />
             ) : (
               tafsirResource && (
-                <CollapsibleSection
-                  key={verse?.verse_key}
-                  title={tafsirResource.name}
-                  icon={<></>}
-                  isLast
-                >
+                <div key={verse?.verse_key} className="p-4">
+                  <h2 className="mb-4 text-center text-xl font-bold text-[var(--foreground)]">
+                    {tafsirResource.name}
+                  </h2>
                   <div
                     className="prose max-w-none whitespace-pre-wrap"
                     style={{
@@ -258,7 +253,7 @@ export default function TafsirVersePage() {
                     }}
                     dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
                   />
-                </CollapsibleSection>
+                </div>
               )
             )}
           </div>


### PR DESCRIPTION
## Summary
- Show selected tafsir title centered above its content
- Add same heading in multi-tafsir tabs
- Clean up unused import in Tafsir switch

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688cde10e2c8832ab4b1ca3994d287f5