### PR TITLE
Align Arabic verses to the right

### DIFF
--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -107,7 +107,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
           >
             {/* Use words if available, else fall back to plain text */}
             {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-3 gap-y-1 justify-end">
+              <span className="flex flex-wrap gap-x-3 gap-y-1 justify-start">
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">
                     <span className="relative group cursor-pointer inline-block">

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/TafsirVerse.tsx
@@ -116,7 +116,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
           >
             {' '}
             {verse.words && verse.words.length > 0 ? (
-              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
+              <span className="flex flex-wrap gap-x-1 gap-y-1 justify-start">
                 {' '}
                 {verse.words.map((word: Word) => (
                   <span key={word.id} className="text-center">

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -77,6 +77,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
       <div className="flex-grow space-y-6">
         {' '}
         <p
+          dir="rtl"
           className="text-right leading-loose"
           style={{
             fontFamily: settings.arabicFontFace,
@@ -86,7 +87,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
         >
           {' '}
           {verse.words && verse.words.length > 0 ? (
-            <span className="flex flex-wrap gap-x-1 gap-y-1 justify-end">
+            <span className="flex flex-wrap gap-x-1 gap-y-1 justify-start">
               {' '}
               {verse.words.map((word: Word) => (
                 <span key={word.id} className="text-center">


### PR DESCRIPTION
## Summary
- fix RTL verse rendering by aligning word groups to the start of the flex container
- add RTL direction to verse card and ensure verses render on the right side

## Testing
- `npm run lint`
- `npm run check` *(fails: Property 'searchParams' is missing; module '@{/app/context/AudioContext}' has no exported member 'RepeatSettings'; Property 'repeatSettings' does not exist; Property 'setRepeatSettings' does not exist; Type '{ src: string; title: string | undefined; }' is not assignable to type 'IntrinsicAttributes & Props')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897abd82ec8832f9155ec10d7dddb8c