### PR TITLE
Add tests for language mapping utilities

### DIFF
--- a/__tests__/languageMappings.test.ts
+++ b/__tests__/languageMappings.test.ts
@@ -1,0 +1,20 @@
+import { LANGUAGE_CODES } from '@/lib/languageCodes';
+import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
+
+describe('language mappings', () => {
+  it('maps language names to codes and labels', () => {
+    expect(LANGUAGE_CODES.english).toBe('en');
+    expect(WORD_LANGUAGE_LABELS.bengali).toBe('Bangla');
+  });
+
+  it('has non-empty keys and values for all mappings', () => {
+    Object.entries(LANGUAGE_CODES).forEach(([key, value]) => {
+      expect(key).toBeTruthy();
+      expect(value).toBeTruthy();
+    });
+    Object.entries(WORD_LANGUAGE_LABELS).forEach(([key, value]) => {
+      expect(key).toBeTruthy();
+      expect(value).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test language code and label mappings
- ensure mapping keys and values are non-empty

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68905cf512b08332a807db5d6a6b2543