### PR TITLE
Sort language lists alphabetically

### DIFF
--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -1,6 +1,7 @@
 // app/features/surah/[SurahId]/_components/TranslationPanel.tsx
 import { FaArrowLeft, FaSearch } from '@/app/components/common/SvgIcons';
 import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
 import { TranslationResource } from '@/types';
 import { useSettings } from '@/app/context/SettingsContext';
 
@@ -21,6 +22,13 @@ export const TranslationPanel = ({
 }: TranslationPanelProps) => {
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
+  const sortedLanguages = useMemo(() => {
+    return Object.keys(groupedTranslations).sort((a, b) => {
+      if (a.toLowerCase() === 'english') return -1;
+      if (b.toLowerCase() === 'english') return 1;
+      return a.localeCompare(b);
+    });
+  }, [groupedTranslations]);
   return (
     <>
       {/* Removed the overlay div */}
@@ -54,7 +62,7 @@ export const TranslationPanel = ({
         </div>
         <div className="flex-grow overflow-y-auto">
           {groupedTranslations &&
-            Object.keys(groupedTranslations).map((lang) => (
+            sortedLanguages.map((lang) => (
               <div key={lang}>
                 <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm">
                   {lang}

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { FaArrowLeft, FaSearch } from '@/app/components/common/SvgIcons';
 import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
 import { useSettings } from '@/app/context/SettingsContext';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import type { LanguageCode } from '@/lib/languageCodes';
@@ -30,8 +31,14 @@ export const WordLanguagePanel = ({
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
 
-  const filtered = languages.filter((lang) =>
-    lang.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const sortedLanguages = useMemo(
+    () => [...languages].sort((a, b) => a.name.localeCompare(b.name)),
+    [languages]
+  );
+  const filtered = useMemo(
+    () =>
+      sortedLanguages.filter((lang) => lang.name.toLowerCase().includes(searchTerm.toLowerCase())),
+    [sortedLanguages, searchTerm]
   );
 
   return (


### PR DESCRIPTION
## Summary
- order translation languages alphabetically after English
- alphabetize word-by-word translation languages

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688e186e7354833281b3b02a9d4ae03d