### PR TITLE
Keep header visible above sidebars

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -26,7 +26,7 @@ const Header = () => {
 
   return (
     <header
-      className={`fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-md ${headerBgClass} text-gray-800 dark:text-gray-100 shadow-sm z-30`}
+      className={`fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 backdrop-blur-md ${headerBgClass} text-gray-800 dark:text-gray-100 shadow-sm z-50`}
     >
       {/* Column 1: Title & Surah List Toggle */}
       <div className="flex items-center gap-2">

--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -201,7 +201,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     <>
       {/* This is the overlay for mobile view, which closes the sidebar when clicked. */}
       <div
-        className={`fixed inset-0 bg-black/30 z-40 md:hidden ${isSurahListOpen ? '' : 'hidden'}`}
+        className={`fixed inset-0 bg-transparent z-30 md:hidden ${isSurahListOpen ? '' : 'hidden'}`}
         role="button"
         tabIndex={0}
         onClick={() => setSurahListOpen(false)}
@@ -213,7 +213,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
       />
       {/* This is the main sidebar container. */}
       <aside
-        className={`fixed md:static top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg pt-16 md:pt-0 z-50 md:z-10 md:h-full transform transition-transform duration-300 ${
+        className={`fixed md:static top-0 bottom-0 left-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg pt-16 md:pt-0 z-40 md:z-10 md:h-full transform transition-transform duration-300 ${
           isSurahListOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
       >

--- a/app/features/juz/layout.tsx
+++ b/app/features/juz/layout.tsx
@@ -9,12 +9,12 @@ export default function JuzLayout({ children }: { children: React.ReactNode }) {
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col pt-16">
+      <div className="h-screen flex flex-col">
         <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full pt-16">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full pt-16">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/page/layout.tsx
+++ b/app/features/page/layout.tsx
@@ -9,12 +9,12 @@ export default function PageLayout({ children }: { children: React.ReactNode }) 
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col pt-16">
+      <div className="h-screen flex flex-col">
         <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full pt-16">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full pt-16">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -84,7 +84,7 @@ export const SettingsSidebar = ({
     <>
       {/* This is the overlay for mobile view, which closes the sidebar when clicked. */}
       <div
-        className={`fixed inset-0 bg-black/30 z-40 lg:hidden ${isSettingsOpen ? '' : 'hidden'}`}
+        className={`fixed inset-0 bg-transparent z-30 lg:hidden ${isSettingsOpen ? '' : 'hidden'}`}
         role="button"
         tabIndex={0}
         onClick={() => setSettingsOpen(false)}
@@ -96,7 +96,7 @@ export const SettingsSidebar = ({
       />
       {/* This is the main settings sidebar container. */}
       <aside
-        className={`fixed lg:static top-0 lg:top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-50 lg:z-50 lg:h-full ${
+        className={`fixed lg:static top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-40 lg:z-40 lg:h-full pt-16 ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -123,7 +123,7 @@ export default function SurahPage({ params }: SurahPageProps) {
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
       <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
-        <div className="w-full relative mt-16">
+        <div className="w-full relative">
           {isLoading ? (
             <div className="flex justify-center py-20">
               <Spinner className="h-8 w-8 text-teal-600" />

--- a/app/features/tafsir/layout.tsx
+++ b/app/features/tafsir/layout.tsx
@@ -9,12 +9,12 @@ export default function TafsirLayout({ children }: { children: React.ReactNode }
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col pt-16">
+      <div className="h-screen flex flex-col">
         <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full pt-16">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full pt-16">
             <SurahListSidebar />
           </nav>
           {children}


### PR DESCRIPTION
## Summary
- keep floating header on top of all content
- drop dark page overlay when sidebars open
- align feature layouts with the transparent header

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689092f307dc8332b17c27dd83167505