### PR TITLE
Use AudioContext for global playback state

### DIFF
--- a/app/components/player/components/PlaybackOptionsModal.tsx
+++ b/app/components/player/components/PlaybackOptionsModal.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { SlidersHorizontal, Mic2, Repeat } from 'lucide-react';
-import type { Reciter, RepeatOptions } from '../CleanPlayer';
+import { useAudio } from '@/app/context/AudioContext';
+import { RECITERS } from '@/lib/reciters';
+import type { RepeatOptions } from '@/app/context/AudioContext';
 
 interface Props {
   open: boolean;
@@ -9,12 +11,6 @@ interface Props {
   theme: 'light' | 'dark';
   activeTab: 'reciter' | 'repeat';
   setActiveTab: (tab: 'reciter' | 'repeat') => void;
-  reciters: Reciter[];
-  localReciter: string;
-  setLocalReciter: (id: string) => void;
-  localRepeat: RepeatOptions;
-  setLocalRepeat: (opts: RepeatOptions) => void;
-  commitOptions: () => void;
 }
 
 export default function PlaybackOptionsModal({
@@ -23,13 +19,25 @@ export default function PlaybackOptionsModal({
   theme,
   activeTab,
   setActiveTab,
-  reciters,
-  localReciter,
-  setLocalReciter,
-  localRepeat,
-  setLocalRepeat,
-  commitOptions,
 }: Props) {
+  const { reciter, setReciter, repeatOptions, setRepeatOptions } = useAudio();
+  const [localReciter, setLocalReciter] = useState(reciter.id.toString());
+  const [localRepeat, setLocalRepeat] = useState<RepeatOptions>(repeatOptions);
+
+  useEffect(() => {
+    setLocalReciter(reciter.id.toString());
+  }, [reciter]);
+
+  useEffect(() => {
+    setLocalRepeat(repeatOptions);
+  }, [repeatOptions]);
+
+  const commitOptions = () => {
+    const newReciter = RECITERS.find((r) => r.id.toString() === localReciter);
+    if (newReciter) setReciter(newReciter);
+    setRepeatOptions(localRepeat);
+    onClose();
+  };
   if (!open) return null;
 
   return (
@@ -121,12 +129,12 @@ export default function PlaybackOptionsModal({
           {activeTab === 'reciter' && (
             <div className="md:col-span-2">
               <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-3 max-h-80 overflow-auto pr-1">
-                {reciters.map((r) => (
+                {RECITERS.map((r) => (
                   <button
                     key={r.id}
-                    onClick={() => setLocalReciter(r.id)}
+                    onClick={() => setLocalReciter(r.id.toString())}
                     className={`flex items-center justify-between gap-3 rounded-xl border px-3 py-2 text-left transition ${
-                      localReciter === r.id
+                      localReciter === r.id.toString()
                         ? theme === 'dark'
                           ? 'border-sky-500 bg-sky-500/10'
                           : 'border-[#0E2A47] bg-[#0E2A47]/5'
@@ -155,7 +163,7 @@ export default function PlaybackOptionsModal({
                     </div>
                     <div
                       className={`h-4 w-4 rounded-full ${
-                        localReciter === r.id
+                        localReciter === r.id.toString()
                           ? theme === 'dark'
                             ? 'bg-sky-500'
                             : 'bg-[#0E2A47]'

--- a/app/components/player/components/SpeedControl.tsx
+++ b/app/components/player/components/SpeedControl.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
+import { useAudio } from '@/app/context/AudioContext';
 
 interface Props {
-  playbackRate: number;
-  setPlaybackRate: (rate: number) => void;
   theme: 'light' | 'dark';
 }
 
-export default function SpeedControl({ playbackRate, setPlaybackRate, theme }: Props) {
+export default function SpeedControl({ theme }: Props) {
+  const { playbackRate, setPlaybackRate } = useAudio();
   const [open, setOpen] = useState(false);
   const speedOptions = [0.75, 1, 1.25, 1.5, 2];
 

--- a/app/components/player/components/VolumeControl.tsx
+++ b/app/components/player/components/VolumeControl.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import * as Slider from '@radix-ui/react-slider';
 import { Volume2, VolumeX } from 'lucide-react';
+import { useAudio } from '@/app/context/AudioContext';
 
 interface Props {
-  volume: number;
-  setVolume: (v: number) => void;
-  onVolume?: (v: number) => void;
   theme: 'light' | 'dark';
 }
 
-export default function VolumeControl({ volume, setVolume, onVolume, theme }: Props) {
+export default function VolumeControl({ theme }: Props) {
+  const { volume, setVolume } = useAudio();
   return (
     <div className="hidden lg:flex items-center gap-2 w-28">
       {volume === 0 ? (
@@ -28,7 +27,6 @@ export default function VolumeControl({ volume, setVolume, onVolume, theme }: Pr
         step={0.01}
         onValueChange={([v]) => {
           setVolume(v);
-          onVolume?.(v);
         }}
         aria-label="Volume"
       >

--- a/app/context/AudioContext.tsx
+++ b/app/context/AudioContext.tsx
@@ -92,7 +92,17 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
       isPlayerVisible,
       closePlayer,
     }),
-    [playingId, isPlaying, loadingId, activeVerse, repeatOptions, reciter, volume, playbackRate, isPlayerVisible]
+    [
+      playingId,
+      isPlaying,
+      loadingId,
+      activeVerse,
+      repeatOptions,
+      reciter,
+      volume,
+      playbackRate,
+      isPlayerVisible,
+    ]
   );
 
   return <AudioContext.Provider value={value}>{children}</AudioContext.Provider>;

--- a/app/dev/player/page.tsx
+++ b/app/dev/player/page.tsx
@@ -117,7 +117,16 @@ export default function Page() {
           {JSON.stringify({ reciter: track.reciter, repeat }, null, 2)}
         </pre>
       </div>
-      <CleanPlayer src={track.url} title={track.title} />
+      <CleanPlayer
+        track={{
+          id: track.id,
+          title: track.title ?? '',
+          artist: track.reciter?.name ?? '',
+          coverUrl: '',
+          durationSec: 0,
+          src: track.url,
+        }}
+      />
     </div>
   );
 }

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -24,7 +24,15 @@ interface VerseProps {
  * and context values are stable.
  */
 export const Verse = memo(function Verse({ verse }: VerseProps) {
-  const { playingId, setPlayingId, loadingId, setLoadingId, setActiveVerse, audioRef } = useAudio();
+  const {
+    playingId,
+    setPlayingId,
+    loadingId,
+    setLoadingId,
+    setActiveVerse,
+    audioRef,
+    setIsPlaying,
+  } = useAudio();
   const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
   const router = useRouter();
   const showByWords = settings.showByWords ?? false;
@@ -40,10 +48,14 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
       setPlayingId(null);
       setLoadingId(null);
       setActiveVerse(null);
+      setIsPlaying(false);
     } else {
       setActiveVerse(verse);
+      setPlayingId(verse.id);
+      setLoadingId(verse.id);
+      setIsPlaying(true);
     }
-  }, [playingId, verse, audioRef, setActiveVerse, setPlayingId, setLoadingId]);
+  }, [playingId, verse, audioRef, setActiveVerse, setPlayingId, setLoadingId, setIsPlaying]);
 
   const handleBookmark = useCallback(() => {
     toggleBookmark(String(verse.id));

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -20,10 +20,9 @@ import { useSettings } from '@/app/context/SettingsContext';
 import Spinner from '@/app/components/common/Spinner';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
-import { useTheme } from '@/app/context/ThemeContext';
 import { CleanPlayer } from '@/app/components/player';
 import { useAudio } from '@/app/context/AudioContext';
-import { RECITERS, buildAudioUrl } from '@/lib/reciters';
+import { buildAudioUrl } from '@/lib/reciters';
 
 const DEFAULT_WORD_TRANSLATION_ID = 85;
 
@@ -43,20 +42,7 @@ export default function SurahPage({ params }: SurahPageProps) {
   const [coverUrl, setCoverUrl] = useState<string | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-  const {
-    activeVerse,
-    setActiveVerse,
-    isPlaying,
-    setIsPlaying,
-    reciter,
-    setReciter,
-    repeatOptions,
-    setRepeatOptions,
-    setVolume,
-    setPlayingId,
-  } = useAudio();
-
-  const { theme } = useTheme();
+  const { activeVerse, setActiveVerse, reciter } = useAudio();
 
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
@@ -162,20 +148,6 @@ export default function SurahPage({ params }: SurahPageProps) {
     }
   };
 
-  const handleTogglePlay = (playing: boolean) => {
-    setIsPlaying(playing);
-    if (playing && activeVerse) {
-      setPlayingId(activeVerse.id);
-    }
-  };
-
-  const handleReciterChange = (id: string) => {
-    const newReciter = RECITERS.find((r) => r.id.toString() === id);
-    if (newReciter) {
-      setReciter(newReciter);
-    }
-  };
-
   const track = activeVerse
     ? {
         id: activeVerse.id.toString(),
@@ -186,8 +158,6 @@ export default function SurahPage({ params }: SurahPageProps) {
         src: buildAudioUrl(activeVerse.verse_key, reciter.path),
       }
     : null;
-
-  const playerReciters = RECITERS.map((r) => ({ id: r.id.toString(), name: r.name }));
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
@@ -247,20 +217,7 @@ export default function SurahPage({ params }: SurahPageProps) {
       />
       {activeVerse && (
         <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
-          <CleanPlayer
-            track={track}
-            state={{ isPlaying }}
-            theme={theme}
-            onTogglePlay={handleTogglePlay}
-            onNext={handleNext}
-            onPrev={handlePrev}
-            onVolume={setVolume}
-            reciters={playerReciters}
-            selectedReciterId={reciter.id.toString()}
-            onReciterChange={handleReciterChange}
-            repeatOptions={repeatOptions}
-            onRepeatChange={setRepeatOptions}
-          />
+          <CleanPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Centralize playback state in `AudioContext` and remove redundant local mirrors in the player
- Let player subcomponents pull and update playback values directly from context
- Simplify verse and surah pages to rely on shared playback state

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6897daf73a80832fb4ceec47850c8936