### PR TITLE
Align panels with sidebar height

### DIFF
--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -32,7 +32,7 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
 
   return (
     <div
-      className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      className={`fixed top-0 bottom-0 lg:top-16 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
         <button

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -25,7 +25,7 @@ export const TranslationPanel = ({
     <>
       {/* Removed the overlay div */}
       <div
-        className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-0 bottom-0 lg:top-16 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -36,7 +36,7 @@ export const WordLanguagePanel = ({
 
   return (
     <div
-      className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      className={`fixed top-0 bottom-0 lg:top-16 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
         <button


### PR DESCRIPTION
## Summary
- keep translation, word language, and tafsir panels within settings sidebar height

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688cf7848e0c832a90603d07c2aaa386