### PR TITLE
Refine language mapping test assertions

### DIFF
--- a/__tests__/languageMappings.test.ts
+++ b/__tests__/languageMappings.test.ts
@@ -9,12 +9,16 @@ describe('language mappings', () => {
 
   it('has non-empty keys and values for all mappings', () => {
     Object.entries(LANGUAGE_CODES).forEach(([key, value]) => {
-      expect(key).toBeTruthy();
-      expect(value).toBeTruthy();
+      expect(typeof key).toBe('string');
+      expect(key).not.toHaveLength(0);
+      expect(typeof value).toBe('string');
+      expect(value).not.toHaveLength(0);
     });
     Object.entries(WORD_LANGUAGE_LABELS).forEach(([key, value]) => {
-      expect(key).toBeTruthy();
-      expect(value).toBeTruthy();
+      expect(typeof key).toBe('string');
+      expect(key).not.toHaveLength(0);
+      expect(typeof value).toBe('string');
+      expect(value).not.toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- ensure language mapping test keys and values are strings and non-empty

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68934bf186e483309db77d53500fa91e