### PR TITLE
ci: allow skipping commitlint with env var

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
+if [ "$SKIP_COMMITLINT" = "1" ]; then
+  exit 0
+fi
+
 npx --no-install commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ npm run check
 - Keep the first line under 50 characters.
 - Separate the summary from any additional details with a blank line.
 - Commit messages are automatically checked by Husky's `commit-msg` hook using commitlint.
+- To bypass this check when necessary, set `SKIP_COMMITLINT=1` before committing.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- allow commitlint to be bypassed via `SKIP_COMMITLINT`
- document `SKIP_COMMITLINT` in contributor guide

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`
- `npx --no-install commitlint --from HEAD~1 --to HEAD`

------
https://chatgpt.com/codex/tasks/task_b_68964d9c109c832fbfd43bf95c27449d