### PR TITLE
Sanitize verse HTML rendering

### DIFF
--- a/app/components/VerseOfDay.tsx
+++ b/app/components/VerseOfDay.tsx
@@ -9,6 +9,7 @@ import type { Surah } from '@/types';
 import { useTheme } from '@/app/providers/ThemeContext';
 import { applyTajweed } from '@/lib/text/tajweed';
 import { stripHtml } from '@/lib/text/stripHtml';
+import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 
 const surahs: Surah[] = surahsData;
 
@@ -99,7 +100,11 @@ export default function VerseOfDay() {
             verse.words.map((w: Word) => (
               <span key={w.id} className="inline-block mx-0.5 relative group">
                 {settings.tajweed ? (
-                  <span dangerouslySetInnerHTML={{ __html: applyTajweed(w.uthmani) }} />
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: sanitizeHtml(applyTajweed(w.uthmani)),
+                    }}
+                  />
                 ) : (
                   w.uthmani
                 )}
@@ -111,7 +116,11 @@ export default function VerseOfDay() {
               </span>
             ))
           ) : settings.tajweed ? (
-            <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+            <span
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHtml(applyTajweed(verse.text_uthmani)),
+              }}
+            />
           ) : (
             verse.text_uthmani
           )}

--- a/app/features/bookmarks/_components/BookmarkedVersesList.tsx
+++ b/app/features/bookmarks/_components/BookmarkedVersesList.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { getVerseById } from '@/lib/api';
+import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 import { Verse } from '@/types';
 
 const BookmarkedVersesList = () => {
@@ -45,9 +46,12 @@ const BookmarkedVersesList = () => {
       {verses.map((verse) => (
         <div key={verse.id}>
           <p className="font-semibold">{verse.verse_key}</p>
-          <p className="text-right" dangerouslySetInnerHTML={{ __html: verse.text_uthmani }} />
+          <p
+            className="text-right"
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(verse.text_uthmani) }}
+          />
           {verse.translations?.map((t) => (
-            <p key={t.resource_id} dangerouslySetInnerHTML={{ __html: t.text }} />
+            <p key={t.resource_id} dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }} />
           ))}
         </div>
       ))}

--- a/app/features/surah/[surahId]/_components/Verse.tsx
+++ b/app/features/surah/[surahId]/_components/Verse.tsx
@@ -14,6 +14,7 @@ import { useAudio } from '@/app/features/player/context/AudioContext';
 import Spinner from '@/app/components/shared/Spinner';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { applyTajweed } from '@/lib/text/tajweed';
+import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 
 interface VerseProps {
   verse: VerseType;
@@ -126,7 +127,9 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
                       {/* Tajweed coloring for each word */}
                       <span
                         dangerouslySetInnerHTML={{
-                          __html: settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani,
+                          __html: sanitizeHtml(
+                            settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani
+                          ),
                         }}
                       />
                       {/* Tooltip translation (when not showByWords) */}
@@ -150,7 +153,11 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
               </span>
             ) : // If no word data, show whole verse with or without Tajweed
             settings.tajweed ? (
-              <span dangerouslySetInnerHTML={{ __html: applyTajweed(verse.text_uthmani) }} />
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeHtml(applyTajweed(verse.text_uthmani)),
+                }}
+              />
             ) : (
               verse.text_uthmani
             )}
@@ -161,7 +168,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
               <p
                 className="text-left leading-relaxed text-[var(--foreground)]"
                 style={{ fontSize: `${settings.translationFontSize}px` }}
-                dangerouslySetInnerHTML={{ __html: t.text }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
               />
             </div>
           ))}

--- a/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
+++ b/app/features/tafsir/[surahId]/[ayahId]/_components/VerseCard.tsx
@@ -12,7 +12,7 @@ import { useAudio } from '@/app/features/player/context/AudioContext';
 import { useSettings } from '@/app/providers/SettingsContext';
 import Spinner from '@/app/components/shared/Spinner';
 import { applyTajweed } from '@/lib/text/tajweed';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 
 interface VerseCardProps {
   verse: VerseType;
@@ -96,7 +96,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
                     {' '}
                     <span
                       dangerouslySetInnerHTML={{
-                        __html: DOMPurify.sanitize(
+                        __html: sanitizeHtml(
                           settings.tajweed ? applyTajweed(word.uthmani) : word.uthmani
                         ),
                       }}
@@ -121,7 +121,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
           ) : settings.tajweed ? (
             <span
               dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(applyTajweed(verse.text_uthmani)),
+                __html: sanitizeHtml(applyTajweed(verse.text_uthmani)),
               }}
             />
           ) : (
@@ -134,7 +134,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
             <p
               className="text-left leading-relaxed"
               style={{ fontSize: `${settings.translationFontSize}px` }}
-              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(t.text) }}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
             />{' '}
           </div>
         ))}{' '}

--- a/lib/__tests__/sanitizeHtml.test.ts
+++ b/lib/__tests__/sanitizeHtml.test.ts
@@ -1,0 +1,15 @@
+import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
+
+describe('sanitizeHtml', () => {
+  it('removes script tags', () => {
+    const unsafe = '<p>Test</p><script>alert(1)</script>';
+    const sanitized = sanitizeHtml(unsafe);
+    expect(sanitized).toBe('<p>Test</p>');
+  });
+
+  it('strips unsafe attributes', () => {
+    const unsafe = '<img src="x" onerror="alert(1)" />';
+    const sanitized = sanitizeHtml(unsafe);
+    expect(sanitized).not.toMatch(/onerror/i);
+  });
+});

--- a/lib/text/sanitizeHtml.ts
+++ b/lib/text/sanitizeHtml.ts
@@ -1,0 +1,10 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitize an HTML string to remove any potentially unsafe content.
+ */
+export function sanitizeHtml(html: string): string {
+  return DOMPurify.sanitize(html);
+}
+
+export default sanitizeHtml;


### PR DESCRIPTION
## Summary
- add central `sanitizeHtml` utility powered by DOMPurify
- sanitize verse text, translations, and Tajweed output across components
- verify sanitizer strips scripts and unsafe attributes

## Testing
- `npm test` *(fails: Cannot find module '@/lib/languageCodes' in SurahPage.test.tsx; Your test suite must contain at least one test: stripHtml.test.ts)*
- `npm run check` *(fails: Cannot find module '@/lib/languageCodes')*

------
https://chatgpt.com/codex/tasks/task_b_68986487b998832f8c3672247b511374