### PR TITLE
Remove duplicate tafsir cache from api module

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,9 +3,6 @@ const API_BASE_URL = process.env.QURAN_API_BASE_URL ?? 'https://api.quran.com/ap
 import { Chapter, TranslationResource, Verse, Juz, Word } from '@/types';
 import type { LanguageCode } from '@/lib/languageCodes';
 
-// Caching tafsir responses for efficiency
-const tafsirCache = new Map<string, string>();
-
 // API response word shape
 interface ApiWord {
   id: number;
@@ -143,24 +140,6 @@ export async function getTafsirByVerse(verseKey: string, tafsirId = 169): Promis
   }
   const data = await res.json();
   return data.tafsir?.text as string;
-}
-
-// Fetch tafsir with cache (for repeated access)
-export async function getTafsirCached(verseKey: string, id: string): Promise<string> {
-  const key = `${id}:${verseKey}`;
-  if (tafsirCache.has(key)) {
-    return tafsirCache.get(key)!;
-  }
-  const res = await fetch(
-    `${API_BASE_URL}/tafsirs/${id}?verse_key=${encodeURIComponent(verseKey)}`
-  );
-  if (!res.ok) {
-    throw new Error(`Failed to fetch tafsir: ${res.status}`);
-  }
-  const data = await res.json();
-  const text = data.tafsir?.text as string;
-  tafsirCache.set(key, text);
-  return text;
 }
 
 // Get verses by Juz (section)


### PR DESCRIPTION
## Summary
- remove duplicate tafsir cache from API module

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f6c1efaa0833292e31c6f83db5b13