### PR TITLE
Limit settings panels and tafsir access

### DIFF
--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -55,9 +55,7 @@ describe('SettingsSidebar interactions', () => {
         <SettingsSidebar
           onTranslationPanelOpen={() => {}}
           onWordLanguagePanelOpen={() => {}}
-          onTafsirPanelOpen={() => {}}
           selectedTranslationName="English"
-          selectedTafsirName="English, Urdu"
           selectedWordLanguageName="English"
         />
       </Wrapper>
@@ -94,9 +92,7 @@ describe('SettingsSidebar interactions', () => {
           <SettingsSidebar
             onTranslationPanelOpen={() => setOpen(true)}
             onWordLanguagePanelOpen={() => {}}
-            onTafsirPanelOpen={() => {}}
             selectedTranslationName="English"
-            selectedTafsirName="English, Urdu"
             selectedWordLanguageName="English"
           />
           <TranslationPanel
@@ -130,9 +126,7 @@ describe('SettingsSidebar interactions', () => {
           <SettingsSidebar
             onTranslationPanelOpen={() => {}}
             onWordLanguagePanelOpen={() => setOpen(true)}
-            onTafsirPanelOpen={() => {}}
             selectedTranslationName="English"
-            selectedTafsirName="English, Urdu"
             selectedWordLanguageName="Bangla"
           />
           <WordLanguagePanel

--- a/app/components/common/SvgIcons.tsx
+++ b/app/components/common/SvgIcons.tsx
@@ -30,6 +30,26 @@ export const FaBookReader = ({ size = 18, className = '' }) => (
     <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
   </svg>
 );
+export const FaTranslation = ({ size = 20, className = '' }) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m5 8 6 6" />
+    <path d="m4 14 6-6 2-3" />
+    <path d="M2 5h12" />
+    <path d="M7 2h1" />
+    <path d="m22 22-5-10-5 10" />
+    <path d="M14 18h6" />
+  </svg>
+);
 export const FaBars = ({ size = 20, className = '' }) => (
   <svg className={className} width={size} height={size} viewBox="0 0 448 512" fill="currentColor">
     <path d="M16 132h416v56H16zm0 96h416v56H16zm0 96h416v56H16z" />

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -6,11 +6,9 @@ import { useTranslation } from 'react-i18next';
 import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
 import { TranslationPanel } from '@/app/features/surah/[surahId]/_components/TranslationPanel';
-import { TafsirPanel } from '@/app/features/surah/[surahId]/_components/TafsirPanel';
 import { WordLanguagePanel } from '@/app/features/surah/[surahId]/_components/WordLanguagePanel';
 import { Verse as VerseType, TranslationResource, Juz } from '@/types';
 import { getTranslations, getWordTranslations, getVersesByJuz, getJuz } from '@/lib/api';
-import { getTafsirResources } from '@/lib/api';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
@@ -34,7 +32,6 @@ export default function JuzPage({ params }: JuzPageProps) {
   const { playingId, setPlayingId } = useAudio();
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
   const [translationSearchTerm, setTranslationSearchTerm] = useState('');
-  const [isTafsirPanelOpen, setIsTafsirPanelOpen] = useState(false);
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
   const [wordTranslationSearchTerm, setWordTranslationSearchTerm] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -47,8 +44,6 @@ export default function JuzPage({ params }: JuzPageProps) {
 
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
-  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
-  const tafsirOptions = useMemo(() => tafsirOptionsData || [], [tafsirOptionsData]);
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
@@ -103,13 +98,6 @@ export default function JuzPage({ params }: JuzPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedTafsirName = useMemo(() => {
-    const names = settings.tafsirIds
-      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
-      .filter(Boolean)
-      .slice(0, 3);
-    return names.length ? names.join(', ') : t('select_tafsir');
-  }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
       wordLanguageOptions.find(
@@ -205,10 +193,8 @@ export default function JuzPage({ params }: JuzPageProps) {
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
-        onTafsirPanelOpen={() => setIsTafsirPanelOpen(true)}
         onReadingPanelOpen={() => {}}
         selectedTranslationName={selectedTranslationName}
-        selectedTafsirName={selectedTafsirName}
         selectedWordLanguageName={selectedWordLanguageName}
       />
 
@@ -234,7 +220,6 @@ export default function JuzPage({ params }: JuzPageProps) {
           });
         }}
       />
-      <TafsirPanel isOpen={isTafsirPanelOpen} onClose={() => setIsTafsirPanelOpen(false)} />
     </div>
   );
 }

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -5,15 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Verse } from '@/app/features/surah/[surahId]/_components/Verse';
 import { SettingsSidebar } from '@/app/features/surah/[surahId]/_components/SettingsSidebar';
 import { TranslationPanel } from '@/app/features/surah/[surahId]/_components/TranslationPanel';
-import { TafsirPanel } from '@/app/features/surah/[surahId]/_components/TafsirPanel';
 import { WordLanguagePanel } from '@/app/features/surah/[surahId]/_components/WordLanguagePanel';
 import { Verse as VerseType, TranslationResource } from '@/types';
-import {
-  getTranslations,
-  getWordTranslations,
-  getVersesByPage,
-  getTafsirResources,
-} from '@/lib/api';
+import { getTranslations, getWordTranslations, getVersesByPage } from '@/lib/api';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
@@ -37,15 +31,12 @@ export default function QuranPage({ params }: QuranPageProps) {
   const { playingId, setPlayingId } = useAudio();
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
   const [translationSearchTerm, setTranslationSearchTerm] = useState('');
-  const [isTafsirPanelOpen, setIsTafsirPanelOpen] = useState(false);
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
   const [wordTranslationSearchTerm, setWordTranslationSearchTerm] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
-  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
-  const tafsirOptions = useMemo(() => tafsirOptionsData || [], [tafsirOptionsData]);
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
@@ -99,13 +90,6 @@ export default function QuranPage({ params }: QuranPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedTafsirName = useMemo(() => {
-    const names = settings.tafsirIds
-      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
-      .filter(Boolean)
-      .slice(0, 3);
-    return names.length ? names.join(', ') : t('select_tafsir');
-  }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
       wordLanguageOptions.find(
@@ -181,10 +165,8 @@ export default function QuranPage({ params }: QuranPageProps) {
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
-        onTafsirPanelOpen={() => setIsTafsirPanelOpen(true)}
         onReadingPanelOpen={() => {}}
         selectedTranslationName={selectedTranslationName}
-        selectedTafsirName={selectedTafsirName}
         selectedWordLanguageName={selectedWordLanguageName}
       />
 
@@ -210,7 +192,6 @@ export default function QuranPage({ params }: QuranPageProps) {
           });
         }}
       />
-      <TafsirPanel isOpen={isTafsirPanelOpen} onClose={() => setIsTafsirPanelOpen(false)} />
     </div>
   );
 }

--- a/app/features/surah/[surahId]/_components/CollapsibleSection.tsx
+++ b/app/features/surah/[surahId]/_components/CollapsibleSection.tsx
@@ -1,6 +1,5 @@
 // app/surah/[surahId]/_components/CollapsibleSection.tsx
 'use client';
-import { useState } from 'react';
 import { FaChevronDown } from '@/app/components/common/SvgIcons';
 
 interface CollapsibleSectionProps {
@@ -8,6 +7,8 @@ interface CollapsibleSectionProps {
   icon: React.ReactNode;
   children: React.ReactNode;
   isLast?: boolean; // Optional prop to indicate if it's the last section
+  isOpen: boolean;
+  onToggle: () => void;
 }
 
 export const CollapsibleSection = ({
@@ -15,16 +16,14 @@ export const CollapsibleSection = ({
   icon,
   children,
   isLast = false,
+  isOpen,
+  onToggle,
 }: CollapsibleSectionProps) => {
-  const [isOpen, setIsOpen] = useState(true);
   return (
     <div className={isLast ? '' : 'border-b border-[var(--border-color)]'}>
       {' '}
       {/* Apply border only if not the last section */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between p-4 text-left"
-      >
+      <button onClick={onToggle} className="w-full flex items-center justify-between p-4 text-left">
         <div className="flex items-center space-x-3">
           {icon}
           <span className="font-semibold text-[var(--foreground)]">{title}</span>

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -4,6 +4,7 @@ import {
   FaFontSetting,
   FaChevronDown,
   FaArrowLeft,
+  FaTranslation,
 } from '@/app/components/common/SvgIcons';
 import { CollapsibleSection } from './CollapsibleSection';
 import { useSettings } from '@/app/context/SettingsContext';
@@ -16,11 +17,12 @@ import { useTheme } from '@/app/context/ThemeContext';
 interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
   onWordLanguagePanelOpen: () => void;
-  onTafsirPanelOpen: () => void;
+  onTafsirPanelOpen?: () => void;
   onReadingPanelOpen?: () => void;
   selectedTranslationName: string;
-  selectedTafsirName: string;
+  selectedTafsirName?: string;
   selectedWordLanguageName: string;
+  showTafsirSetting?: boolean;
 }
 
 export const SettingsSidebar = ({
@@ -31,6 +33,7 @@ export const SettingsSidebar = ({
   selectedTranslationName,
   selectedTafsirName,
   selectedWordLanguageName,
+  showTafsirSetting = false,
 }: SettingsSidebarProps) => {
   const { settings, setSettings, arabicFonts } = useSettings();
   const { t } = useTranslation();
@@ -38,6 +41,7 @@ export const SettingsSidebar = ({
   const { isSettingsOpen, setSettingsOpen } = useSidebar();
   const { theme, setTheme } = useTheme();
   const [activeTab, setActiveTab] = useState('translation');
+  const [openPanels, setOpenPanels] = useState<string[]>(['reading', 'font']);
 
   // Helper function to calculate the slider's progress percentage
   const getPercentage = (value: number, min: number, max: number) => {
@@ -59,6 +63,22 @@ export const SettingsSidebar = ({
       onReadingPanelOpen?.();
     }
   };
+
+  const togglePanel = (panel: string) => {
+    setOpenPanels((prev) => {
+      if (prev.includes(panel)) {
+        return prev.filter((p) => p !== panel);
+      }
+      if (prev.length >= 2) {
+        return [prev[0], panel];
+      }
+      return [...prev, panel];
+    });
+  };
+
+  const isReadingOpen = openPanels.includes('reading');
+  const isTafsirOpen = openPanels.includes('tafsir');
+  const isFontOpen = openPanels.includes('font');
 
   return (
     <>
@@ -107,8 +127,10 @@ export const SettingsSidebar = ({
           {activeTab === 'translation' && (
             <CollapsibleSection
               title={t('reading_setting')}
-              icon={<FaBookReader size={20} className="text-teal-700" />}
+              icon={<FaTranslation size={20} className="text-teal-700" />}
               isLast={false}
+              isOpen={isReadingOpen}
+              onToggle={() => togglePanel('reading')}
             >
               <div className="space-y-4">
                 <div className="flex items-center justify-between pt-2">
@@ -169,11 +191,13 @@ export const SettingsSidebar = ({
               </div>
             </CollapsibleSection>
           )}
-          {activeTab === 'translation' && (
+          {activeTab === 'translation' && showTafsirSetting && (
             <CollapsibleSection
               title={t('tafsir_setting')}
               icon={<FaBookReader size={20} className="text-teal-700" />}
               isLast={false}
+              isOpen={isTafsirOpen}
+              onToggle={() => togglePanel('tafsir')}
             >
               <div className="space-y-4">
                 <div>
@@ -210,6 +234,8 @@ export const SettingsSidebar = ({
               title={t('font_setting')}
               icon={<FaFontSetting size={20} className="text-teal-700" />}
               isLast={true}
+              isOpen={isFontOpen}
+              onToggle={() => togglePanel('font')}
             >
               <div className="space-y-4">
                 <div>

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -5,11 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Verse } from './_components/Verse';
 import { SettingsSidebar } from './_components/SettingsSidebar';
 import { TranslationPanel } from './_components/TranslationPanel';
-import { TafsirPanel } from './_components/TafsirPanel';
 import { WordLanguagePanel } from './_components/WordLanguagePanel';
 import { Verse as VerseType, TranslationResource } from '@/types';
 import { getTranslations, getWordTranslations, getVersesByChapter } from '@/lib/api';
-import { getTafsirResources } from '@/lib/api';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
@@ -34,7 +32,6 @@ export default function SurahPage({ params }: SurahPageProps) {
   const { playingId, setPlayingId, setLoadingId } = useAudio();
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
   const [translationSearchTerm, setTranslationSearchTerm] = useState('');
-  const [isTafsirPanelOpen, setIsTafsirPanelOpen] = useState(false);
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
   const [wordTranslationSearchTerm, setWordTranslationSearchTerm] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -44,9 +41,6 @@ export default function SurahPage({ params }: SurahPageProps) {
 
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
-
-  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
-  const tafsirOptions = useMemo(() => tafsirOptionsData || [], [tafsirOptionsData]);
 
   const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
   const wordLanguageMap = useMemo(() => {
@@ -101,13 +95,6 @@ export default function SurahPage({ params }: SurahPageProps) {
       t('select_translation'),
     [settings.translationId, translationOptions, t]
   );
-  const selectedTafsirName = useMemo(() => {
-    const names = settings.tafsirIds
-      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
-      .filter(Boolean)
-      .slice(0, 3);
-    return names.length ? names.join(', ') : t('select_tafsir');
-  }, [settings.tafsirIds, tafsirOptions, t]);
   const selectedWordLanguageName = useMemo(
     () =>
       wordLanguageOptions.find(
@@ -186,10 +173,8 @@ export default function SurahPage({ params }: SurahPageProps) {
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
-        onTafsirPanelOpen={() => setIsTafsirPanelOpen(true)}
         onReadingPanelOpen={() => {}}
         selectedTranslationName={selectedTranslationName}
-        selectedTafsirName={selectedTafsirName}
         selectedWordLanguageName={selectedWordLanguageName}
       />
       <TranslationPanel
@@ -214,7 +199,6 @@ export default function SurahPage({ params }: SurahPageProps) {
           });
         }}
       />
-      <TafsirPanel isOpen={isTafsirPanelOpen} onClose={() => setIsTafsirPanelOpen(false)} />
     </div>
   );
 }

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -268,6 +268,7 @@ export default function TafsirVersePage() {
         selectedTranslationName={selectedTranslationName}
         selectedTafsirName={selectedTafsirName}
         selectedWordLanguageName={selectedWordLanguageName}
+        showTafsirSetting
       />
       <TranslationPanel
         isOpen={isTranslationPanelOpen}


### PR DESCRIPTION
## Summary
- limit concurrent settings sections to two and remove tafsir options from non-tafsir pages
- show tafsir settings only on Tafsir page
- use translation icon for reading settings

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688e13e6032c83329134dc4b9015d066