### PR TITLE
Use i18n config from next-i18next

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -34,7 +34,7 @@ const securityHeaders = [
 const nextConfig: NextConfig = {
   // --- MERGED CONFIGURATIONS ---
   // 1. Add i18n configuration
-  ...nextI18NextConfig,
+  i18n: nextI18NextConfig.i18n,
 
   // 2. Expose the Quran API base URL to the app
   env: {


### PR DESCRIPTION
## Summary
- use `nextI18NextConfig.i18n` directly in `next.config.ts`

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint` *(fails: Non-interactive elements should not be assigned mouse or keyboard event listeners)*
- `npm run check` *(fails: Non-interactive elements should not be assigned mouse or keyboard event listeners)*
- `npm run build -- --no-lint` *(fails: Type error in app/features/juz/[juzId]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_6897b4df300c832fa4dd5f01a2a48612