### PR TITLE
Keep sidebars below sticky header

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -27,7 +27,7 @@ const Header = () => {
   return (
     // Adjusted background, padding, and grid layout for cleaner look
     <header
-      className="fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-md shadow-sm z-30"
+      className="fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-md shadow-sm z-60"
       style={{
         backgroundColor: 'var(--header-background)',
         color: 'var(--header-text-color)',

--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -203,7 +203,9 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
   return (
     <>
       <div
-        className={`fixed inset-0 bg-black/30 z-40 md:hidden ${isSurahListOpen ? '' : 'hidden'}`}
+        className={`fixed inset-0 top-16 bg-black/30 z-40 md:hidden ${
+          isSurahListOpen ? '' : 'hidden'
+        }`}
         role="button"
         tabIndex={0}
         onClick={() => setSurahListOpen(false)}
@@ -214,7 +216,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
         }}
       />
       <aside
-        className={`fixed md:static inset-y-0 left-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-50 md:z-10 transform transition-transform duration-300 ${
+        className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-50 md:z-10 transform transition-transform duration-300 ${
           isSurahListOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
       >

--- a/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
+++ b/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
@@ -36,7 +36,9 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
     <>
       {/* No overlay div */}
       <div
-        className={`fixed top-0 right-0 w-[23rem] h-full bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
       >
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -83,7 +83,9 @@ export const SettingsSidebar = ({
   return (
     <>
       <div
-        className={`fixed inset-0 bg-black/30 z-40 lg:hidden ${isSettingsOpen ? '' : 'hidden'}`}
+        className={`fixed inset-0 top-16 bg-black/30 z-40 lg:hidden ${
+          isSettingsOpen ? '' : 'hidden'
+        }`}
         role="button"
         tabIndex={0}
         onClick={() => setSettingsOpen(false)}
@@ -94,7 +96,9 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed lg:static inset-y-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${isSettingsOpen ? 'translate-x-0' : 'translate-x-full'} lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
+        className={`fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${
+          isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
+        } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >
         <header className="flex items-center justify-between p-4 border-b border-[var(--border-color)]">
           <button

--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -32,7 +32,9 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
 
   return (
     <div
-      className={`fixed top-0 bottom-0 lg:top-16 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+        isOpen ? 'translate-x-0' : 'translate-x-full'
+      }`}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200/80 mb-4">
         <button

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -48,7 +48,9 @@ export const TranslationPanel = ({
     <>
       {/* Removed the overlay div */}
       <div
-        className={`fixed top-0 bottom-0 lg:top-16 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
       >
         <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
           <button

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -43,7 +43,9 @@ export const WordLanguagePanel = ({
 
   return (
     <div
-      className={`fixed top-0 bottom-0 lg:top-16 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+        isOpen ? 'translate-x-0' : 'translate-x-full'
+      }`}
     >
       <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
         <button


### PR DESCRIPTION
## Summary
- raise header z-index so it stays on top
- offset Surah list, settings sidebar and related panels below the header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688fb44ba89c8332bc5aaea94d158fdb