### PR TITLE
Fix RTL word order on verse pages

### DIFF
--- a/app/components/player/CleanPlayer.tsx
+++ b/app/components/player/CleanPlayer.tsx
@@ -400,7 +400,6 @@ export default function CleanPlayer({
 
       {/* Options Sheet (Reciter + Repeat) */}
       {optionsOpen && (
-        // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
         <div
           className="fixed inset-0 z-50 grid place-items-center bg-black/40 p-4"
           onClick={() => setOptionsOpen(false)}
@@ -408,12 +407,14 @@ export default function CleanPlayer({
           role="button"
           tabIndex={0}
         >
-          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
           <div
             className="w-full max-w-3xl rounded-2xl bg-white border border-transparent shadow-[0_10px_30px_rgba(2,6,23,0.12),0_1px_2px_rgba(2,6,23,0.06)] p-4 md:p-6"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
             role="dialog"
             aria-modal="true"
+            tabIndex={-1}
           >
             {/* Header */}
             <div className="flex items-center gap-3 mb-4">
@@ -588,7 +589,6 @@ function IconBtn({ children, className = '', disabled, ...rest }: React.Componen
     </button>
   );
 }
-
 
 function NumberField({
   label,

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -97,6 +97,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
         <div className="flex-grow space-y-6">
           {/* ARABIC VERSE DISPLAY, WITH TAJWEED + WORD TRANSLATIONS */}
           <p
+            dir="rtl"
             className="text-right leading-loose text-[var(--foreground)]"
             style={{
               fontFamily: settings.arabicFontFace,

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -106,6 +106,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
         <div className="flex-grow space-y-6">
           {' '}
           <p
+            dir="rtl"
             className="text-right leading-loose text-[var(--foreground)]"
             style={{
               fontFamily: settings.arabicFontFace,


### PR DESCRIPTION
## Summary
- ensure Arabic verse words render right-to-left on Surah and Tafsir views
- clean up player options sheet to satisfy lint rules

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run lint`
- `npm run check` *(fails: Property 'searchParams' is missing in type... AudioSettingsModal.tsx no exported member 'RepeatSettings'...)*

------
https://chatgpt.com/codex/tasks/task_b_6897a65686e8832fb1aa63091594f67a