### PR TITLE
Add IconSidebar navigation test

### DIFF
--- a/__tests__/IconSidebar.test.tsx
+++ b/__tests__/IconSidebar.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import IconSidebar from '@/app/components/common/IconSidebar';
+import { SidebarProvider } from '@/app/context/SidebarContext';
+import { ThemeProvider } from '@/app/context/ThemeContext';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider>
+    <SidebarProvider>{children}</SidebarProvider>
+  </ThemeProvider>
+);
+
+// mock translation hook
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('IconSidebar', () => {
+  it('renders navigation buttons with correct hrefs', () => {
+    render(
+      <Wrapper>
+        <IconSidebar />
+      </Wrapper>
+    );
+
+    const homeBtn = screen.getByRole('button', { name: 'home' });
+    expect(homeBtn).toBeInTheDocument();
+    expect(homeBtn.closest('a')).toHaveAttribute('href', '/');
+
+    const surahBtn = screen.getByRole('button', { name: 'all_surahs' });
+    expect(surahBtn).toBeInTheDocument();
+    expect(surahBtn.closest('a')).toHaveAttribute('href', '/features/surah/1');
+
+    const bookmarksBtn = screen.getByRole('button', { name: 'bookmarks' });
+    expect(bookmarksBtn).toBeInTheDocument();
+    expect(bookmarksBtn.closest('a')).toHaveAttribute('href', '/features/bookmarks');
+  });
+});

--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -43,10 +43,7 @@ const Header = () => {
       {/* Column 2: Centered Search Bar */}
       <div className="flex justify-center">
         <div className="relative w-full max-w-lg">
-          <FaSearch
-            size={18}
-            className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"
-          />
+          <FaSearch size={18} className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" />
           <input
             type="text"
             placeholder={t('search_placeholder')}


### PR DESCRIPTION
## Summary
- test IconSidebar buttons navigate to the expected paths
- format Header search icon for linting

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890875a903883329221845fd30fb714