### PR TITLE
Avoid double wrapping Arabic font

### DIFF
--- a/__tests__/applyArabicFont.test.ts
+++ b/__tests__/applyArabicFont.test.ts
@@ -23,4 +23,11 @@ describe('applyArabicFont', () => {
     expect(container.querySelector('span')).toBeNull();
     expect(container.textContent).toBe(text);
   });
+
+  it('does not wrap text multiple times when called repeatedly', () => {
+    const input = 'السلام عليكم';
+    const once = applyArabicFont(input, 'Amiri');
+    const twice = applyArabicFont(once, 'Amiri');
+    expect(twice).toBe(once);
+  });
 });

--- a/lib/applyArabicFont.ts
+++ b/lib/applyArabicFont.ts
@@ -6,5 +6,12 @@
  * @returns Modified HTML with font applied to Arabic text.
  */
 export function applyArabicFont(html: string, font: string): string {
-  return html.replace(/([\u0600-\u06FF]+)/g, `<span style="font-family:${font};">$1</span>`);
+  const withoutExisting = html.replace(
+    /<span style="font-family:[^"]+;">([\u0600-\u06FF]+)<\/span>/g,
+    '$1'
+  );
+  return withoutExisting.replace(
+    /([\u0600-\u06FF]+)/g,
+    `<span style="font-family:${font};">$1</span>`
+  );
 }


### PR DESCRIPTION
## Summary
- prevent nested spans by stripping existing font-family wrappers before applying Arabic font
- add regression test to ensure applyArabicFont is idempotent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68934aaa0fb883308358c49adc3b534c