### PR TITLE
Refactor feature layouts to share header and sidebars

### DIFF
--- a/app/features/juz/layout.tsx
+++ b/app/features/juz/layout.tsx
@@ -1,25 +1,7 @@
 // app/features/juz/layout.tsx
 'use client';
-import Header from '@/app/components/common/Header';
-import IconSidebar from '@/app/components/common/IconSidebar';
-import SurahListSidebar from '@/app/components/common/SurahListSidebar';
 import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function JuzLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <AudioProvider>
-      <Header />
-      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
-        <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
-            <IconSidebar />
-          </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
-            <SurahListSidebar />
-          </nav>
-          {children}
-        </div>
-      </div>
-    </AudioProvider>
-  );
+  return <AudioProvider>{children}</AudioProvider>;
 }

--- a/app/features/layout.tsx
+++ b/app/features/layout.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Header from '@/app/components/common/Header';
+import IconSidebar from '@/app/components/common/IconSidebar';
+import SurahListSidebar from '@/app/components/common/SurahListSidebar';
+
+export default function FeaturesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
+        <div className="flex flex-grow overflow-hidden min-h-0">
+          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
+            <IconSidebar />
+          </nav>
+          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
+            <SurahListSidebar />
+          </nav>
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/features/page/layout.tsx
+++ b/app/features/page/layout.tsx
@@ -1,25 +1,7 @@
 // app/features/page/layout.tsx
 'use client';
-import Header from '@/app/components/common/Header';
-import IconSidebar from '@/app/components/common/IconSidebar';
-import SurahListSidebar from '@/app/components/common/SurahListSidebar';
 import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function PageLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <AudioProvider>
-      <Header />
-      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
-        <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
-            <IconSidebar />
-          </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
-            <SurahListSidebar />
-          </nav>
-          {children}
-        </div>
-      </div>
-    </AudioProvider>
-  );
+  return <AudioProvider>{children}</AudioProvider>;
 }

--- a/app/features/surah/layout.tsx
+++ b/app/features/surah/layout.tsx
@@ -1,25 +1,7 @@
 'use client';
 
-import Header from '@/app/components/common/Header';
-import IconSidebar from '@/app/components/common/IconSidebar';
-import SurahListSidebar from '@/app/components/common/SurahListSidebar';
 import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function SurahLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <AudioProvider>
-      <Header />
-      <div className="h-screen flex flex-col">
-        <div className="flex flex-grow overflow-hidden">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 pt-16">
-            <IconSidebar />
-          </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 pt-16">
-            <SurahListSidebar />
-          </nav>
-          {children}
-        </div>
-      </div>
-    </AudioProvider>
-  );
+  return <AudioProvider>{children}</AudioProvider>;
 }

--- a/app/features/tafsir/layout.tsx
+++ b/app/features/tafsir/layout.tsx
@@ -1,25 +1,7 @@
 'use client';
 // app/features/tafsir/layout.tsx
-import Header from '@/app/components/common/Header';
-import IconSidebar from '@/app/components/common/IconSidebar';
-import SurahListSidebar from '@/app/components/common/SurahListSidebar';
 import { AudioProvider } from '@/app/context/AudioContext';
 
 export default function TafsirLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <AudioProvider>
-      <Header />
-      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
-        <div className="flex flex-grow overflow-hidden min-h-0">
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
-            <IconSidebar />
-          </nav>
-          <nav aria-label="Surah navigation" className="flex-shrink-0 h-full">
-            <SurahListSidebar />
-          </nav>
-          {children}
-        </div>
-      </div>
-    </AudioProvider>
-  );
+  return <AudioProvider>{children}</AudioProvider>;
 }


### PR DESCRIPTION
## Summary
- add shared features layout with Header, IconSidebar and SurahListSidebar
- remove duplicated header and sidebars from feature layouts

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890bcc8f6908332be42ebe30ec0156f