### PR TITLE
Extend Tailwind config with brand and shadow tokens

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -12,6 +12,7 @@ const config = {
         border: 'var(--border-color)',
         accent: designTokens.colors.accent,
         'accent-hover': designTokens.colors.accentHover,
+        brand: '#009688',
       },
       spacing: designTokens.spacing,
       fontFamily: {
@@ -25,9 +26,13 @@ const config = {
       },
       borderRadius: {
         DEFAULT: designTokens.components.borderRadius,
+        xl: '1rem',
+        '2xl': '1.5rem',
       },
       boxShadow: {
         default: designTokens.components.shadow,
+        card: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        modal: '0 4px 6px rgba(0, 0, 0, 0.15)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add `colors.brand` to Tailwind theme
- define `boxShadow.card` and `boxShadow.modal`
- add `borderRadius.xl` and `borderRadius['2xl']`

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68971346bf4c832f9f911daaa1079572