### PR TITLE
Document and test clearTafsirCache

### DIFF
--- a/__tests__/tafsirCache.test.ts
+++ b/__tests__/tafsirCache.test.ts
@@ -35,6 +35,19 @@ describe('getTafsirCached', () => {
     spy.mockRestore();
   });
 
+  it('forces subsequent fetch after cache is cleared', async () => {
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('text1');
+    await getTafsirCached('1:1', 1);
+    expect(getTafsirByVerse).toHaveBeenCalledTimes(1);
+
+    clearTafsirCache();
+
+    (getTafsirByVerse as jest.Mock).mockResolvedValue('text2');
+    await getTafsirCached('1:1', 1);
+
+    expect(getTafsirByVerse).toHaveBeenCalledTimes(2);
+  });
+
   it('removes oldest when max size exceeded', async () => {
     const spy = jest.spyOn(Date, 'now').mockReturnValue(0);
     for (let i = 0; i < MAX_CACHE_SIZE; i++) {

--- a/lib/tafsirCache.ts
+++ b/lib/tafsirCache.ts
@@ -45,6 +45,9 @@ export function getTafsirCached(verseKey: string, tafsirId = 169): Promise<strin
   return value;
 }
 
+/**
+ * Empties the in-memory tafsir cache.
+ */
 export function clearTafsirCache() {
   cache.clear();
 }


### PR DESCRIPTION
## Summary
- document the function that empties the tafsir cache
- add test verifying cache is cleared and refreshed

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f7857dc18833282faae4730c0a8d6