### PR TITLE
Fix verse alignment on Juz and page views

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -127,8 +127,8 @@ export default function JuzPage({ params }: JuzPageProps) {
 
   return (
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
-        <div className="max-w-4xl mx-auto relative">
+      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+        <div className="w-full relative">
           {/* Only render content when juzId is available */}
           {juzId ? (
             isLoading ? (

--- a/app/features/juz/layout.tsx
+++ b/app/features/juz/layout.tsx
@@ -1,4 +1,5 @@
 // app/features/juz/layout.tsx
+'use client';
 import Header from '@/app/components/common/Header';
 import IconSidebar from '@/app/components/common/IconSidebar';
 import SurahListSidebar from '@/app/components/common/SurahListSidebar';
@@ -10,8 +11,12 @@ export default function JuzLayout({ children }: { children: React.ReactNode }) {
       <Header />
       <div className="h-screen flex flex-col pt-16">
         <div className="flex flex-grow overflow-hidden">
-          <IconSidebar />
-          <SurahListSidebar />
+          <nav aria-label="Primary navigation" className="flex-shrink-0">
+            <IconSidebar />
+          </nav>
+          <nav aria-label="Surah navigation" className="flex-shrink-0">
+            <SurahListSidebar />
+          </nav>
           {children}
         </div>
       </div>

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -119,8 +119,8 @@ export default function QuranPage({ params }: QuranPageProps) {
 
   return (
     <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto">
-        <div className="max-w-4xl mx-auto relative">
+      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+        <div className="w-full relative">
           {/* Only render content when pageId is available */}
           {pageId ? (
             isLoading ? (

--- a/app/features/page/layout.tsx
+++ b/app/features/page/layout.tsx
@@ -1,4 +1,5 @@
 // app/features/page/layout.tsx
+'use client';
 import Header from '@/app/components/common/Header';
 import IconSidebar from '@/app/components/common/IconSidebar';
 import SurahListSidebar from '@/app/components/common/SurahListSidebar';
@@ -10,8 +11,12 @@ export default function PageLayout({ children }: { children: React.ReactNode }) 
       <Header />
       <div className="h-screen flex flex-col pt-16">
         <div className="flex flex-grow overflow-hidden">
-          <IconSidebar />
-          <SurahListSidebar />
+          <nav aria-label="Primary navigation" className="flex-shrink-0">
+            <IconSidebar />
+          </nav>
+          <nav aria-label="Surah navigation" className="flex-shrink-0">
+            <SurahListSidebar />
+          </nav>
           {children}
         </div>
       </div>

--- a/app/features/surah/layout.tsx
+++ b/app/features/surah/layout.tsx
@@ -11,10 +11,10 @@ export default function SurahLayout({ children }: { children: React.ReactNode })
       <Header />
       <div className="h-screen flex flex-col pt-16">
         <div className="flex flex-grow overflow-hidden">
-          <nav aria-label="Primary navigation">
+          <nav aria-label="Primary navigation" className="flex-shrink-0">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation">
+          <nav aria-label="Surah navigation" className="flex-shrink-0">
             <SurahListSidebar />
           </nav>
           {children}


### PR DESCRIPTION
## Summary
- Keep feature sidebars from shrinking by wrapping IconSidebar and SurahListSidebar in non-flexing nav elements

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688f848ebad48332be457c269cea2757