### PR TITLE
style: increase spacing between word translations

### DIFF
--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -93,7 +93,7 @@ export const Verse = ({ verse }: VerseProps) => {
           >
             {/* Use words if available, else fall back to plain text */}
             {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
+              <span className="flex flex-wrap gap-x-3 gap-y-1 justify-end">
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">
                     <span className="relative group cursor-pointer inline-block">


### PR DESCRIPTION
## Summary
- increase gap between Arabic words to give translations more breathing room

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688e179d91048332ba2939315623ecaf