### PR TITLE
feat: make header sticky with translucent blur

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -27,7 +27,7 @@ const Header = () => {
   return (
     // Adjusted background, padding, and grid layout for cleaner look
     <header
-      className="fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-md shadow-sm z-30"
+      className="sticky top-0 w-full h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur border-b border-white/20 dark:border-gray-700 shadow-sm z-30"
       style={{
         backgroundColor: 'var(--header-background)',
         color: 'var(--header-text-color)',

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,7 @@
   --subtle-grey: #d1d5db;
 
   /* Header variables for light mode */
-  --header-background: rgba(255, 255, 255, 0.3);
+  --header-background: rgba(255, 255, 255, 0.4);
   --header-text-color: #1f2937;
 }
 
@@ -21,7 +21,7 @@
   --subtle-grey: #4b5563;
 
   /* Header variables for dark mode */
-  --header-background: rgba(31, 41, 55, 0.3);
+  --header-background: rgba(31, 41, 55, 0.4);
   --header-text-color: #f9fafb;
 }
 


### PR DESCRIPTION
## Summary
- make header sticky with backdrop blur and subtle border
- increase header background opacity for light and dark modes

## Testing
- `nvm use`
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688fb749169883328569eae0cce5de3a