### PR TITLE
Add ThemeContext tests

### DIFF
--- a/__tests__/ThemeContext.test.tsx
+++ b/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, useTheme } from '@/app/context/ThemeContext';
+
+const ThemeTest = () => {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>Toggle</button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.dataset.theme = '';
+  });
+
+  it('useTheme throws when rendered without ThemeProvider', () => {
+    expect(() => render(<ThemeTest />)).toThrow('useTheme must be used within ThemeProvider');
+  });
+
+  it('sets and updates theme with persistence', async () => {
+    render(
+      <ThemeProvider>
+        <ThemeTest />
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('theme').textContent).toBe('light');
+      expect(document.documentElement.dataset.theme).toBe('light');
+      expect(localStorage.getItem('theme')).toBe('light');
+    });
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('theme').textContent).toBe('dark');
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(localStorage.getItem('theme')).toBe('dark');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add ThemeContext tests

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint` *(fails: prettier errors in `app/components/common/SurahListSidebar.tsx`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688fe50d306c83329154e7bd08a68be7