### PR TITLE
Use pure white background for Surah page

### DIFF
--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -123,8 +123,8 @@ export default function SurahPage({ params }: SurahPageProps) {
   );
 
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {isLoading ? (
             <div className="flex justify-center py-20">

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,7 @@
 @import 'tailwindcss';
 
 :root {
-  --background: #f7f9f9;
+  --background: #ffffff;
   --foreground: #374151;
   --border-color: #e5e7eb;
   --accent: #0d9488;


### PR DESCRIPTION
## Summary
- set light theme background variable to pure white
- render Surah page content on a white background for light mode

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Type 'JuzPageProps' does not satisfy the constraint 'PageProps')*

------
https://chatgpt.com/codex/tasks/task_b_688fcb350a1c8332b86efc23ca88ae0e