### PR TITLE
Refactor stripHtml helper

### DIFF
--- a/__tests__/stripHtml.test.ts
+++ b/__tests__/stripHtml.test.ts
@@ -1,0 +1,12 @@
+import { stripHtml } from '../lib/stripHtml';
+
+describe('stripHtml', () => {
+  it('removes HTML tags and returns plain text', () => {
+    const input = '<p>Hello <strong>world</strong></p>';
+    expect(stripHtml(input)).toBe('Hello world');
+  });
+
+  it('handles strings with only tags', () => {
+    expect(stripHtml('<div><span></span></div>')).toBe('');
+  });
+});

--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -8,16 +8,9 @@ import surahsData from '@/data/surahs.json';
 import type { Surah } from '@/types';
 import { useTheme } from '@/app/context/ThemeContext';
 import { applyTajweed } from '@/lib/tajweed';
+import { stripHtml } from '@/lib/stripHtml';
 
 const surahs: Surah[] = surahsData;
-
-function stripHtml(html: string): string {
-  if (typeof window !== 'undefined') {
-    const doc = new DOMParser().parseFromString(html, 'text/html');
-    return doc.body.textContent || '';
-  }
-  return html.replace(/<[^>]*>/g, '');
-}
 
 export default function VerseOfDay() {
   const { settings } = useSettings();

--- a/lib/stripHtml.ts
+++ b/lib/stripHtml.ts
@@ -1,0 +1,13 @@
+/**
+ * Removes HTML tags from a string.
+ *
+ * @param html - The HTML string to clean.
+ * @returns The plain text content with all tags removed.
+ */
+export function stripHtml(html: string): string {
+  if (typeof window !== 'undefined') {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return doc.body.textContent || '';
+  }
+  return html.replace(/<[^>]*>/g, '');
+}


### PR DESCRIPTION
## Summary
- extract stripHtml utility to strip HTML tags
- use helper in VerseOfDay component
- test stripHtml removes tags

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f7307a0188332930e79e7ae09630c