### PR TITLE
Allow Surah content to scroll under header

### DIFF
--- a/app/features/surah/layout.tsx
+++ b/app/features/surah/layout.tsx
@@ -9,8 +9,8 @@ export default function SurahLayout({ children }: { children: React.ReactNode })
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col pt-16">
-        <div className="flex flex-grow overflow-hidden">
+      <div className="h-screen flex flex-col">
+        <div className="flex flex-grow overflow-hidden mt-16">
           <nav aria-label="Primary navigation" className="flex-shrink-0">
             <IconSidebar />
           </nav>


### PR DESCRIPTION
## Summary
- remove fixed padding from Surah layout container
- offset content with margin so Surah text can scroll under transparent header

## Testing
- `npm run format`
- `npm run lint`
- `npm audit --omit=dev`
- `npm run check`
- `node -e "const {chromium}=require('playwright');(async()=>{const browser=await chromium.launch();const page=await browser.newPage();await page.goto('http://localhost:3000/features/surah/1');await page.waitForSelector('main');await page.evaluate(()=>window.scrollBy(0,200));await page.screenshot({path:'/tmp/surah_after.png'});await browser.close();})();"`

------
https://chatgpt.com/codex/tasks/task_b_688fcb3631ec833293e559abba06af4b