### PR TITLE
Test getRandomVerse

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,5 +1,5 @@
-import { getJuz, API_BASE_URL } from '@/lib/api';
-import { Juz } from '@/types';
+import { getJuz, API_BASE_URL, getRandomVerse } from '@/lib/api';
+import { Juz, Verse } from '@/types';
 
 describe('getJuz', () => {
   afterEach(() => {
@@ -29,5 +29,49 @@ describe('getJuz', () => {
   it('throws on fetch error', async () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as jest.Mock;
     await expect(getJuz(1)).rejects.toThrow('Failed to fetch juz: 404');
+  });
+});
+
+describe('getRandomVerse', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('normalizes random verse data', async () => {
+    const mockRaw: Verse & { words: any[] } = {
+      id: 1,
+      verse_key: '1:1',
+      text_uthmani: 'test',
+      words: [
+        { id: 1, text_uthmani: 'foo', translation: { text: 'bar' } },
+        { id: 2, text: 'baz', translation: { text: 'qux' } },
+      ],
+    } as any;
+
+    const expected: Verse = {
+      id: 1,
+      verse_key: '1:1',
+      text_uthmani: 'test',
+      words: [
+        { id: 1, uthmani: 'foo', en: 'bar' },
+        { id: 2, uthmani: 'baz', en: 'qux' },
+      ],
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ verse: mockRaw }),
+    }) as jest.Mock;
+
+    const result = await getRandomVerse(20);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE_URL}/verses/random?translations=20&fields=text_uthmani`
+    );
+    expect(result).toEqual(expected);
+  });
+
+  it('throws on fetch error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as jest.Mock;
+    await expect(getRandomVerse(20)).rejects.toThrow('Failed to fetch random verse: 500');
   });
 });


### PR DESCRIPTION
## Summary
- add tests for getRandomVerse to check normalization of API responses
- ensure non-OK random verse responses throw errors

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f5b46c4288332812bc515768bd59e