### PR TITLE
Document normalizeVerse helper

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -20,7 +20,13 @@ interface ApiVerse extends Omit<Verse, 'words'> {
   words?: ApiWord[];
 }
 
-// Normalize API verse to app shape
+/**
+ * Converts API verse and word objects into the internal {@link Verse} format.
+ *
+ * @param raw - Verse object returned from the API. May include word entries.
+ * @param wordLang - Language to use for each word's translation. Defaults to English.
+ * @returns The normalized verse with translated words.
+ */
 function normalizeVerse(raw: ApiVerse, wordLang: LanguageCode = 'en'): Verse {
   return {
     ...raw,


### PR DESCRIPTION
## Summary
- add JSDoc for normalizeVerse to explain conversion to internal Verse

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f6c44e02483329cfef34b1d73733f