### PR TITLE
docs: document SettingsContext

### DIFF
--- a/app/context/SettingsContext.tsx
+++ b/app/context/SettingsContext.tsx
@@ -44,6 +44,14 @@ interface SettingsContextType {
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
 
+/**
+ * Provides global access to user-configurable settings such as fonts, font sizes,
+ * translation and tafsīr selections, word-by-word preferences, tajweed display and
+ * verse bookmarks. Settings and bookmarks are persisted to `localStorage`.
+ *
+ * Wrap parts of the application that need these values with this provider and use
+ * the {@link useSettings} hook to read or update them.
+ */
 export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
   const [settings, setSettings] = useState<Settings>(defaultSettings);
   const [bookmarkedVerses, setBookmarkedVerses] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- document SettingsProvider context usage and exposed settings

## Testing
- `npm audit --omit=dev`
- `npm run check`
- `npm run lint -- --file app/context/SettingsContext.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688fe50badc08332b160295c9e6913c5