### PR TITLE
Offset settings sidebar below header

### DIFF
--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -96,7 +96,7 @@ export const SettingsSidebar = ({
       />
       {/* This is the main settings sidebar container. */}
       <aside
-        className={`fixed lg:static top-0 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-40 lg:z-40 lg:h-full pt-16 ${
+        className={`fixed lg:static top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-40 lg:z-40 lg:h-full ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >


### PR DESCRIPTION
## Summary
- place settings sidebar below the header by shifting it to `top-16`
- remove extra top padding from sidebar for consistent layout

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890a45e4e0c8332887930732868cba0