### PR TITLE
Rename CleanPlayer to QuranAudioPlayer

### DIFF
--- a/app/components/player/QuranAudioPlayer.tsx
+++ b/app/components/player/QuranAudioPlayer.tsx
@@ -64,7 +64,7 @@ type Props = {
   onNext?: () => void;
 };
 
-export default function CleanPlayer({ track, onPrev, onNext }: Props) {
+export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
   const { theme } = useTheme();
   const {
     isPlayerVisible,

--- a/app/components/player/index.ts
+++ b/app/components/player/index.ts
@@ -1,2 +1,2 @@
-export { default as CleanPlayer } from './CleanPlayer';
+export { default as QuranAudioPlayer } from './QuranAudioPlayer';
 export * from './types';

--- a/app/context/AudioContext.tsx
+++ b/app/context/AudioContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useMemo, useRef, useState } from 'rea
 import { Verse } from '@/types';
 import { RECITERS, Reciter } from '@/lib/reciters';
 
-// This is from the new CleanPlayer component.
+// This is from the new QuranAudioPlayer component.
 export type RepeatOptions = {
   mode: 'off' | 'single' | 'range' | 'surah';
   start?: number;

--- a/app/dev/player/page.tsx
+++ b/app/dev/player/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { CleanPlayer } from '@/app/components/player';
+import { QuranAudioPlayer } from '@/app/components/player';
 import type { Track, RepeatOptions } from '@/app/components/player/types';
 
 const DEMO_TRACKS: Track[] = [
@@ -117,7 +117,7 @@ export default function Page() {
           {JSON.stringify({ reciter: track.reciter, repeat }, null, 2)}
         </pre>
       </div>
-      <CleanPlayer
+      <QuranAudioPlayer
         track={{
           id: track.id,
           title: track.title ?? '',

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -20,7 +20,7 @@ import { useSettings } from '@/app/context/SettingsContext';
 import Spinner from '@/app/components/common/Spinner';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
-import { CleanPlayer } from '@/app/components/player';
+import { QuranAudioPlayer } from '@/app/components/player';
 import { useAudio } from '@/app/context/AudioContext';
 import { buildAudioUrl } from '@/lib/reciters';
 
@@ -217,7 +217,7 @@ export default function SurahPage({ params }: SurahPageProps) {
       />
       {activeVerse && (
         <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
-          <CleanPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
+          <QuranAudioPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- rename `CleanPlayer` to `QuranAudioPlayer`
- update all imports and docs to use `QuranAudioPlayer`

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run lint`
- `npm run check` *(fails: Property 'searchParams' is missing...)*

------
https://chatgpt.com/codex/tasks/task_b_6897ee11f7c4832f9270bf9fa7847572