### PR TITLE
Fix verse HTML property and spaces

### DIFF
--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -1,11 +1,11 @@
 // app/surah/[surahId]/_components/Verse.tsx
 import {
-  FaPlay,
-  FaPause,
-  FaBookmark,
-  FaRegBookmark,
-  FaEllipsisH,
-  FaBookReader,
+  FaPlay,
+  FaPause,
+  FaBookmark,
+  FaRegBookmark,
+  FaEllipsisH,
+  FaBookReader,
 } from '@/app/components/common/SvgIcons';
 import { useRouter } from 'next/navigation';
 import { Verse as VerseType, Translation, Word } from '@/types';
@@ -16,131 +16,131 @@ import { useSettings } from '@/app/context/SettingsContext';
 import { applyTajweed } from '@/lib/tajweed';
 
 interface VerseProps {
-  verse: VerseType;
+  verse: VerseType;
 }
 
 export const Verse = ({ verse }: VerseProps) => {
-  const { playingId, setPlayingId, loadingId } = useAudio();
-  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
-  const router = useRouter();
-  const showByWords = settings.showByWords ?? false;
-  const wordLang = settings.wordLang ?? 'en';
-  const isPlaying = playingId === verse.id;
-  const isLoadingAudio = loadingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(String(verse.id)); // Check if verse is bookmarked (using string ID)
-  const [surahId, ayahId] = verse.verse_key.split(':');
+  const { playingId, setPlayingId, loadingId } = useAudio();
+  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
+  const router = useRouter();
+  const showByWords = settings.showByWords ?? false;
+  const wordLang = settings.wordLang ?? 'en';
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id)); // Check if verse is bookmarked (using string ID)
+  const [surahId, ayahId] = verse.verse_key.split(':');
 
-  return (
-    <>
-      <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
-        <div className="w-16 text-center pt-1 space-y-2 flex-shrink-0">
-          <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>
-          <div className="flex flex-col items-center space-y-1 text-gray-400 dark:text-gray-500">
-            <button
-              aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
-              onClick={() =>
-                setPlayingId((currentId) => (currentId === verse.id ? null : verse.id))
-              }
-              title="Play/Pause"
-              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
-            >
-              {isLoadingAudio ? (
-                <Spinner className="h-4 w-4 text-teal-600" />
-              ) : isPlaying ? (
-                <FaPause size={18} />
-              ) : (
-                <FaPlay size={18} />
-              )}
-            </button>
-            {/* Bookmark button */}
-            <button
-              aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
-              title="Bookmark"
-              onClick={() => toggleBookmark(String(verse.id))}
-              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
-            >
-              {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
-            </button>
+  return (
+    <>
+      <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
+        <div className="w-16 text-center pt-1 space-y-2 flex-shrink-0">
+          <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>
+          <div className="flex flex-col items-center space-y-1 text-gray-400 dark:text-gray-500">
+            <button
+              aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
+              onClick={() =>
+                setPlayingId((currentId) => (currentId === verse.id ? null : verse.id))
+              }
+              title="Play/Pause"
+              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
+            >
+              {isLoadingAudio ? (
+                <Spinner className="h-4 w-4 text-teal-600" />
+              ) : isPlaying ? (
+                <FaPause size={18} />
+              ) : (
+                <FaPlay size={18} />
+              )}
+            </button>
+            {/* Bookmark button */}
+            <button
+              aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
+              title="Bookmark"
+              onClick={() => toggleBookmark(String(verse.id))}
+              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
+            >
+              {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
+            </button>
 
-            {/* Tafsir button navigates to tafsir page */}
-            <button
-              aria-label="Tafsir"
-              title="Tafsir"
-              onClick={() => router.push(`/features/tafsir/${surahId}/${ayahId}`)}
-              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
-            >
-              <FaBookReader size={18} />
-            </button>
+            {/* Tafsir button navigates to tafsir page */}
+            <button
+              aria-label="Tafsir"
+              title="Tafsir"
+              onClick={() => router.push(`/features/tafsir/${surahId}/${ayahId}`)}
+              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+            >
+              <FaBookReader size={18} />
+            </button>
 
-            <button
-              aria-label="More options"
-              title="More"
-              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
-            >
-              <FaEllipsisH size={18} />
-            </button>
-          </div>
-        </div>
-        <div className="flex-grow space-y-6">
-          {/* ARABIC VERSE DISPLAY, WITH TAJWEED + WORD TRANSLATIONS */}
-          <p
-            className="text-right leading-loose text-[var(--foreground)]"
-            style={{
-              fontFamily: settings.arabicFontFace,
-              fontSize: `${settings.arabicFontSize}px`,
-              lineHeight: 2.2,
-            }}
-          >
-            {/* Use words if available, else fall back to plain text */}
-            {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
-                {verse.words.map((word: Word) => (
-                  <span key={word.id} className="text-center">
-                    <span className="relative group cursor-pointer inline-block">
-                      {/* Tajweed coloring for each word */}
-                      <span
-                        dangerouslySetInnerHTML={{
-                    _html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
-                        }}
-                      />
-                      {/* Tooltip translation (when not showByWords) */}
-                      {!showByWords && (
-                        <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
-                          {word[wordLang as LanguageCode] as string}
-                        </span>
-                      )}
-                    </span>
-                    {/* Inline translation below the word (when showByWords) */}
-                    {showByWords && (
-                      <span
-                        className="mt-0.5 block text-gray-500 mx-1"
-                        style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
-                      >
-                        {word[wordLang as LanguageCode] as string}
-                      </span>
-                    )}
-                  </span>
-                ))}
-              </span>
-            ) : // If no word data, show whole verse with or without Tajweed
-            settings.tajweed ? (
-              <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
-            ) : (
-              verse.text_uthmani
-            )}
-          </p>
-          {/* TRANSLATIONS */}
-          {verse.translations?.map((t: Translation) => (
-            <div key={t.resource_id}>
-              <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
-                style={{ fontSize: `${settings.translationFontSize}px` }}
-                dangerouslySetInnerHTML={{ __html: t.text }}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
-    </>
-  );
+            <button
+              aria-label="More options"
+              title="More"
+              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+            >
+              <FaEllipsisH size={18} />
+            </button>
+          </div>
+        </div>
+        <div className="flex-grow space-y-6">
+          {/* ARABIC VERSE DISPLAY, WITH TAJWEED + WORD TRANSLATIONS */}
+          <p
+            className="text-right leading-loose text-[var(--foreground)]"
+            style={{
+              fontFamily: settings.arabicFontFace,
+              fontSize: `${settings.arabicFontSize}px`,
+              lineHeight: 2.2,
+            }}
+          >
+            {/* Use words if available, else fall back to plain text */}
+            {verse.words && verse.words.length > 0 ? (
+              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
+                {verse.words.map((word: Word) => (
+                  <span key={word.id} className="text-center">
+                    <span className="relative group cursor-pointer inline-block">
+                      {/* Tajweed coloring for each word */}
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
+                        }}
+                      />
+                      {/* Tooltip translation (when not showByWords) */}
+                      {!showByWords && (
+                        <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
+                          {word[wordLang as LanguageCode] as string}
+                        </span>
+                      )}
+                    </span>
+                    {/* Inline translation below the word (when showByWords) */}
+                    {showByWords && (
+                      <span
+                        className="mt-0.5 block text-gray-500 mx-1"
+                        style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
+                      >
+                        {word[wordLang as LanguageCode] as string}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </span>
+            ) : // If no word data, show whole verse with or without Tajweed
+            settings.tajweed ? (
+              <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+            ) : (
+              verse.text_uthmani
+            )}
+          </p>
+          {/* TRANSLATIONS */}
+          {verse.translations?.map((t: Translation) => (
+            <div key={t.resource_id}>
+              <p
+                className="text-left leading-relaxed text-[var(--foreground)]"
+                style={{ fontSize: `${settings.translationFontSize}px` }}
+                dangerouslySetInnerHTML={{ __html: t.text }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
 };

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -1,11 +1,11 @@
 'use client';
 import {
-  FaPlay,
-  FaPause,
-  FaBookmark,
-  FaRegBookmark,
-  FaShare,
-  FaChevronDown,
+  FaPlay,
+  FaPause,
+  FaBookmark,
+  FaRegBookmark,
+  FaShare,
+  FaChevronDown,
 } from '@/app/components/common/SvgIcons';
 import { Verse as VerseType, Translation, Word } from '@/types';
 import type { LanguageCode } from '@/lib/languageCodes';
@@ -18,181 +18,195 @@ import { getTafsirCached } from '@/lib/tafsirCache';
 import { applyArabicFont } from '@/lib/applyArabicFont';
 
 interface TafsirVerseProps {
-  verse: VerseType;
-  tafsirIds: number[];
+  verse: VerseType;
+  tafsirIds: number[];
 }
 
 export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
-  const { playingId, setPlayingId, loadingId } = useAudio();
-  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
-  const [openPanels, setOpenPanels] = useState<Record<number, boolean>>({});
-  const [tafseerTexts, setTafseerTexts] = useState<Record<number, string>>({});
-  const [loadingTafsir, setLoadingTafsir] = useState<Record<number, boolean>>({});
+  const { playingId, setPlayingId, loadingId } = useAudio();
+  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
+  const [openPanels, setOpenPanels] = useState<Record<number, boolean>>({});
+  const [tafseerTexts, setTafseerTexts] = useState<Record<number, string>>({});
+  const [loadingTafsir, setLoadingTafsir] = useState<Record<number, boolean>>({});
 
-  const showByWords = settings.showByWords ?? false;
-  const wordLang = settings.wordLang ?? 'en';
-  const isPlaying = playingId === verse.id;
-  const isLoadingAudio = loadingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
+  const showByWords = settings.showByWords ?? false;
+  const wordLang = settings.wordLang ?? 'en';
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
 
-  const togglePanel = async (id: number) => {
-    setOpenPanels((p) => ({ ...p, [id]: !p[id] }));
-    if (!openPanels[id] && !tafseerTexts[id]) {
-      setLoadingTafsir((l) => ({ ...l, [id]: true }));
-      try {
-        const text = await getTafsirCached(verse.verse_key, id);
-        setTafseerTexts((t) => ({ ...t, [id]: text }));
-      } catch {
-        setTafseerTexts((t) => ({ ...t, [id]: 'Error loading tafsir.' }));
-      } finally {
-        setLoadingTafsir((l) => ({ ...l, [id]: false }));
-      }
-    }
-  };
+  const togglePanel = async (id: number) => {
+    setOpenPanels((p) => ({ ...p, [id]: !p[id] }));
+    if (!openPanels[id] && !tafseerTexts[id]) {
+      setLoadingTafsir((l) => ({ ...l, [id]: true }));
+      try {
+        const text = await getTafsirCached(verse.verse_key, id);
+        setTafseerTexts((t) => ({ ...t, [id]: text }));
+      } catch {
+        setTafseerTexts((t) => ({ ...t, [id]: 'Error loading tafsir.' }));
+      } finally {
+        setLoadingTafsir((l) => ({ ...l, [id]: false }));
+      }
+    }
+  };
 
-  const handleShare = () => {
-    const url = typeof window !== 'undefined' ? window.location.href : '';
-    if (navigator.share) {
-      navigator.share({ title: 'Quran', url }).catch(() => {});
-    } else if (navigator.clipboard) {
-      navigator.clipboard.writeText(url).catch(() => {});
-    }
-  };
+  const handleShare = () => {
+    const url = typeof window !== 'undefined' ? window.location.href : '';
+    if (navigator.share) {
+      navigator.share({ title: 'Quran', url }).catch(() => {});
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(url).catch(() => {});
+    }
+  };
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-start gap-x-6 pb-8 border-b border-[var(--border-color)]">
-        <div className="w-16 text-center pt-1 space-y-2 flex-shrink-0">
-          <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>
-          <div className="flex flex-col items-center space-y-1 text-gray-400 dark:text-gray-500">
-            <button
-              aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
-              onClick={() =>
-                setPlayingId((currentId) => (currentId === verse.id ? null : verse.id))
-              }
-              title="Play"
-              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
-            >
-              {isLoadingAudio ? (
-                <Spinner className="h-4 w-4 text-teal-600" />
-              ) : isPlaying ? (
-                <FaPause size={18} />
-              ) : (
-                <FaPlay size={18} />
-              )}
-            </button>
-            <button
-              aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
-              title="Bookmark"
-              onClick={() => toggleBookmark(String(verse.id))}
-              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
-            >
-              {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
-            </button>
-            <button
-              aria-label="Share"
-              title="Share"
-              onClick={handleShare}
-              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
-            >
-              <FaShare size={18} />
-            </button>
-          </div>
-        </div>
-        <div className="flex-grow space-y-6">
-          <p
-            className="text-right leading-loose text-[var(--foreground)]"
-            style={{
-              fontFamily: settings.arabicFontFace,
-              fontSize: `${settings.arabicFontSize}px`,
-              lineHeight: 2.2,
-            }}
-          >
-            {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
-                {verse.words.map((word: Word) => (
-                  <span key={word.id} className="text-center">
-                    <span className="relative group cursor-pointer inline-block">
-                      <span
-                        dangerouslySetInnerHTML={{
-                          __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
-                        }}
-                      />
-                      {!showByWords && (
-                        <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
-                          {word[wordLang as LanguageCode] as string}
-                        </span>
-                      )}
-                    </span>
-                    {showByWords && (
-                      <span
-                        className="mt-0.5 block text-gray-500 mx-1"
-                        style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
-                      >
-                        {word[wordLang as LanguageCode] as string}
-                      </span>
-                    )}
-                  </span>
-                ))}
-              </span>
-            ) : settings.tajweed ? (
-              <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
-            ) : (
-              verse.text_uthmani
-            )}
-          </p>
-          {verse.translations?.map((t: Translation) => (
-            <div key={t.resource_id}>
-              <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
-                style={{ fontSize: `${settings.translationFontSize}px` }}
-                dangerouslySetInnerHTML={{ __html: t.text }}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {tafsirIds.map((id) => {
-        const open = !!openPanels[id];
-        return (
-          <div key={id} className="border-b border-[var(--border-color)] last:border-none">
-            <button
-              onClick={() => togglePanel(id)}
-              className="w-full flex items-center justify-between py-3 text-left"
-            >
-              <span className="font-semibold text-[var(--foreground)]">Tafsir {id}</span>
-              <FaChevronDown
-                size={16}
-                className={`text-gray-500 transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
-              />
-            </button>
-            <div
-              className={`grid transition-all duration-300 ease-in-out ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
-            >
-              <div className="overflow-hidden">
-                <div className="bg-teal-50 dark:bg-slate-800 rounded-md p-4 max-h-64 overflow-y-auto">
-                  {loadingTafsir[id] ? (
-                    <div className="flex justify-center py-4">
-                      <Spinner className="h-5 w-5 text-teal-600" />
-                    </div>
-                  ) : (
-                    <div
-                      className="prose max-w-none text-[var(--foreground)] whitespace-pre-wrap"
-                      style={{
-                        fontSize: `${settings.tafsirFontSize}px`,
-                      }}
-                      dangerouslySetInnerHTML={{
-                        __html: applyArabicFont(tafseerTexts[id] || '', settings.arabicFontFace),
-                      }}
-                    />
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
+  return (
+    <div className="space-y-6">
+      {' '}
+      <div className="flex items-start gap-x-6 pb-8 border-b border-[var(--border-color)]">
+        {' '}
+        <div className="w-16 text-center pt-1 space-y-2 flex-shrink-0">
+          <p className="font-semibold text-teal-600 text-sm">{verse.verse_key}</p>{' '}
+          <div className="flex flex-col items-center space-y-1 text-gray-400 dark:text-gray-500">
+            {' '}
+            <button
+              aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
+              onClick={() =>
+                setPlayingId((currentId) => (currentId === verse.id ? null : verse.id))
+              }
+              title="Play"
+              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isPlaying ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
+            >
+              {' '}
+              {isLoadingAudio ? (
+                <Spinner className="h-4 w-4 text-teal-600" />
+              ) : isPlaying ? (
+                <FaPause size={18} />
+              ) : (
+                <FaPlay size={18} />
+              )}{' '}
+            </button>{' '}
+            <button
+              aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
+              title="Bookmark"
+              onClick={() => toggleBookmark(String(verse.id))}
+              className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
+            >
+              {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}{' '}
+            </button>{' '}
+            <button
+              aria-label="Share"
+              title="Share"
+              onClick={handleShare}
+              className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+            >
+              <FaShare size={18} />{' '}
+            </button>{' '}
+          </div>{' '}
+        </div>{' '}
+        <div className="flex-grow space-y-6">
+          {' '}
+          <p
+            className="text-right leading-loose text-[var(--foreground)]"
+            style={{
+              fontFamily: settings.arabicFontFace,
+              fontSize: `${settings.arabicFontSize}px`,
+              lineHeight: 2.2,
+            }}
+          >
+            {' '}
+            {verse.words && verse.words.length > 0 ? (
+              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
+                {' '}
+                {verse.words.map((word: Word) => (
+                  <span key={word.id} className="text-center">
+                    {' '}
+                    <span className="relative group cursor-pointer inline-block">
+                      {' '}
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
+                        }}
+                      />{' '}
+                      {!showByWords && (
+                        <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
+                          {word[wordLang as LanguageCode] as string}{' '}
+                        </span>
+                      )}{' '}
+                    </span>{' '}
+                    {showByWords && (
+                      <span
+                        className="mt-0.5 block text-gray-500 mx-1"
+                        style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
+                      >
+                        {word[wordLang as LanguageCode] as string}{' '}
+                      </span>
+                    )}{' '}
+                  </span>
+                ))}{' '}
+              </span>
+            ) : settings.tajweed ? (
+              <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+            ) : (
+              verse.text_uthmani
+            )}{' '}
+          </p>{' '}
+          {verse.translations?.map((t: Translation) => (
+            <div key={t.resource_id}>
+              {' '}
+              <p
+                className="text-left leading-relaxed text-[var(--foreground)]"
+                style={{ fontSize: `${settings.translationFontSize}px` }}
+                dangerouslySetInnerHTML={{ __html: t.text }}
+              />{' '}
+            </div>
+          ))}{' '}
+        </div>{' '}
+      </div>{' '}
+      {tafsirIds.map((id) => {
+        const open = !!openPanels[id];
+        return (
+          <div key={id} className="border-b border-[var(--border-color)] last:border-none">
+            {' '}
+            <button
+              onClick={() => togglePanel(id)}
+              className="w-full flex items-center justify-between py-3 text-left"
+            >
+              {' '}
+              <span className="font-semibold text-[var(--foreground)]">Tafsir {id}</span>{' '}
+              <FaChevronDown
+                size={16}
+                className={`text-gray-500 transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
+              />{' '}
+            </button>{' '}
+            <div
+              className={`grid transition-all duration-300 ease-in-out ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
+            >
+              {' '}
+              <div className="overflow-hidden">
+                {' '}
+                <div className="bg-teal-50 dark:bg-slate-800 rounded-md p-4 max-h-64 overflow-y-auto">
+                  {' '}
+                  {loadingTafsir[id] ? (
+                    <div className="flex justify-center py-4">
+                      <Spinner className="h-5 w-5 text-teal-600" />{' '}
+                    </div>
+                  ) : (
+                    <div
+                      className="prose max-w-none text-[var(--foreground)] whitespace-pre-wrap"
+                      style={{
+                        fontSize: `${settings.tafsirFontSize}px`,
+                      }}
+                      dangerouslySetInnerHTML={{
+                        __html: applyArabicFont(tafseerTexts[id] || '', settings.arabicFontFace),
+                      }}
+                    />
+                  )}{' '}
+                </div>{' '}
+              </div>{' '}
+            </div>{' '}
+          </div>
+        );
+      })}{' '}
+    </div>
+  );
 };

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -1,10 +1,10 @@
 'use client';
 import {
-  FaPlay,
-  FaPause,
-  FaBookmark,
-  FaRegBookmark,
-  FaShare,
+  FaPlay,
+  FaPause,
+  FaBookmark,
+  FaRegBookmark,
+  FaShare,
 } from '@/app/components/common/SvgIcons';
 import { Verse as VerseType, Translation, Word } from '@/types';
 import type { LanguageCode } from '@/lib/languageCodes';
@@ -14,114 +14,123 @@ import Spinner from '@/app/components/common/Spinner';
 import { applyTajweed } from '@/lib/tajweed';
 
 interface VerseCardProps {
-  verse: VerseType;
+  verse: VerseType;
 }
 
 export default function VerseCard({ verse }: VerseCardProps) {
-  const { playingId, setPlayingId, loadingId } = useAudio();
-  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
+  const { playingId, setPlayingId, loadingId } = useAudio();
+  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
 
-  const showByWords = settings.showByWords ?? false;
-  const wordLang = settings.wordLang ?? 'en';
-  const isPlaying = playingId === verse.id;
-  const isLoadingAudio = loadingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
+  const showByWords = settings.showByWords ?? false;
+  const wordLang = settings.wordLang ?? 'en';
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
 
-  const handleShare = () => {
-    const url = typeof window !== 'undefined' ? window.location.href : '';
-    if (navigator.share) {
-      navigator.share({ title: 'Quran', url }).catch(() => {});
-    } else if (navigator.clipboard) {
-      navigator.clipboard.writeText(url).catch(() => {});
-    }
-  };
+  const handleShare = () => {
+    const url = typeof window !== 'undefined' ? window.location.href : '';
+    if (navigator.share) {
+      navigator.share({ title: 'Quran', url }).catch(() => {});
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(url).catch(() => {});
+    }
+  };
 
-  return (
-    <div className="relative flex bg-white rounded-md border shadow p-6">
-      <span className="absolute -top-3 left-4 bg-slate-100 text-xs px-3 py-0.5 rounded-full">
-        {verse.verse_key}
-      </span>
-      <div className="w-14 flex flex-col items-center space-y-2 mr-4 pt-2 text-gray-500">
-        <button
-          aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
-          onClick={() => setPlayingId((id) => (id === verse.id ? null : verse.id))}
-          className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-emerald-600' : 'hover:text-emerald-600'}`}
-        >
-          {isLoadingAudio ? (
-            <Spinner className="h-4 w-4 text-emerald-600" />
-          ) : isPlaying ? (
-            <FaPause size={18} />
-          ) : (
-            <FaPlay size={18} />
-          )}
-        </button>
-        <button
-          aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
-          onClick={() => toggleBookmark(String(verse.id))}
-          className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isBookmarked ? 'text-emerald-600' : 'hover:text-emerald-600'}`}
-        >
-          {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
-        </button>
-        <button
-          aria-label="Share"
-          onClick={handleShare}
-          className="p-1.5 rounded-full hover:bg-gray-100 hover:text-emerald-600 transition"
-        >
-          <FaShare size={18} />
-        </button>
-      </div>
-      <div className="flex-grow space-y-6">
-        <p
-          className="text-right leading-loose"
-          style={{
-            fontFamily: settings.arabicFontFace,
-            fontSize: `${settings.arabicFontSize}px`,
-            lineHeight: 2.2,
-          }}
-        >
-          {verse.words && verse.words.length > 0 ? (
-            <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
-              {verse.words.map((word: Word) => (
-                <span key={word.id} className="text-center">
-                  <span className="relative group cursor-pointer inline-block">
-                    <span
-                      dangerouslySetInnerHTML={{
-                        __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
-                      }}
-                    />
-                    {!showByWords && (
-                      <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
-                        {word[wordLang as LanguageCode] as string}
-                      </span>
-                    )}
-                  </span>
-                  {showByWords && (
-                    <span
-                      className="mt-0.5 block text-gray-500 mx-1"
-                      style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
-                    >
-                      {word[wordLang as LanguageCode] as string}
-                    </span>
-                  )}
-                </span>
-              ))}
-            </span>
-          ) : settings.tajweed ? (
-            <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
-          ) : (
-            verse.text_uthmani
-          )}
-        </p>
-        {verse.translations?.map((t: Translation) => (
-          <div key={t.resource_id}>
-            <p
-              className="text-left leading-relaxed"
-              style={{ fontSize: `${settings.translationFontSize}px` }}
-              dangerouslySetInnerHTML={{ __html: t.text }}
-            />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return (
+    <div className="relative flex bg-white rounded-md border shadow p-6">
+      {' '}
+      <span className="absolute -top-3 left-4 bg-slate-100 text-xs px-3 py-0.5 rounded-full">
+        {verse.verse_key}{' '}
+      </span>{' '}
+      <div className="w-14 flex flex-col items-center space-y-2 mr-4 pt-2 text-gray-500">
+        {' '}
+        <button
+          aria-label={isPlaying ? 'Pause audio' : 'Play audio'}
+          onClick={() => setPlayingId((id) => (id === verse.id ? null : verse.id))}
+          className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isPlaying ? 'text-emerald-600' : 'hover:text-emerald-600'}`}
+        >
+          {' '}
+          {isLoadingAudio ? (
+            <Spinner className="h-4 w-4 text-emerald-600" />
+          ) : isPlaying ? (
+            <FaPause size={18} />
+          ) : (
+            <FaPlay size={18} />
+          )}{' '}
+        </button>{' '}
+        <button
+          aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
+          onClick={() => toggleBookmark(String(verse.id))}
+          className={`p-1.5 rounded-full hover:bg-gray-100 transition ${isBookmarked ? 'text-emerald-600' : 'hover:text-emerald-600'}`}
+        >
+          {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}{' '}
+        </button>{' '}
+        <button
+          aria-label="Share"
+          onClick={handleShare}
+          className="p-1.5 rounded-full hover:bg-gray-100 hover:text-emerald-600 transition"
+        >
+          <FaShare size={18} />{' '}
+        </button>{' '}
+      </div>{' '}
+      <div className="flex-grow space-y-6">
+        {' '}
+        <p
+          className="text-right leading-loose"
+          style={{
+            fontFamily: settings.arabicFontFace,
+            fontSize: `${settings.arabicFontSize}px`,
+            lineHeight: 2.2,
+          }}
+        >
+          {' '}
+          {verse.words && verse.words.length > 0 ? (
+            <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
+              {' '}
+              {verse.words.map((word: Word) => (
+                <span key={word.id} className="text-center">
+                  {' '}
+                  <span className="relative group cursor-pointer inline-block">
+                    {' '}
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
+                      }}
+                    />{' '}
+                    {!showByWords && (
+                      <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
+                        {word[wordLang as LanguageCode] as string}{' '}
+                      </span>
+                    )}{' '}
+                  </span>{' '}
+                  {showByWords && (
+                    <span
+                      className="mt-0.5 block text-gray-500 mx-1"
+                      style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
+                    >
+                      {word[wordLang as LanguageCode] as string}{' '}
+                    </span>
+                  )}{' '}
+                </span>
+              ))}{' '}
+            </span>
+          ) : settings.tajweed ? (
+            <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+          ) : (
+            verse.text_uthmani
+          )}{' '}
+        </p>{' '}
+        {verse.translations?.map((t: Translation) => (
+          <div key={t.resource_id}>
+            {' '}
+            <p
+              className="text-left leading-relaxed"
+              style={{ fontSize: `${settings.translationFontSize}px` }}
+              dangerouslySetInnerHTML={{ __html: t.text }}
+            />{' '}
+          </div>
+        ))}{' '}
+      </div>{' '}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fix verse word rendering by using `__html`
- normalize spacing in tafsir components

## Testing
- `npm run lint -- --file app/features/surah/[surahId]/_components/Verse.tsx`
- `npm run lint -- --file app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx`
- `npm run lint -- --file app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx`
- `npm run type-check`
- `npm test`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_b_688db49e882c8332b5e424b1ab7a9446