### PR TITLE
Refine word-by-word translation spacing

### DIFF
--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -93,10 +93,10 @@ export const Verse = ({ verse }: VerseProps) => {
           >
             {/* Use words if available, else fall back to plain text */}
             {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
+              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">
-                    <span className="relative group cursor-pointer inline-block border-b border-gray-300">
+                    <span className="relative group cursor-pointer inline-block">
                       {/* Tajweed coloring for each word */}
                       <span
                         dangerouslySetInnerHTML={{
@@ -113,7 +113,7 @@ export const Verse = ({ verse }: VerseProps) => {
                     {/* Inline translation below the word (when showByWords) */}
                     {showByWords && (
                       <span
-                        className="mt-1 inline-block text-gray-500 border-b border-gray-300"
+                        className="mt-0.5 block text-gray-500"
                         style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                       >
                         {word[wordLang as LanguageCode] as string}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -109,10 +109,10 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
             }}
           >
             {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
+              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">
-                    <span className="relative group cursor-pointer inline-block border-b border-gray-300">
+                    <span className="relative group cursor-pointer inline-block">
                       <span
                         dangerouslySetInnerHTML={{
                           __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
@@ -126,7 +126,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
                     </span>
                     {showByWords && (
                       <span
-                        className="mt-1 inline-block text-gray-500 border-b border-gray-300"
+                        className="mt-0.5 block text-gray-500"
                         style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                       >
                         {word[wordLang as LanguageCode] as string}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -80,10 +80,10 @@ export default function VerseCard({ verse }: VerseCardProps) {
           }}
         >
           {verse.words && verse.words.length > 0 ? (
-            <span className="flex flex-wrap gap-x-2 gap-y-1 justify-end">
+            <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
               {verse.words.map((word: Word) => (
                 <span key={word.id} className="text-center">
-                  <span className="relative group cursor-pointer inline-block border-b border-gray-300">
+                  <span className="relative group cursor-pointer inline-block">
                     <span
                       dangerouslySetInnerHTML={{
                         __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
@@ -97,7 +97,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
                   </span>
                   {showByWords && (
                     <span
-                      className="mt-1 inline-block text-gray-500 border-b border-gray-300"
+                      className="mt-0.5 block text-gray-500"
                       style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                     >
                       {word[wordLang as LanguageCode] as string}


### PR DESCRIPTION
## Summary
- tighten word-by-word layout and remove borders so Arabic words sit directly above translations

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688cf17e2d48832ab5790c1ed11432d7