### PR TITLE
Refactor IconSidebar links

### DIFF
--- a/__tests__/IconSidebar.test.tsx
+++ b/__tests__/IconSidebar.test.tsx
@@ -38,16 +38,16 @@ describe('IconSidebar', () => {
       </Wrapper>
     );
 
-    const homeBtn = screen.getByRole('button', { name: 'home' });
-    expect(homeBtn).toBeInTheDocument();
-    expect(homeBtn.closest('a')).toHaveAttribute('href', '/');
+    const homeLink = screen.getByRole('link', { name: 'home' });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute('href', '/');
 
-    const surahBtn = screen.getByRole('button', { name: 'all_surahs' });
-    expect(surahBtn).toBeInTheDocument();
-    expect(surahBtn.closest('a')).toHaveAttribute('href', '/features/surah/1');
+    const surahLink = screen.getByRole('link', { name: 'all_surahs' });
+    expect(surahLink).toBeInTheDocument();
+    expect(surahLink).toHaveAttribute('href', '/features/surah/1');
 
-    const bookmarksBtn = screen.getByRole('button', { name: 'bookmarks' });
-    expect(bookmarksBtn).toBeInTheDocument();
-    expect(bookmarksBtn.closest('a')).toHaveAttribute('href', '/features/bookmarks');
+    const bookmarksLink = screen.getByRole('link', { name: 'bookmarks' });
+    expect(bookmarksLink).toBeInTheDocument();
+    expect(bookmarksLink).toHaveAttribute('href', '/features/bookmarks');
   });
 });

--- a/app/components/common/IconSidebar.tsx
+++ b/app/components/common/IconSidebar.tsx
@@ -17,14 +17,15 @@ const IconSidebar = () => {
     // Added h-full to make the sidebar take full height for vertical centering
     <aside className="w-20 bg-[var(--background)] text-[var(--foreground)] flex flex-col justify-center py-4 h-full overflow-x-hidden">
       <nav className="flex flex-col items-center space-y-2">
-        {navItems.map((item, index) => (
-          <Link key={index} href={item.href} title={item.label}>
-            <button
-              aria-label={item.label}
-              className="p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-[var(--foreground)] hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 border-0"
-            >
-              <item.icon className="h-6 w-6" />
-            </button>
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            title={item.label}
+            aria-label={item.label}
+            className="p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-[var(--foreground)] hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 border-0"
+          >
+            <item.icon className="h-6 w-6" />
           </Link>
         ))}
       </nav>


### PR DESCRIPTION
## Summary
- render IconSidebar items as styled `<Link>` elements
- update IconSidebar test to query links

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6890e86a9e248332a66f098714127b29