### PR TITLE
Implement bookmark verse fetching

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -229,5 +229,19 @@ export async function getRandomVerse(translationId: number): Promise<Verse> {
   return normalizeVerse(data.verse);
 }
 
+// Fetch a single verse by its ID
+export async function getVerseById(
+  verseId: string | number,
+  translationId: number
+): Promise<Verse> {
+  const url = `${API_BASE_URL}/verses/${verseId}?translations=${translationId}&fields=text_uthmani`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch verse: ${res.status}`);
+  }
+  const data = await res.json();
+  return normalizeVerse(data.verse);
+}
+
 // Export base URL for use elsewhere
 export { API_BASE_URL };


### PR DESCRIPTION
## Summary
- add helper to fetch a single verse by id
- show verse details for bookmarks with error handling
- test bookmark list for verse rendering and failures

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689087571c648332a8860387bda390e3