### PR TITLE
fix: remove extra text color class

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -285,7 +285,7 @@ export default function HomePage() {
 
             {filteredSurahs.length === 0 && activeTab === 'Surah' && (
               <div className="text-center py-10 col-span-full content-visibility-auto animate-fade-in-up">
-                <p className="text-slate-500 dark:text-slate-400 text-slate-900">
+                <p className="text-slate-500 dark:text-slate-400">
                   No Surahs found for your search.
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- remove duplicate text color from the no-results message on the home page

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6890e887bb608332afd70e2c2226ed58