### PR TITLE
Test translation fetch helpers

### DIFF
--- a/__tests__/translations.test.ts
+++ b/__tests__/translations.test.ts
@@ -1,0 +1,56 @@
+import { getTranslations, getWordTranslations, API_BASE_URL } from '@/lib/api';
+import { TranslationResource } from '@/types';
+
+describe('getTranslations', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetches translations', async () => {
+    const mockTranslations: TranslationResource[] = [
+      { id: 1, name: 'Saheeh', language_name: 'English' },
+    ];
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ translations: mockTranslations }),
+    }) as jest.Mock;
+
+    const result = await getTranslations();
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE_URL}/resources/translations`);
+    expect(result).toEqual(mockTranslations);
+  });
+
+  it('throws on fetch error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as jest.Mock;
+    await expect(getTranslations()).rejects.toThrow('Failed to fetch translations: 500');
+  });
+});
+
+describe('getWordTranslations', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetches word-by-word translations', async () => {
+    const mockTranslations: TranslationResource[] = [
+      { id: 1, name: 'WBW', language_name: 'English' },
+    ];
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ translations: mockTranslations }),
+    }) as jest.Mock;
+
+    const result = await getWordTranslations();
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE_URL}/resources/translations?resource_type=word_by_word`
+    );
+    expect(result).toEqual(mockTranslations);
+  });
+
+  it('throws on fetch error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as jest.Mock;
+    await expect(getWordTranslations()).rejects.toThrow('Failed to fetch translations: 404');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for translation resource helpers to confirm correct endpoints and error handling

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f7309d0dc8332b8e8a60368661458