### PR TITLE
Document and test Spinner component

### DIFF
--- a/__tests__/Spinner.test.tsx
+++ b/__tests__/Spinner.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import Spinner from '@/app/components/common/Spinner';
+
+describe('Spinner', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass('animate-spin');
+  });
+
+  it('applies a custom class name', () => {
+    const { container } = render(<Spinner className="test-class" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('test-class');
+  });
+});

--- a/app/components/common/Spinner.tsx
+++ b/app/components/common/Spinner.tsx
@@ -4,6 +4,13 @@ interface SpinnerProps {
   className?: string;
 }
 
+/**
+ * Renders a spinning SVG to indicate loading state.
+ *
+ * @param props - Component properties.
+ * @param props.className - Optional CSS classes applied to the spinner.
+ * @returns The spinner SVG element.
+ */
 const Spinner = ({ className = '' }: SpinnerProps) => (
   <svg
     className={`animate-spin ${className}`}


### PR DESCRIPTION
## Summary
- add JSDoc to Spinner for className prop
- test Spinner renders SVG and applies custom class

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68908776b0808332a3930b0e88edff2f