### PR TITLE
Fix header overlay with sidebars

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -200,7 +200,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
   return (
     <>
       <div
-        className={`fixed inset-0 top-16 bg-black/30 z-40 md:hidden ${
+        className={`fixed inset-0 top-16 bg-black/30 z-10 md:hidden ${
           isSurahListOpen ? '' : 'hidden'
         }`}
         role="button"
@@ -213,7 +213,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
         }}
       />
       <aside
-        className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-50 md:z-10 md:h-full transform transition-transform duration-300 ${
+        className={`fixed md:static top-0 md:top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg pt-16 md:pt-0 z-20 md:z-10 md:h-full transform transition-transform duration-300 ${
           isSurahListOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
       >

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -83,9 +83,7 @@ export const SettingsSidebar = ({
   return (
     <>
       <div
-        className={`fixed inset-0 top-16 bg-black/30 z-40 lg:hidden ${
-          isSettingsOpen ? '' : 'hidden'
-        }`}
+        className={`fixed inset-0 bg-black/30 z-40 lg:hidden ${isSettingsOpen ? '' : 'hidden'}`}
         role="button"
         tabIndex={0}
         onClick={() => setSettingsOpen(false)}
@@ -96,7 +94,7 @@ export const SettingsSidebar = ({
         }}
       />
       <aside
-        className={`fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto lg:h-full ${
+        className={`fixed lg:static top-0 lg:top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-auto lg:h-full ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >


### PR DESCRIPTION
## Summary
- ensure surah list sidebar sits beneath the transparent header
- allow settings sidebar to cover the header when opened

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890686b29648332adf52a453e93a40f