### PR TITLE
Test fetchVerses error path

### DIFF
--- a/__tests__/getVerses.test.ts
+++ b/__tests__/getVerses.test.ts
@@ -41,6 +41,13 @@ describe('fetchVerses', () => {
       ],
     });
   });
+
+  it('throws an error when the response is not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as jest.Mock;
+    await expect(fetchVerses('by_chapter', 1, 20, 1, 1, 'en')).rejects.toThrow(
+      'Failed to fetch verses: 500'
+    );
+  });
 });
 
 describe('getVersesByChapter', () => {


### PR DESCRIPTION
## Summary
- add test asserting fetchVerses throws when fetch fails with 500

## Testing
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688fbea29d488332a5f6ffac2de53d5b