### PR TITLE
Add glass blur style to header

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -27,7 +27,7 @@ const Header = () => {
   return (
     // Adjusted background, padding, and grid layout for cleaner look
     <header
-      className="fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-sm shadow-sm z-30"
+      className="fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-md shadow-sm z-30"
       style={{
         backgroundColor: 'var(--header-background)',
         color: 'var(--header-text-color)',

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,7 @@
   --subtle-grey: #d1d5db;
 
   /* Header variables for light mode */
-  --header-background: rgba(255, 255, 255, 0.8);
+  --header-background: rgba(255, 255, 255, 0.3);
   --header-text-color: #1f2937;
 }
 
@@ -21,7 +21,7 @@
   --subtle-grey: #4b5563;
 
   /* Header variables for dark mode */
-  --header-background: rgba(31, 41, 55, 0.8);
+  --header-background: rgba(31, 41, 55, 0.3);
   --header-text-color: #f9fafb;
 }
 


### PR DESCRIPTION
## Summary
- make header use stronger blur
- lighten header background for glass effect

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_b_688fae195e108332bf3cf97367951fcd