### PR TITLE
Refactor header to use visibility context

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -2,10 +2,13 @@ import { render, screen } from '@testing-library/react';
 import Header from '@/app/components/common/Header';
 import { SidebarProvider } from '@/app/context/SidebarContext';
 import { ThemeProvider } from '@/app/context/ThemeContext';
+import { HeaderVisibilityProvider } from '@/app/context/HeaderVisibilityContext';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ThemeProvider>
-    <SidebarProvider>{children}</SidebarProvider>
+    <HeaderVisibilityProvider>
+      <SidebarProvider>{children}</SidebarProvider>
+    </HeaderVisibilityProvider>
   </ThemeProvider>
 );
 
@@ -18,6 +21,7 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/',
 }));
 
 beforeAll(() => {

--- a/__tests__/SettingsSidebar.test.tsx
+++ b/__tests__/SettingsSidebar.test.tsx
@@ -8,6 +8,7 @@ import { TranslationPanel } from '@/app/features/surah/[surahId]/_components/Tra
 import { SettingsProvider } from '@/app/context/SettingsContext';
 import { SidebarProvider } from '@/app/context/SidebarContext';
 import { ThemeProvider } from '@/app/context/ThemeContext';
+import { HeaderVisibilityProvider } from '@/app/context/HeaderVisibilityContext';
 
 // mock translation hook
 jest.mock('react-i18next', () => ({
@@ -17,13 +18,16 @@ jest.mock('react-i18next', () => ({
 // mock next/navigation for Header
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/',
 }));
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ThemeProvider>
-    <SettingsProvider>
-      <SidebarProvider>{children}</SidebarProvider>
-    </SettingsProvider>
+    <HeaderVisibilityProvider>
+      <SettingsProvider>
+        <SidebarProvider>{children}</SidebarProvider>
+      </SettingsProvider>
+    </HeaderVisibilityProvider>
   </ThemeProvider>
 );
 

--- a/app/components/common/Header.tsx
+++ b/app/components/common/Header.tsx
@@ -2,52 +2,19 @@
 import { FaSearch, FaBars } from './SvgIcons';
 import { useTranslation } from 'react-i18next';
 import { useSidebar } from '@/app/context/SidebarContext';
-import { useState, useEffect, useRef } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { FaCog } from 'react-icons/fa';
 import { useTheme } from '@/app/context/ThemeContext';
+import { useHeaderVisibility } from '@/app/context/HeaderVisibilityContext';
 
-interface HeaderProps {
-  isHidden?: boolean;
-}
-
-const Header = ({ isHidden = false }: HeaderProps) => {
+const Header = () => {
   const { t } = useTranslation();
   const { setSurahListOpen, setSettingsOpen } = useSidebar();
   const router = useRouter();
   const [query, setQuery] = useState('');
   const { theme } = useTheme(); // Use the theme context to determine colors
-  const [scrollHidden, setScrollHidden] = useState(false);
-  const lastScrollY = useRef(0);
-  let pathname = '';
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    pathname = usePathname();
-  } catch {
-    // no-op in non-navigation environments (e.g., tests)
-  }
-
-  useEffect(() => {
-    const scrollEl = document.querySelector('.homepage-scrollable-area');
-    if (!scrollEl) return;
-
-    const handleScroll = () => {
-      const currentY = (scrollEl as HTMLElement).scrollTop;
-      if (currentY > lastScrollY.current && currentY > 50) {
-        setScrollHidden(true);
-      } else {
-        setScrollHidden(false);
-      }
-      lastScrollY.current = currentY;
-    };
-
-    scrollEl.addEventListener('scroll', handleScroll);
-    // Reset scroll tracking and ensure header is visible on navigation
-    lastScrollY.current = 0;
-    setScrollHidden(false);
-
-    return () => scrollEl.removeEventListener('scroll', handleScroll);
-  }, [pathname]);
+  const { isHidden } = useHeaderVisibility();
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && query.trim()) {
@@ -62,7 +29,7 @@ const Header = ({ isHidden = false }: HeaderProps) => {
 
   return (
     <header
-      className={`fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 ${headerBgClass} text-gray-800 dark:text-gray-100 shadow-sm z-50 transform transition-transform duration-300 ${isHidden || scrollHidden ? '-translate-y-full' : 'translate-y-0'}`}
+      className={`fixed top-0 left-0 right-0 h-16 grid grid-cols-[auto_1fr_auto] items-center px-4 sm:px-8 ${headerBgClass} text-gray-800 dark:text-gray-100 shadow-sm z-50 transform transition-transform duration-300 ${isHidden ? '-translate-y-full' : 'translate-y-0'}`}
     >
       {/* Column 1: Title & Surah List Toggle */}
       <div className="flex items-center gap-2">

--- a/app/context/HeaderVisibilityContext.tsx
+++ b/app/context/HeaderVisibilityContext.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
 
 interface HeaderVisibilityState {
   isHidden: boolean;
@@ -10,6 +11,7 @@ const HeaderVisibilityContext = createContext<HeaderVisibilityState>({ isHidden:
 export const HeaderVisibilityProvider = ({ children }: { children: React.ReactNode }) => {
   const [isHidden, setIsHidden] = useState(false);
   const lastScrollY = useRef(0);
+  const pathname = usePathname();
 
   useEffect(() => {
     const scrollEl = document.querySelector('.homepage-scrollable-area');
@@ -26,8 +28,12 @@ export const HeaderVisibilityProvider = ({ children }: { children: React.ReactNo
     };
 
     scrollEl.addEventListener('scroll', handleScroll);
+    // Reset scroll tracking and ensure header is visible on navigation
+    lastScrollY.current = 0;
+    setIsHidden(false);
+
     return () => scrollEl.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [pathname]);
 
   return (
     <HeaderVisibilityContext.Provider value={{ isHidden }}>

--- a/app/features/layout.tsx
+++ b/app/features/layout.tsx
@@ -12,7 +12,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   const { isHidden } = useHeaderVisibility();
   return (
     <>
-      <Header isHidden={isHidden} />
+      <Header />
       <div className="flex flex-col h-screen">
         <div
           className={`flex flex-grow overflow-hidden min-h-0 transition-[padding-top] duration-300 ${isHidden ? 'pt-0' : 'pt-16'}`}


### PR DESCRIPTION
## Summary
- remove local scroll tracking from Header
- centralize scroll listener in HeaderVisibilityContext
- consume visibility context in Header and feature layout

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890e79bcb348332b3b884b6e55d2a70