### PR TITLE
Fix light mode language header colors

### DIFF
--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -64,7 +64,7 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
       <div className="flex-grow overflow-y-auto">
         {Object.keys(grouped).map((lang) => (
           <div key={lang}>
-            <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm my-4">
+            <h3 className="sticky top-0 px-4 py-2 font-bold text-teal-800 text-sm my-4 bg-teal-50 dark:bg-gray-700 dark:text-teal-300">
               {lang}
             </h3>
             <div className="p-2 space-y-1">

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -83,7 +83,7 @@ export const TranslationPanel = ({
           {groupedTranslations &&
             sortedLanguages.map((lang) => (
               <div key={lang}>
-                <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm">
+                <h3 className="sticky top-0 px-4 py-2 font-bold text-teal-800 text-sm bg-teal-50 dark:bg-gray-700 dark:text-teal-300">
                   {lang.charAt(0).toUpperCase() + lang.slice(1)}
                 </h3>
                 <div className="p-2 space-y-1">


### PR DESCRIPTION
## Summary
- ensure translation and tafsir language headers use teal styling in light mode while preserving dark mode styles

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68964ff7b348832f831d5a2cf2b23c0f