### PR TITLE
docs: clarify Husky setup in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,10 @@ This project also provides an `.editorconfig` file. Ensure your editor respects
 it so that files use UTF-8 encoding, two spaces for indentation, and always end
 with a newline.
 
-Install dependencies and initialize Git hooks with:
+Install dependencies. Husky Git hooks are installed automatically by the `prepare` script:
 
 ```bash
 npm install
-npx husky install
 ```
 
 ## Commit Message Style


### PR DESCRIPTION
## Summary
- remove manual Husky installation from setup instructions
- note that `npm install` runs `husky install` via the `prepare` script

## Testing
- `npm audit --omit=dev`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68934dcbbb2c8330ae8bf189889f19e0