### PR TITLE
Use useParams for page ID

### DIFF
--- a/app/features/page/[pageId]/page.tsx
+++ b/app/features/page/[pageId]/page.tsx
@@ -14,24 +14,19 @@ import { WORD_LANGUAGE_LABELS } from '@/lib/wordLanguages';
 import { useSettings } from '@/app/context/SettingsContext';
 import { useAudio } from '@/app/context/AudioContext';
 import { buildAudioUrl } from '@/lib/reciters';
+import { useParams } from 'next/navigation';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 
 const DEFAULT_WORD_TRANSLATION_ID = 85;
 
-interface QuranPageProps {
-  params: { pageId: string };
-}
-
 /**
  * Displays Quran verses for a specific page.
  *
  * Loads verses, manages translation and word panels, and supports infinite scrolling.
- *
- * @param {{ params: { pageId: string } }} props Route parameters including `pageId`.
  */
-export default function QuranPage({ params }: QuranPageProps) {
-  const { pageId } = params;
+export default function QuranPage() {
+  const { pageId } = useParams<{ pageId: string }>();
 
   const [error, setError] = useState<string | null>(null);
   const { settings, setSettings } = useSettings();


### PR DESCRIPTION
## Summary
- retrieve pageId with useParams hook instead of route params in QuranPage

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint` *(fails: jsx-a11y/no-noninteractive-element-interactions in CleanPlayer.tsx)*
- `npm run check` *(fails: jsx-a11y/no-noninteractive-element-interactions in CleanPlayer.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_6897b4df7024832fbe6c45d96d8cced1