### PR TITLE
Sanitize VerseCard HTML content

### DIFF
--- a/__tests__/TafsirVerseCard.test.tsx
+++ b/__tests__/TafsirVerseCard.test.tsx
@@ -62,3 +62,24 @@ it('bookmarks verse when icon clicked', async () => {
   await userEvent.click(bookmarkButton);
   expect(bookmarkButton).toHaveAttribute('aria-label', 'Remove bookmark');
 });
+
+it('strips malicious tags from content', () => {
+  const maliciousVerse: Verse = {
+    id: 2,
+    verse_key: '1:2',
+    text_uthmani: 'م<script>alert(1)</script>',
+    words: [{ id: 1, uthmani: 'م<script>alert(1)</script>', en: 'In' }],
+    translations: [{ resource_id: 20, text: '<script>alert(1)</script>Safe' }],
+  };
+
+  render(
+    <AudioProvider>
+      <SettingsProvider>
+        <VerseCard verse={maliciousVerse} />
+      </SettingsProvider>
+    </AudioProvider>
+  );
+
+  expect(document.querySelector('script')).toBeNull();
+  expect(screen.getByText('Safe')).toBeInTheDocument();
+});

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -12,6 +12,7 @@ import { useAudio } from '@/app/context/AudioContext';
 import { useSettings } from '@/app/context/SettingsContext';
 import Spinner from '@/app/components/common/Spinner';
 import { applyTajweed } from '@/lib/tajweed';
+import DOMPurify from 'dompurify';
 
 interface VerseCardProps {
   verse: VerseType;
@@ -94,7 +95,9 @@ export default function VerseCard({ verse }: VerseCardProps) {
                     {' '}
                     <span
                       dangerouslySetInnerHTML={{
-                        __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
+                        __html: DOMPurify.sanitize(
+                          settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani
+                        ),
                       }}
                     />{' '}
                     {!showByWords && (
@@ -115,7 +118,11 @@ export default function VerseCard({ verse }: VerseCardProps) {
               ))}{' '}
             </span>
           ) : settings.tajweed ? (
-            <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+            <span
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(applyTajweed(verse.text_uthmani)),
+              }}
+            />
           ) : (
             verse.text_uthmani
           )}{' '}
@@ -126,7 +133,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
             <p
               className="text-left leading-relaxed"
               style={{ fontSize: `${settings.translationFontSize}px` }}
-              dangerouslySetInnerHTML={{ __html: t.text }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(t.text) }}
             />{' '}
           </div>
         ))}{' '}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "quran-app-v1",
       "version": "0.2.0",
       "dependencies": {
+        "dompurify": "^3.2.6",
         "framer-motion": "^11.0.17",
         "i18next": "^25.3.2",
         "lucide-react": "^0.533.0",
@@ -7631,6 +7632,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "generate-feature": "ts-node scripts/generateFeature.ts"
   },
   "dependencies": {
+    "dompurify": "^3.2.6",
+    "framer-motion": "^11.0.17",
     "i18next": "^25.3.2",
     "lucide-react": "^0.533.0",
     "next": "15.4.4",
@@ -28,10 +30,11 @@
     "react-dom": "19.1.1",
     "react-i18next": "^15.6.1",
     "react-icons": "^5.5.0",
-    "swr": "^2.3.4",
-    "framer-motion": "^11.0.17"
+    "swr": "^2.3.4"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.4",
@@ -48,6 +51,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.3",
+    "husky": "^9",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "node-fetch": "^3.3.2",
@@ -56,9 +60,6 @@
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.1",
     "typescript": "^5",
-    "whatwg-fetch": "^3.6.20",
-    "husky": "^9",
-    "@commitlint/cli": "^19.8.1",
-    "@commitlint/config-conventional": "^19.8.1"
+    "whatwg-fetch": "^3.6.20"
   }
 }


### PR DESCRIPTION
## Summary
- sanitize VerseCard Arabic and translation HTML with DOMPurify
- test that malicious tags are removed

## Testing
- `npm audit --omit=dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890e87fc364833299e9065800a6477e