### PR TITLE
Add audio settings modal

### DIFF
--- a/app/components/AudioSettingsModal.tsx
+++ b/app/components/AudioSettingsModal.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { useState } from 'react';
+import { FaTimes } from '@/app/components/common/SvgIcons';
+
+interface AudioSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function AudioSettingsModal({ isOpen, onClose }: AudioSettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<'repeat' | 'reciter'>('repeat');
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg bg-white dark:bg-[var(--background)] p-4 shadow-lg">
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex space-x-4">
+            <button
+              className={`pb-1 border-b-2 ${activeTab === 'repeat' ? 'border-teal-600 text-teal-600' : 'border-transparent'}`}
+              onClick={() => setActiveTab('repeat')}
+            >
+              Repeat
+            </button>
+            <button
+              className={`pb-1 border-b-2 ${activeTab === 'reciter' ? 'border-teal-600 text-teal-600' : 'border-transparent'}`}
+              onClick={() => setActiveTab('reciter')}
+            >
+              Reciter
+            </button>
+          </div>
+          <button
+            aria-label="Close"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            <FaTimes size={16} />
+          </button>
+        </div>
+        {activeTab === 'repeat' ? <div>Repeat settings</div> : <div>Reciter settings</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -1,5 +1,5 @@
 // app/surah/[surahId]/_components/Verse.tsx
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import {
   FaPlay,
   FaPause,
@@ -15,6 +15,7 @@ import { useAudio } from '@/app/context/AudioContext';
 import Spinner from '@/app/components/common/Spinner';
 import { useSettings } from '@/app/context/SettingsContext';
 import { applyTajweed } from '@/lib/tajweed';
+import AudioSettingsModal from '@/app/components/AudioSettingsModal';
 
 interface VerseProps {
   verse: VerseType;
@@ -34,6 +35,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
   const isLoadingAudio = loadingId === verse.id;
   const isBookmarked = bookmarkedVerses.includes(String(verse.id)); // Check if verse is bookmarked (using string ID)
   const [surahId, ayahId] = verse.verse_key.split(':');
+  const [showAudioSettings, setShowAudioSettings] = useState(false);
 
   const handlePlayPause = useCallback(() => {
     if (playingId === verse.id) {
@@ -53,6 +55,14 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
   const handleTafsir = useCallback(() => {
     router.push(`/features/tafsir/${surahId}/${ayahId}`);
   }, [router, surahId, ayahId]);
+
+  const handleAudioSettings = useCallback(() => {
+    setShowAudioSettings(true);
+  }, []);
+
+  const closeAudioSettings = useCallback(() => {
+    setShowAudioSettings(false);
+  }, []);
 
   return (
     <>
@@ -97,6 +107,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
             <button
               aria-label="More options"
               title="More"
+              onClick={handleAudioSettings}
               className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
             >
               <FaEllipsisH size={18} />
@@ -163,6 +174,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
           ))}
         </div>
       </div>
+      <AudioSettingsModal isOpen={showAudioSettings} onClose={closeAudioSettings} />
     </>
   );
 });


### PR DESCRIPTION
## Summary
- build audio settings modal with Repeat and Reciter tabs
- open modal from verse options button

## Testing
- `npm run lint` *(fails: Delete `··` in app/features/juz/[juzId]/page.tsx)*
- `npx eslint app/components/AudioSettingsModal.tsx app/features/surah/[surahId]/_components/Verse.tsx`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896660e62f4832f946574eb97415487