### PR TITLE
Add Surah page tests

### DIFF
--- a/__tests__/SurahPage.test.tsx
+++ b/__tests__/SurahPage.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import { SettingsProvider } from '@/app/context/SettingsContext';
+import { AudioProvider } from '@/app/context/AudioContext';
+import { ThemeProvider } from '@/app/context/ThemeContext';
+import { SidebarProvider } from '@/app/context/SidebarContext';
+import SurahPage from '@/app/features/surah/[surahId]/page';
+import { Verse } from '@/types';
+import * as api from '@/lib/api';
+import useSWRInfinite from 'swr/infinite';
+import { SWRConfig } from 'swr';
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return { ...actual, use: (v: any) => v };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/lib/api');
+jest.mock('swr/infinite', () => ({ __esModule: true, default: jest.fn() }));
+
+const mockVerse: Verse = {
+  id: 1,
+  verse_key: '1:1',
+  text_uthmani: 'surah verse',
+  words: [],
+} as Verse;
+
+let intersectionCallback: (entries: { isIntersecting: boolean }[]) => void;
+
+beforeAll(() => {
+  class IO {
+    constructor(cb: typeof intersectionCallback) {
+      intersectionCallback = cb;
+    }
+    observe() {}
+    disconnect() {}
+  }
+  (
+    global as unknown as { IntersectionObserver: typeof IntersectionObserver }
+  ).IntersectionObserver = IO as unknown as typeof IntersectionObserver;
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (api.getTranslations as jest.Mock).mockResolvedValue([]);
+  (api.getWordTranslations as jest.Mock).mockResolvedValue([]);
+  (useSWRInfinite as jest.Mock).mockImplementation(jest.requireActual('swr/infinite').default);
+});
+
+const renderPage = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <AudioProvider>
+        <SettingsProvider>
+          <ThemeProvider>
+            <SidebarProvider>
+              <SurahPage params={{ surahId: '1' }} />
+            </SidebarProvider>
+          </ThemeProvider>
+        </SettingsProvider>
+      </AudioProvider>
+    </SWRConfig>
+  );
+
+test('renders verses on successful fetch', async () => {
+  (api.getVersesByChapter as jest.Mock).mockResolvedValue({
+    verses: [mockVerse],
+    totalPages: 1,
+  });
+
+  renderPage();
+
+  expect(await screen.findByText('surah verse')).toBeInTheDocument();
+});
+
+test('shows error message when fetch rejects', async () => {
+  (api.getVersesByChapter as jest.Mock).mockRejectedValue(new Error('boom'));
+
+  renderPage();
+
+  expect(await screen.findByText('Failed to load content. boom')).toBeInTheDocument();
+});
+
+test('sentinel intersection calls setSize', () => {
+  const mockSetSize = jest.fn();
+  (useSWRInfinite as jest.Mock).mockReturnValue({
+    data: [{ verses: [mockVerse], totalPages: 2 }],
+    size: 1,
+    setSize: mockSetSize,
+    isValidating: false,
+  });
+
+  renderPage();
+
+  intersectionCallback([{ isIntersecting: true }]);
+
+  expect(mockSetSize).toHaveBeenCalledWith(2);
+});


### PR DESCRIPTION
## Summary
- add tests covering successful verse fetch and error display on the Surah page
- verify infinite scroll by triggering IntersectionObserver and calling setSize

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68905cedadac8332ae62b0e5b0baecc8