### PR TITLE
Use gray headers for language selection

### DIFF
--- a/app/features/surah/[surahId]/_components/TafsirPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TafsirPanel.tsx
@@ -64,7 +64,7 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
       <div className="flex-grow overflow-y-auto">
         {Object.keys(grouped).map((lang) => (
           <div key={lang}>
-            <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm my-4">
+            <h3 className="sticky top-0 px-4 py-2 font-bold text-gray-700 text-sm my-4 bg-gray-100 dark:bg-gray-700 dark:text-teal-300">
               {lang}
             </h3>
             <div className="p-2 space-y-1">

--- a/app/features/surah/[surahId]/_components/TranslationPanel.tsx
+++ b/app/features/surah/[surahId]/_components/TranslationPanel.tsx
@@ -83,7 +83,7 @@ export const TranslationPanel = ({
           {groupedTranslations &&
             sortedLanguages.map((lang) => (
               <div key={lang}>
-                <h3 className="sticky top-0 bg-gray-100 px-4 py-2 font-bold text-teal-800 text-sm">
+                <h3 className="sticky top-0 px-4 py-2 font-bold text-gray-700 text-sm bg-gray-100 dark:bg-gray-700 dark:text-teal-300">
                   {lang.charAt(0).toUpperCase() + lang.slice(1)}
                 </h3>
                 <div className="p-2 space-y-1">


### PR DESCRIPTION
## Summary
- use gray language group headers in light mode for translation and tafsir panels while preserving dark mode styles

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run lint` *(fails: app/features/juz/[juzId]/page.tsx unused var and formatting)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68964ff7b348832f831d5a2cf2b23c0f