### PR TITLE
fix: adjust sidebar layouts for scroll

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -155,8 +155,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     if (activeEl) {
       const sidebarRect = sidebar.getBoundingClientRect();
       const activeRect = activeEl.getBoundingClientRect();
-      const isOutside =
-        activeRect.top < sidebarRect.top || activeRect.bottom > sidebarRect.bottom;
+      const isOutside = activeRect.top < sidebarRect.top || activeRect.bottom > sidebarRect.bottom;
 
       if (shouldCenterRef.current[activeTab] && (top === 0 || isOutside)) {
         activeEl.scrollIntoView({ block: 'center' });
@@ -214,7 +213,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
         }}
       />
       <aside
-        className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-50 md:z-10 transform transition-transform duration-300 ${
+        className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-50 md:z-10 md:h-full transform transition-transform duration-300 ${
           isSurahListOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
       >
@@ -245,8 +244,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                       ? 'bg-white text-slate-900 shadow'
                       : 'bg-slate-700 text-white shadow'
                     : theme === 'light'
-                    ? 'text-slate-400 hover:text-slate-700'
-                    : 'text-slate-400 hover:text-white'
+                      ? 'text-slate-400 hover:text-slate-700'
+                      : 'text-slate-400 hover:text-white'
                 }`}
               >
                 {label}
@@ -314,8 +313,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                         isActive
                           ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
                           : theme === 'light'
-                          ? 'bg-white shadow hover:bg-slate-50'
-                          : 'bg-slate-800 shadow hover:bg-slate-700'
+                            ? 'bg-white shadow hover:bg-slate-50'
+                            : 'bg-slate-800 shadow hover:bg-slate-700'
                       }`}
                     >
                       <div
@@ -323,8 +322,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                           isActive
                             ? 'bg-white/20 text-white'
                             : theme === 'light'
-                            ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                            : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                              ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
+                              : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
                         }`}
                       >
                         {chapter.id}
@@ -335,8 +334,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                             isActive
                               ? 'text-white'
                               : theme === 'light'
-                              ? 'text-slate-700'
-                              : 'text-[var(--foreground)]'
+                                ? 'text-slate-700'
+                                : 'text-[var(--foreground)]'
                           }`}
                         >
                           {chapter.name_simple}
@@ -350,8 +349,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                           isActive
                             ? 'text-white'
                             : theme === 'light'
-                            ? 'text-gray-500 group-hover:text-teal-600'
-                            : 'text-gray-500 group-hover:text-teal-400'
+                              ? 'text-gray-500 group-hover:text-teal-600'
+                              : 'text-gray-500 group-hover:text-teal-400'
                         }`}
                       >
                         {chapter.name_arabic}
@@ -388,8 +387,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                         isActive
                           ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
                           : theme === 'light'
-                          ? 'bg-white shadow hover:bg-slate-50'
-                          : 'bg-slate-800 shadow hover:bg-slate-700'
+                            ? 'bg-white shadow hover:bg-slate-50'
+                            : 'bg-slate-800 shadow hover:bg-slate-700'
                       }`}
                     >
                       <div
@@ -397,8 +396,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                           isActive
                             ? 'bg-white/20 text-white'
                             : theme === 'light'
-                            ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                            : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                              ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
+                              : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
                         }`}
                       >
                         {juz.number}
@@ -409,8 +408,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                             isActive
                               ? 'text-white'
                               : theme === 'light'
-                              ? 'text-slate-700'
-                              : 'text-[var(--foreground)]'
+                                ? 'text-slate-700'
+                                : 'text-[var(--foreground)]'
                           }`}
                         >
                           Juz {juz.number}
@@ -420,8 +419,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                             isActive
                               ? 'text-white/90'
                               : theme === 'light'
-                              ? 'text-slate-600'
-                              : 'text-slate-400'
+                                ? 'text-slate-600'
+                                : 'text-slate-400'
                           }`}
                         >
                           {juz.surahRange}
@@ -458,8 +457,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                         isActive
                           ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
                           : theme === 'light'
-                          ? 'bg-white shadow hover:bg-slate-50'
-                          : 'bg-slate-800 shadow hover:bg-slate-700'
+                            ? 'bg-white shadow hover:bg-slate-50'
+                            : 'bg-slate-800 shadow hover:bg-slate-700'
                       }`}
                     >
                       <div
@@ -467,8 +466,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                           isActive
                             ? 'bg-white/20 text-white'
                             : theme === 'light'
-                            ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                            : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                              ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
+                              : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
                         }`}
                       >
                         {p}
@@ -478,8 +477,8 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                           isActive
                             ? 'text-white'
                             : theme === 'light'
-                            ? 'text-slate-700'
-                            : 'text-[var(--foreground)]'
+                              ? 'text-slate-700'
+                              : 'text-[var(--foreground)]'
                         }`}
                       >
                         Page {p}

--- a/app/context/SidebarContext.tsx
+++ b/app/context/SidebarContext.tsx
@@ -25,14 +25,17 @@ export const SidebarProvider = ({ children }: { children: React.ReactNode }) => 
   const [isSurahListOpen, setSurahListOpen] = useState(false);
   const [isSettingsOpen, setSettingsOpen] = useState(false);
   const [surahScrollTop, _setSurahScrollTop] = useState(() => {
+    if (typeof window === 'undefined') return 0;
     const stored = sessionStorage.getItem('surahScrollTop');
     return stored ? Number(stored) : 0;
   });
   const [juzScrollTop, _setJuzScrollTop] = useState(() => {
+    if (typeof window === 'undefined') return 0;
     const stored = sessionStorage.getItem('juzScrollTop');
     return stored ? Number(stored) : 0;
   });
   const [pageScrollTop, _setPageScrollTop] = useState(() => {
+    if (typeof window === 'undefined') return 0;
     const stored = sessionStorage.getItem('pageScrollTop');
     return stored ? Number(stored) : 0;
   });

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -126,7 +126,7 @@ export default function JuzPage({ params }: JuzPageProps) {
   );
 
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
       <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {/* Only render content when juzId is available */}

--- a/app/features/juz/layout.tsx
+++ b/app/features/juz/layout.tsx
@@ -10,11 +10,11 @@ export default function JuzLayout({ children }: { children: React.ReactNode }) {
     <AudioProvider>
       <Header />
       <div className="h-screen flex flex-col pt-16">
-        <div className="flex flex-grow overflow-hidden">
-          <nav aria-label="Primary navigation" className="flex-shrink-0">
+        <div className="flex flex-grow overflow-hidden min-h-0">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -118,7 +118,7 @@ export default function QuranPage({ params }: QuranPageProps) {
   );
 
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
       <main className="flex-grow bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {/* Only render content when pageId is available */}

--- a/app/features/page/layout.tsx
+++ b/app/features/page/layout.tsx
@@ -10,11 +10,11 @@ export default function PageLayout({ children }: { children: React.ReactNode }) 
     <AudioProvider>
       <Header />
       <div className="h-screen flex flex-col pt-16">
-        <div className="flex flex-grow overflow-hidden">
-          <nav aria-label="Primary navigation" className="flex-shrink-0">
+        <div className="flex flex-grow overflow-hidden min-h-0">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -96,7 +96,7 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto ${
+        className={`fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto lg:h-full ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -123,7 +123,7 @@ export default function SurahPage({ params }: SurahPageProps) {
   );
 
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
+    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
       <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 pt-16 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {isLoading ? (

--- a/app/features/surah/layout.tsx
+++ b/app/features/surah/layout.tsx
@@ -9,12 +9,12 @@ export default function SurahLayout({ children }: { children: React.ReactNode })
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col">
-        <div className="flex flex-grow overflow-hidden">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 pt-16">
+      <div className="h-screen flex flex-col pt-16">
+        <div className="flex flex-grow overflow-hidden min-h-0">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 pt-16">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -170,7 +170,7 @@ export default function TafsirVersePage() {
   const currentSurah = surahList.find((surah) => surah.number === Number(surahId));
 
   return (
-    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] overflow-hidden">
+    <div className="flex flex-grow bg-[var(--background)] text-[var(--foreground)] overflow-hidden min-h-0">
       <div className="flex-grow overflow-y-auto p-6 lg:p-10">
         <div className="w-full space-y-6">
           {/* Ayah Navigation */}

--- a/app/features/tafsir/layout.tsx
+++ b/app/features/tafsir/layout.tsx
@@ -10,11 +10,11 @@ export default function TafsirLayout({ children }: { children: React.ReactNode }
     <AudioProvider>
       <Header />
       <div className="h-screen flex flex-col pt-16">
-        <div className="flex flex-grow overflow-hidden">
-          <nav aria-label="Primary navigation">
+        <div className="flex flex-grow overflow-hidden min-h-0">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}


### PR DESCRIPTION
## Summary
- ensure main feature layouts stretch to viewport height and allow scrolling sidebars
- size surah and settings sidebars to full height on desktop
- guard sidebar context against server-side sessionStorage access

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_688fe34362fc8332b139fb58f2c6c00d