### PR TITLE
fix: remove bottom bar on Surah page

### DIFF
--- a/app/features/layout.tsx
+++ b/app/features/layout.tsx
@@ -8,8 +8,8 @@ export default function FeaturesLayout({ children }: { children: React.ReactNode
   return (
     <>
       <Header />
-      <div className="h-[calc(100vh-64px)] pt-16 flex flex-col">
-        <div className="flex flex-grow overflow-hidden min-h-0">
+      <div className="flex flex-col h-screen">
+        <div className="flex flex-grow overflow-hidden min-h-0 pt-16">
           <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>


### PR DESCRIPTION
## Summary
- ensure features layout spans full viewport height so the Surah page has no persistent bottom bar

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890c08795c483329ef681fca623a8f1