### PR TITLE
Offset settings sidebar below header

### DIFF
--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -297,7 +297,7 @@ export const SettingsSidebar = ({
           )}
         </div>
         {/* Theme Toggle */}
-        <div className="pt-2 p-4">
+        <div className="p-4">
           <div
             className={`flex items-center p-1 rounded-full ${theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'}`}
           >


### PR DESCRIPTION
## Summary
- ensure settings sidebar starts below the fixed header
- remove redundant top padding in settings sidebar footer

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890bcca504c83329ec2ffd17567036f