### PR TITLE
fix: offset layouts below header

### DIFF
--- a/app/features/juz/layout.tsx
+++ b/app/features/juz/layout.tsx
@@ -9,12 +9,12 @@ export default function JuzLayout({ children }: { children: React.ReactNode }) {
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col">
+      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
         <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full pt-16">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full pt-16">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/page/layout.tsx
+++ b/app/features/page/layout.tsx
@@ -9,12 +9,12 @@ export default function PageLayout({ children }: { children: React.ReactNode }) 
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col">
+      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
         <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full pt-16">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full pt-16">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}

--- a/app/features/tafsir/layout.tsx
+++ b/app/features/tafsir/layout.tsx
@@ -9,12 +9,12 @@ export default function TafsirLayout({ children }: { children: React.ReactNode }
   return (
     <AudioProvider>
       <Header />
-      <div className="h-screen flex flex-col">
+      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
         <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full pt-16">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full pt-16">
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
             <SurahListSidebar />
           </nav>
           {children}


### PR DESCRIPTION
## Summary
- shift feature layouts below the fixed header
- remove redundant padding from sidebars

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_b_6890a45edb608332b7279275de7df9c8