### PR TITLE
Fix Surah header transparency and scrolling

### DIFF
--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -124,7 +124,7 @@ export default function SurahPage({ params }: SurahPageProps) {
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 pt-16 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {isLoading ? (
             <div className="flex justify-center py-20">

--- a/app/features/surah/layout.tsx
+++ b/app/features/surah/layout.tsx
@@ -10,11 +10,11 @@ export default function SurahLayout({ children }: { children: React.ReactNode })
     <AudioProvider>
       <Header />
       <div className="h-screen flex flex-col">
-        <div className="flex flex-grow overflow-hidden mt-16">
-          <nav aria-label="Primary navigation" className="flex-shrink-0">
+        <div className="flex flex-grow overflow-hidden">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 pt-16">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 pt-16">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,7 @@
   --subtle-grey: #d1d5db;
 
   /* Header variables for light mode */
-  --header-background: rgba(255, 255, 255, 0.3);
+  --header-background: rgba(255, 255, 255, 0.6);
   --header-text-color: #1f2937;
 }
 
@@ -21,7 +21,7 @@
   --subtle-grey: #4b5563;
 
   /* Header variables for dark mode */
-  --header-background: rgba(31, 41, 55, 0.3);
+  --header-background: rgba(31, 41, 55, 0.6);
   --header-text-color: #f9fafb;
 }
 


### PR DESCRIPTION
## Summary
- lighten header background opacity for glass effect
- let Surah content scroll beneath fixed header

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688fc9a46f548332b0e0ffce822498db