### PR TITLE
Document and test getVerseById

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,4 +1,11 @@
-import { getJuz, API_BASE_URL, getRandomVerse, searchVerses, getChapters } from '@/lib/api';
+import {
+  getJuz,
+  API_BASE_URL,
+  getRandomVerse,
+  searchVerses,
+  getChapters,
+  getVerseById,
+} from '@/lib/api';
 import { Juz, Verse, Chapter } from '@/types';
 
 describe('getChapters', () => {
@@ -105,6 +112,50 @@ describe('getRandomVerse', () => {
   it('throws on fetch error', async () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as jest.Mock;
     await expect(getRandomVerse(20)).rejects.toThrow('Failed to fetch random verse: 500');
+  });
+});
+
+describe('getVerseById', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('normalizes verse data', async () => {
+    const mockRaw: Verse & { words: any[] } = {
+      id: 1,
+      verse_key: '1:1',
+      text_uthmani: 'test',
+      words: [
+        { id: 1, text_uthmani: 'foo', translation: { text: 'bar' } },
+        { id: 2, text: 'baz', translation: { text: 'qux' } },
+      ],
+    } as any;
+
+    const expected: Verse = {
+      id: 1,
+      verse_key: '1:1',
+      text_uthmani: 'test',
+      words: [
+        { id: 1, uthmani: 'foo', en: 'bar' },
+        { id: 2, uthmani: 'baz', en: 'qux' },
+      ],
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ verse: mockRaw }),
+    }) as jest.Mock;
+
+    const result = await getVerseById(1, 20);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE_URL}/verses/1?translations=20&fields=text_uthmani`
+    );
+    expect(result).toEqual(expected);
+  });
+
+  it('throws on fetch error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as jest.Mock;
+    await expect(getVerseById(1, 20)).rejects.toThrow('Failed to fetch verse: 404');
   });
 });
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -229,7 +229,13 @@ export async function getRandomVerse(translationId: number): Promise<Verse> {
   return normalizeVerse(data.verse);
 }
 
-// Fetch a single verse by its ID
+/**
+ * Fetches a single verse by its identifier and normalizes the result.
+ *
+ * @param {string|number} verseId - Identifier of the verse to retrieve.
+ * @param {number} translationId - Translation resource to include.
+ * @returns {Promise<Verse>} Promise resolving to the normalized verse.
+ */
 export async function getVerseById(
   verseId: string | number,
   translationId: number


### PR DESCRIPTION
## Summary
- document `getVerseById`
- add tests for `getVerseById` success and error cases

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68908f6bac088332b1aa7dad33ab3084