### PR TITLE
Hide header on downward scroll

### DIFF
--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -7,7 +7,11 @@ import { useRouter } from 'next/navigation';
 import { FaCog } from 'react-icons/fa';
 import { useTheme } from '@/app/context/ThemeContext';
 
-const Header = () => {
+interface HeaderProps {
+  isHidden?: boolean;
+}
+
+const Header = ({ isHidden = false }: HeaderProps) => {
   const { t } = useTranslation();
   const { setSurahListOpen, setSettingsOpen } = useSidebar();
   const router = useRouter();
@@ -27,7 +31,7 @@ const Header = () => {
 
   return (
     <header
-      className={`fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 ${headerBgClass} text-gray-800 dark:text-gray-100 shadow-sm z-50`}
+      className={`fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 ${headerBgClass} text-gray-800 dark:text-gray-100 shadow-sm z-50 transform transition-transform duration-300 ${isHidden ? '-translate-y-full' : 'translate-y-0'}`}
     >
       {/* Column 1: Title & Surah List Toggle */}
       <div className="flex items-center gap-2">

--- a/app/context/HeaderVisibilityContext.tsx
+++ b/app/context/HeaderVisibilityContext.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+
+interface HeaderVisibilityState {
+  isHidden: boolean;
+}
+
+const HeaderVisibilityContext = createContext<HeaderVisibilityState>({ isHidden: false });
+
+export const HeaderVisibilityProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isHidden, setIsHidden] = useState(false);
+  const lastScrollY = useRef(0);
+
+  useEffect(() => {
+    const scrollEl = document.querySelector('.homepage-scrollable-area');
+    if (!scrollEl) return;
+
+    const handleScroll = () => {
+      const currentY = (scrollEl as HTMLElement).scrollTop;
+      if (currentY > lastScrollY.current && currentY > 50) {
+        setIsHidden(true);
+      } else {
+        setIsHidden(false);
+      }
+      lastScrollY.current = currentY;
+    };
+
+    scrollEl.addEventListener('scroll', handleScroll);
+    return () => scrollEl.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <HeaderVisibilityContext.Provider value={{ isHidden }}>
+      {children}
+    </HeaderVisibilityContext.Provider>
+  );
+};
+
+export const useHeaderVisibility = () => useContext(HeaderVisibilityContext);

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -134,7 +134,7 @@ export default function JuzPage({ params }: JuzPageProps) {
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 pt-16 overflow-y-auto homepage-scrollable-area">
+      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {/* Only render content when juzId is available */}
           {juzId ? (

--- a/app/features/layout.tsx
+++ b/app/features/layout.tsx
@@ -3,13 +3,20 @@
 import Header from '@/app/components/common/Header';
 import IconSidebar from '@/app/components/common/IconSidebar';
 import SurahListSidebar from '@/app/components/common/SurahListSidebar';
+import {
+  HeaderVisibilityProvider,
+  useHeaderVisibility,
+} from '@/app/context/HeaderVisibilityContext';
 
-export default function FeaturesLayout({ children }: { children: React.ReactNode }) {
+function LayoutContent({ children }: { children: React.ReactNode }) {
+  const { isHidden } = useHeaderVisibility();
   return (
     <>
-      <Header />
+      <Header isHidden={isHidden} />
       <div className="flex flex-col h-screen">
-        <div className="flex flex-grow overflow-hidden min-h-0 pt-16">
+        <div
+          className={`flex flex-grow overflow-hidden min-h-0 transition-[padding-top] duration-300 ${isHidden ? 'pt-0' : 'pt-16'}`}
+        >
           <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
@@ -20,5 +27,13 @@ export default function FeaturesLayout({ children }: { children: React.ReactNode
         </div>
       </div>
     </>
+  );
+}
+
+export default function FeaturesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <HeaderVisibilityProvider>
+      <LayoutContent>{children}</LayoutContent>
+    </HeaderVisibilityProvider>
   );
 }

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -126,7 +126,7 @@ export default function QuranPage({ params }: QuranPageProps) {
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 pt-16 overflow-y-auto homepage-scrollable-area">
+      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {/* Only render content when pageId is available */}
           {pageId ? (

--- a/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
+++ b/app/features/surah/[surahId]/_components/ArabicFontPanel.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useState } from 'react'; // Import useState
 import { useTheme } from '@/app/context/ThemeContext';
+import { useHeaderVisibility } from '@/app/context/HeaderVisibilityContext';
 
 interface ArabicFontPanelProps {
   isOpen: boolean;
@@ -16,6 +17,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState('Uthmani'); // State for active tab
   const { theme } = useTheme();
+  const { isHidden } = useHeaderVisibility();
 
   // Group fonts by category
   const groupedFonts = arabicFonts.reduce(
@@ -36,7 +38,7 @@ export const ArabicFontPanel = ({ isOpen, onClose }: ArabicFontPanelProps) => {
     <>
       {/* No overlay div */}
       <div
-        className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+        className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >

--- a/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
+++ b/app/features/surah/[surahId]/_components/SettingsSidebar.tsx
@@ -13,6 +13,7 @@ import { useSettings } from '@/app/context/SettingsContext';
 import { ArabicFontPanel } from './ArabicFontPanel';
 import { useSidebar } from '@/app/context/SidebarContext';
 import { useTheme } from '@/app/context/ThemeContext';
+import { useHeaderVisibility } from '@/app/context/HeaderVisibilityContext';
 
 interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
@@ -42,6 +43,7 @@ export const SettingsSidebar = ({
   const { theme, setTheme } = useTheme();
   const [activeTab, setActiveTab] = useState('translation');
   const [openPanels, setOpenPanels] = useState<string[]>(['reading', 'font']);
+  const { isHidden } = useHeaderVisibility();
 
   // Helper function to calculate the slider's progress percentage
   const getPercentage = (value: number, min: number, max: number) => {
@@ -96,7 +98,7 @@ export const SettingsSidebar = ({
       />
       {/* This is the main settings sidebar container. */}
       <aside
-        className={`fixed lg:static top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-transform duration-300 z-40 lg:z-40 lg:h-full ${
+        className={`fixed lg:static ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-all duration-300 z-40 lg:z-40 lg:h-full ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex`}
       >

--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -6,6 +6,7 @@ import { TafsirResource } from '@/types';
 import { getTafsirResources } from '@/lib/api';
 import useSWR from 'swr';
 import { useMemo, useState } from 'react';
+import { useHeaderVisibility } from '@/app/context/HeaderVisibilityContext';
 
 interface TafsirPanelProps {
   isOpen: boolean;
@@ -17,6 +18,7 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
   const { t } = useTranslation();
   const { data } = useSWR('tafsirs', getTafsirResources);
   const [searchTerm, setSearchTerm] = useState('');
+  const { isHidden } = useHeaderVisibility();
 
   const grouped = useMemo(() => {
     const filtered = (data || []).filter(
@@ -32,7 +34,7 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
 
   return (
     <div
-      className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+      className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
       }`}
     >

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { TranslationResource } from '@/types';
 import { useSettings } from '@/app/context/SettingsContext';
+import { useHeaderVisibility } from '@/app/context/HeaderVisibilityContext';
 
 interface TranslationPanelProps {
   isOpen: boolean;
@@ -22,6 +23,7 @@ export const TranslationPanel = ({
 }: TranslationPanelProps) => {
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
+  const { isHidden } = useHeaderVisibility();
   const sortedLanguages = useMemo(() => {
     return Object.keys(groupedTranslations).sort((a, b) => {
       const aLower = a.toLowerCase();
@@ -48,7 +50,7 @@ export const TranslationPanel = ({
     <>
       {/* Removed the overlay div */}
       <div
-        className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+        className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >

--- a/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
+++ b/app/features/surah/[surahId]/_components/WordLanguagePanel.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 import { useSettings } from '@/app/context/SettingsContext';
 import { LANGUAGE_CODES } from '@/lib/languageCodes';
 import type { LanguageCode } from '@/lib/languageCodes';
+import { useHeaderVisibility } from '@/app/context/HeaderVisibilityContext';
 
 interface LanguageOption {
   name: string;
@@ -30,6 +31,7 @@ export const WordLanguagePanel = ({
 }: WordLanguagePanelProps) => {
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
+  const { isHidden } = useHeaderVisibility();
 
   const sortedLanguages = useMemo(
     () => [...languages].sort((a, b) => a.name.localeCompare(b.name)),
@@ -43,7 +45,7 @@ export const WordLanguagePanel = ({
 
   return (
     <div
-      className={`fixed top-16 bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
+      className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[23rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
       }`}
     >

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -122,7 +122,7 @@ export default function SurahPage({ params }: SurahPageProps) {
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 pt-16 overflow-y-auto homepage-scrollable-area">
+      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {isLoading ? (
             <div className="flex justify-center py-20">

--- a/app/features/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/page.tsx
@@ -171,7 +171,7 @@ export default function TafsirVersePage() {
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] overflow-hidden min-h-0">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] overflow-y-auto p-6 lg:p-10 pt-16 homepage-scrollable-area">
+      <main className="flex-grow bg-white dark:bg-[var(--background)] overflow-y-auto p-6 lg:p-10 homepage-scrollable-area">
         <div className="w-full space-y-6">
           {/* Ayah Navigation */}
           <div className="flex items-center justify-between rounded-full bg-teal-600 text-white p-2">


### PR DESCRIPTION
## Summary
- slide entire header out of view on scroll and collapse top spacing
- apply scroll-driven header hiding to tafsir views and side panels

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890c5cdeb148332ba0870415ead9238