### PR TITLE
refactor: memoize context values

### DIFF
--- a/app/context/AudioContext.tsx
+++ b/app/context/AudioContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useMemo, useState } from 'react';
 
 interface AudioContextType {
   playingId: number | null;
@@ -19,11 +19,12 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
   const [playingId, setPlayingId] = useState<number | null>(null);
   const [loadingId, setLoadingId] = useState<number | null>(null);
 
-  return (
-    <AudioContext.Provider value={{ playingId, setPlayingId, loadingId, setLoadingId }}>
-      {children}
-    </AudioContext.Provider>
+  const value = useMemo(
+    () => ({ playingId, setPlayingId, loadingId, setLoadingId }),
+    [playingId, setPlayingId, loadingId, setLoadingId]
   );
+
+  return <AudioContext.Provider value={value}>{children}</AudioContext.Provider>;
 };
 
 /**

--- a/app/context/SettingsContext.tsx
+++ b/app/context/SettingsContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Settings } from '@/types';
 
 export const ARABIC_FONTS = [
@@ -97,41 +97,67 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
     }
   }, [bookmarkedVerses]);
 
-  const toggleBookmark = (verseId: string) => {
-    setBookmarkedVerses((prev) =>
-      prev.includes(verseId) ? prev.filter((id) => id !== verseId) : [...prev, verseId]
-    );
-  };
-
-  const setShowByWords = (val: boolean) => setSettings((prev) => ({ ...prev, showByWords: val }));
-
-  const setTajweed = (val: boolean) => setSettings((prev) => ({ ...prev, tajweed: val }));
-
-  const setWordLang = (lang: string) => setSettings((prev) => ({ ...prev, wordLang: lang }));
-
-  const setWordTranslationId = (id: number) =>
-    setSettings((prev) => ({ ...prev, wordTranslationId: id }));
-
-  const setTafsirIds = (ids: number[]) => setSettings((prev) => ({ ...prev, tafsirIds: ids }));
-
-  return (
-    <SettingsContext.Provider
-      value={{
-        settings,
-        setSettings,
-        arabicFonts: ARABIC_FONTS,
-        bookmarkedVerses,
-        toggleBookmark,
-        setShowByWords,
-        setTajweed,
-        setWordLang,
-        setWordTranslationId,
-        setTafsirIds,
-      }}
-    >
-      {children}
-    </SettingsContext.Provider>
+  const toggleBookmark = useCallback(
+    (verseId: string) => {
+      setBookmarkedVerses((prev) =>
+        prev.includes(verseId) ? prev.filter((id) => id !== verseId) : [...prev, verseId]
+      );
+    },
+    [setBookmarkedVerses]
   );
+
+  const setShowByWords = useCallback(
+    (val: boolean) => setSettings((prev) => ({ ...prev, showByWords: val })),
+    [setSettings]
+  );
+
+  const setTajweed = useCallback(
+    (val: boolean) => setSettings((prev) => ({ ...prev, tajweed: val })),
+    [setSettings]
+  );
+
+  const setWordLang = useCallback(
+    (lang: string) => setSettings((prev) => ({ ...prev, wordLang: lang })),
+    [setSettings]
+  );
+
+  const setWordTranslationId = useCallback(
+    (id: number) => setSettings((prev) => ({ ...prev, wordTranslationId: id })),
+    [setSettings]
+  );
+
+  const setTafsirIds = useCallback(
+    (ids: number[]) => setSettings((prev) => ({ ...prev, tafsirIds: ids })),
+    [setSettings]
+  );
+
+  const value = useMemo(
+    () => ({
+      settings,
+      setSettings,
+      arabicFonts: ARABIC_FONTS,
+      bookmarkedVerses,
+      toggleBookmark,
+      setShowByWords,
+      setTajweed,
+      setWordLang,
+      setWordTranslationId,
+      setTafsirIds,
+    }),
+    [
+      settings,
+      setSettings,
+      bookmarkedVerses,
+      toggleBookmark,
+      setShowByWords,
+      setTajweed,
+      setWordLang,
+      setWordTranslationId,
+      setTafsirIds,
+    ]
+  );
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 };
 
 export const useSettings = () => {

--- a/app/context/SidebarContext.tsx
+++ b/app/context/SidebarContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 interface SidebarContextType {
   isSurahListOpen: boolean;
@@ -40,37 +40,56 @@ export const SidebarProvider = ({ children }: { children: React.ReactNode }) => 
     return stored ? Number(stored) : 0;
   });
 
-  const setSurahScrollTop = (top: number) => {
-    _setSurahScrollTop(top);
-    sessionStorage.setItem('surahScrollTop', top.toString());
-  };
-  const setJuzScrollTop = (top: number) => {
-    _setJuzScrollTop(top);
-    sessionStorage.setItem('juzScrollTop', top.toString());
-  };
-  const setPageScrollTop = (top: number) => {
-    _setPageScrollTop(top);
-    sessionStorage.setItem('pageScrollTop', top.toString());
-  };
-
-  return (
-    <SidebarContext.Provider
-      value={{
-        isSurahListOpen,
-        setSurahListOpen,
-        isSettingsOpen,
-        setSettingsOpen,
-        surahScrollTop,
-        setSurahScrollTop,
-        juzScrollTop,
-        setJuzScrollTop,
-        pageScrollTop,
-        setPageScrollTop,
-      }}
-    >
-      {children}
-    </SidebarContext.Provider>
+  const setSurahScrollTop = useCallback(
+    (top: number) => {
+      _setSurahScrollTop(top);
+      sessionStorage.setItem('surahScrollTop', top.toString());
+    },
+    [_setSurahScrollTop]
   );
+  const setJuzScrollTop = useCallback(
+    (top: number) => {
+      _setJuzScrollTop(top);
+      sessionStorage.setItem('juzScrollTop', top.toString());
+    },
+    [_setJuzScrollTop]
+  );
+  const setPageScrollTop = useCallback(
+    (top: number) => {
+      _setPageScrollTop(top);
+      sessionStorage.setItem('pageScrollTop', top.toString());
+    },
+    [_setPageScrollTop]
+  );
+
+  const value = useMemo(
+    () => ({
+      isSurahListOpen,
+      setSurahListOpen,
+      isSettingsOpen,
+      setSettingsOpen,
+      surahScrollTop,
+      setSurahScrollTop,
+      juzScrollTop,
+      setJuzScrollTop,
+      pageScrollTop,
+      setPageScrollTop,
+    }),
+    [
+      isSurahListOpen,
+      setSurahListOpen,
+      isSettingsOpen,
+      setSettingsOpen,
+      surahScrollTop,
+      setSurahScrollTop,
+      juzScrollTop,
+      setJuzScrollTop,
+      pageScrollTop,
+      setPageScrollTop,
+    ]
+  );
+
+  return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;
 };
 
 /**

--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 export type Theme = 'light' | 'dark';
 
@@ -48,7 +48,9 @@ export const ThemeProvider = ({
     }
   }, [theme]);
 
-  return <ThemeContext.Provider value={{ theme, setTheme }}>{children}</ThemeContext.Provider>;
+  const value = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 };
 
 /**


### PR DESCRIPTION
## Summary
- memoize context provider values
- stabilize custom setter helpers with useCallback

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890ce077f388332aa40e07066d0e881