### PR TITLE
Cache lowercased search term in sidebar

### DIFF
--- a/app/components/common/SurahListSidebar.tsx
+++ b/app/components/common/SurahListSidebar.tsx
@@ -177,14 +177,13 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
   ]);
 
   // Filtering lists based on search term
+  const term = searchTerm.toLowerCase();
   const filteredChapters = useMemo(
     () =>
       chapters.filter(
-        (c) =>
-          c.name_simple.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          c.id.toString().includes(searchTerm)
+        (c) => c.name_simple.toLowerCase().includes(term) || c.id.toString().includes(searchTerm)
       ),
-    [chapters, searchTerm]
+    [chapters, searchTerm, term]
   );
   const filteredJuzs = useMemo(
     () => juzs.filter((j) => j.number.toString().includes(searchTerm)),


### PR DESCRIPTION
## Summary
- avoid repeated `toLowerCase` when filtering surahs

## Testing
- `npm audit --omit=dev`
- `npm run check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890ce09daa08332b1714ebb584aa7d2