### PR TITLE
Add reciter selection and audio URL builder

### DIFF
--- a/app/components/AudioPlayer.tsx
+++ b/app/components/AudioPlayer.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useAudio } from '@/app/context/AudioContext';
 import { API_BASE_URL } from '@/lib/api';
+import { buildAudioUrl } from '@/lib/reciters';
 import type { Verse } from '@/types';
 import Spinner from '@/app/components/common/Spinner';
 import { FaArrowLeft, FaPlay, FaPause, FaTimes } from '@/app/components/common/SvgIcons';
@@ -22,6 +23,7 @@ export default function AudioPlayer({ onError }: AudioPlayerProps) {
     loadingId,
     setLoadingId,
     repeatSettings,
+    reciter,
   } = useAudio();
 
   const [currentTime, setCurrentTime] = useState(0);
@@ -37,8 +39,8 @@ export default function AudioPlayer({ onError }: AudioPlayerProps) {
   };
 
   useEffect(() => {
-    if (!audioRef.current || !activeVerse?.audio?.url) return;
-    audioRef.current.src = `https://verses.quran.com/${activeVerse.audio.url}`;
+    if (!audioRef.current || !activeVerse) return;
+    audioRef.current.src = buildAudioUrl(activeVerse.verse_key, reciter.path);
     setLoadingId(activeVerse.id);
     audioRef.current
       .play()
@@ -48,7 +50,7 @@ export default function AudioPlayer({ onError }: AudioPlayerProps) {
         setPlayingId(null);
         setLoadingId(null);
       });
-  }, [activeVerse, audioRef, onError, setLoadingId, setPlayingId, t]);
+  }, [activeVerse, audioRef, onError, setLoadingId, setPlayingId, t, reciter]);
 
   useEffect(() => {
     setCurrentTime(0);
@@ -107,7 +109,7 @@ export default function AudioPlayer({ onError }: AudioPlayerProps) {
   const fetchVerse = async (key: string): Promise<Verse | null> => {
     try {
       const res = await fetch(
-        `${API_BASE_URL}/verses/by_key/${encodeURIComponent(key)}?fields=text_uthmani,audio`
+        `${API_BASE_URL}/verses/by_key/${encodeURIComponent(key)}?fields=text_uthmani`
       );
       const data = await res.json();
       return data.verse as Verse;

--- a/app/components/AudioSettingsModal.tsx
+++ b/app/components/AudioSettingsModal.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { FaTimes } from '@/app/components/common/SvgIcons';
 import { useAudio, RepeatSettings } from '@/app/context/AudioContext';
+import { RECITERS } from '@/lib/reciters';
 
 interface AudioSettingsModalProps {
   isOpen: boolean;
@@ -10,7 +11,8 @@ interface AudioSettingsModalProps {
 
 export default function AudioSettingsModal({ isOpen, onClose }: AudioSettingsModalProps) {
   const [activeTab, setActiveTab] = useState<'repeat' | 'reciter'>('repeat');
-  const { repeatSettings, setRepeatSettings } = useAudio();
+  const { repeatSettings, setRepeatSettings, reciter, setReciter } = useAudio();
+  const [search, setSearch] = useState('');
 
   const handleChange = (field: keyof RepeatSettings, value: string | number) => {
     setRepeatSettings({ ...repeatSettings, [field]: value });
@@ -139,7 +141,32 @@ export default function AudioSettingsModal({ isOpen, onClose }: AudioSettingsMod
             )}
           </div>
         ) : (
-          <div>Reciter settings</div>
+          <div className="space-y-4">
+            <input
+              type="text"
+              placeholder="Search reciter"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full border border-gray-300 dark:border-gray-600 rounded p-2 text-sm"
+            />
+            <ul className="max-h-48 overflow-y-auto divide-y divide-gray-200 dark:divide-gray-700">
+              {RECITERS.filter((r) => r.name.toLowerCase().includes(search.toLowerCase())).map(
+                (r) => (
+                  <li key={r.id}>
+                    <button
+                      onClick={() => setReciter(r)}
+                      className={
+                        'w-full text-left p-2 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-700 ' +
+                        (reciter.id === r.id ? 'bg-teal-100 dark:bg-teal-800' : '')
+                      }
+                    >
+                      {r.name}
+                    </button>
+                  </li>
+                )
+              )}
+            </ul>
+          </div>
         )}
       </div>
     </div>

--- a/app/context/AudioContext.tsx
+++ b/app/context/AudioContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { createContext, useContext, useMemo, useRef, useState } from 'react';
 import { Verse } from '@/types';
+import { RECITERS, Reciter } from '@/lib/reciters';
 
 interface AudioContextType {
   playingId: number | null;
@@ -12,6 +13,8 @@ interface AudioContextType {
   audioRef: React.MutableRefObject<HTMLAudioElement | null>;
   repeatSettings: RepeatSettings;
   setRepeatSettings: React.Dispatch<React.SetStateAction<RepeatSettings>>;
+  reciter: Reciter;
+  setReciter: React.Dispatch<React.SetStateAction<Reciter>>;
 }
 
 export interface RepeatSettings {
@@ -43,6 +46,7 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
     repeatEach: 1,
     delay: 0,
   });
+  const [reciter, setReciter] = useState<Reciter>(RECITERS[0]);
 
   const value = useMemo(
     () => ({
@@ -55,8 +59,10 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
       audioRef,
       repeatSettings,
       setRepeatSettings,
+      reciter,
+      setReciter,
     }),
-    [playingId, loadingId, activeVerse, repeatSettings]
+    [playingId, loadingId, activeVerse, repeatSettings, reciter]
   );
 
   return <AudioContext.Provider value={value}>{children}</AudioContext.Provider>;

--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -14,7 +14,7 @@ import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
-import { useTheme } from '@/app/context/ThemeContext';
+import { buildAudioUrl } from '@/lib/reciters';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
@@ -37,13 +37,12 @@ export default function JuzPage({ params }: JuzPageProps) {
   const [error, setError] = useState<string | null>(null);
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
-  const { playingId, setPlayingId } = useAudio();
-  const { theme } = useTheme();
+  const { playingId, setPlayingId, reciter } = useAudio();
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
   const [translationSearchTerm, setTranslationSearchTerm] = useState('');
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
   const [wordTranslationSearchTerm, setWordTranslationSearchTerm] = useState('');
-  
+
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   // Fetch Juz information using juzId
@@ -166,9 +165,9 @@ export default function JuzPage({ params }: JuzPageProps) {
                     {verses.map((v) => (
                       <React.Fragment key={v.id}>
                         <Verse verse={v} />
-                        {playingId === v.id && v.audio?.url && (
+                        {playingId === v.id && (
                           <audio
-                            src={`https://verses.quran.com/${v.audio.url}`}
+                            src={buildAudioUrl(v.verse_key, reciter.path)}
                             autoPlay
                             onEnded={() => setPlayingId(null)}
                             onError={() => {

--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -13,6 +13,7 @@ import type { LanguageCode } from '@/lib/languageCodes';
 import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
+import { buildAudioUrl } from '@/lib/reciters';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
@@ -35,7 +36,7 @@ export default function QuranPage({ params }: QuranPageProps) {
   const [error, setError] = useState<string | null>(null);
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
-  const { playingId, setPlayingId } = useAudio();
+  const { playingId, setPlayingId, reciter } = useAudio();
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
   const [translationSearchTerm, setTranslationSearchTerm] = useState('');
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
@@ -139,9 +140,9 @@ export default function QuranPage({ params }: QuranPageProps) {
                 {verses.map((v) => (
                   <React.Fragment key={v.id}>
                     <Verse verse={v} />
-                    {playingId === v.id && v.audio?.url && (
+                    {playingId === v.id && (
                       <audio
-                        src={`https://verses.quran.com/${v.audio.url}`}
+                        src={buildAudioUrl(v.verse_key, reciter.path)}
                         autoPlay
                         onEnded={() => setPlayingId(null)}
                         onError={() => {

--- a/lib/reciters.ts
+++ b/lib/reciters.ts
@@ -1,0 +1,21 @@
+export interface Reciter {
+  id: number;
+  name: string;
+  path: string;
+}
+
+export const RECITERS: Reciter[] = [
+  { id: 2, name: 'Abdul Basit (Murattal)', path: 'AbdulBaset/Murattal' },
+  { id: 1, name: 'Abdul Basit (Mujawwad)', path: 'AbdulBaset/Mujawwad' },
+  { id: 7, name: 'Mishari Rashid Alafasy', path: 'Alafasy' },
+  { id: 3, name: 'Abdurrahman as-Sudais', path: 'Sudais' },
+  { id: 4, name: 'Abu Bakr al-Shatri', path: 'Shatri' },
+];
+
+export function buildAudioUrl(verseKey: string, reciterPath: string): string {
+  const [surah, ayah] = verseKey.split(':').map((s) => s.padStart(3, '0'));
+  if (reciterPath.startsWith('http') || reciterPath.startsWith('//')) {
+    return `${reciterPath}${surah}${ayah}.mp3`;
+  }
+  return `https://verses.quran.com/${reciterPath}/mp3/${surah}${ayah}.mp3`;
+}


### PR DESCRIPTION
## Summary
- add reciter definitions and URL builder
- enable reciter search and selection in audio settings
- derive audio playback URLs from chosen reciter across pages

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6896c8e81090832fa3e030817679d286