### PR TITLE
Add player translation namespace

### DIFF
--- a/app/i18n.ts
+++ b/app/i18n.ts
@@ -2,13 +2,16 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import commonEn from '../public/locales/en/common.json';
+import playerEn from '../public/locales/en/player.json';
 import commonBn from '../public/locales/bn/common.json';
 
 i18n.use(initReactI18next).init({
   resources: {
-    en: { translation: commonEn },
+    en: { translation: commonEn, player: playerEn },
     bn: { translation: commonBn },
   },
+  ns: ['translation', 'player'],
+  defaultNS: 'translation',
   lng: 'en',
   fallbackLng: 'en',
   interpolation: { escapeValue: false },

--- a/next-i18next.config.mjs
+++ b/next-i18next.config.mjs
@@ -3,4 +3,6 @@ export default {
     defaultLocale: 'en',
     locales: ['en', 'bn'],
   },
+  ns: ['common', 'player'],
+  defaultNS: 'common',
 };

--- a/public/locales/en/player.json
+++ b/public/locales/en/player.json
@@ -1,0 +1,11 @@
+{
+  "skip_back": "Skip back 10 seconds",
+  "skip_forward": "Skip forward 10 seconds",
+  "pause_audio": "Pause audio",
+  "play_audio": "Play audio",
+  "toggle_repeat": "Toggle repeat",
+  "toggle_mute": "Toggle mute",
+  "audio_settings": "Audio Settings",
+  "microphone": "Microphone",
+  "could_not_play_audio": "Could not play audio."
+}


### PR DESCRIPTION
## Summary
- add player i18n namespace to app configuration
- provide English translations for player strings

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689714715904832fa3c85546d70b2fa8