### PR TITLE
Expand surah grid width on home page

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -47,7 +47,7 @@ export default function HomePage() {
         <div className="relative z-10 flex flex-col h-full overflow-y-auto px-4 sm:px-6 lg:px-8 homepage-scrollable-area">
           <header className="w-full py-4">
             <nav
-              className={`flex justify-between items-center max-w-7xl mx-auto p-3 sm:p-4 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/50'}`}
+              className={`flex justify-between items-center max-w-screen-2xl mx-auto p-3 sm:p-4 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/50'}`}
             >
               <h1
                 className={`text-2xl font-bold tracking-wider ${theme === 'light' ? 'text-slate-900' : 'text-white'}`}
@@ -116,7 +116,7 @@ export default function HomePage() {
             <VerseOfDay />
           </main>
 
-          <section id="surahs" className="py-20 max-w-7xl mx-auto w-full">
+          <section id="surahs" className="py-20 max-w-screen-2xl mx-auto w-full">
             <div className="flex justify-between items-center mb-8 content-visibility-auto animate-fade-in-up animation-delay-600">
               <h2 className="text-3xl font-bold text-slate-900 dark:text-white">All Surahs</h2>
               <div


### PR DESCRIPTION
## Summary
- widen navigation bar and surah grid containers for large screens

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e195c3040833295405c54f3bbb53d