### PR TITLE
Fix param access and cover image warnings

### DIFF
--- a/app/features/juz/[juzId]/page.tsx
+++ b/app/features/juz/[juzId]/page.tsx
@@ -23,10 +23,10 @@ const DEFAULT_WORD_TRANSLATION_ID = 85;
 export default function JuzPage({
   params,
 }: {
-  params: { juzId: string };
+  params: Promise<{ juzId: string }>;
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const { juzId } = params;
+  const { juzId } = React.use(params);
 
   const [error, setError] = useState<string | null>(null);
   const { settings, setSettings } = useSettings();

--- a/app/features/juz/__tests__/JuzPage.test.tsx
+++ b/app/features/juz/__tests__/JuzPage.test.tsx
@@ -73,7 +73,10 @@ const renderPage = () =>
       <SettingsProvider>
         <ThemeProvider>
           <SidebarProvider>
-            <JuzPage params={{ juzId: '1' }} searchParams={{}} />
+            <JuzPage
+              params={{ juzId: '1' } as unknown as Promise<{ juzId: string }>}
+              searchParams={{}}
+            />
           </SidebarProvider>
         </ThemeProvider>
       </SettingsProvider>

--- a/app/features/player/QuranAudioPlayer.tsx
+++ b/app/features/player/QuranAudioPlayer.tsx
@@ -158,7 +158,7 @@ export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
   const title = track?.title ?? 'No track selected';
   const artist = track?.artist ?? '';
   const cover =
-    track?.coverUrl ??
+    track?.coverUrl ||
     "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><rect width='100%' height='100%' rx='12' ry='12' fill='%23e5e7eb'/><text x='50%' y='52%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, system-ui, sans-serif' font-size='12' fill='%239ca3af'>No cover</text></svg>";
 
   if (!isPlayerVisible) return null;

--- a/app/features/player/components/TrackInfo.tsx
+++ b/app/features/player/components/TrackInfo.tsx
@@ -11,7 +11,7 @@ export default function TrackInfo({ cover, title, artist, theme }: Props) {
   return (
     <div className="flex items-center gap-3 min-w-0 sm:min-w-[220px] flex-shrink-0">
       <img
-        src={cover}
+        src={cover || undefined}
         alt="cover"
         className="h-12 w-12 rounded-full shadow-sm object-cover"
         onError={(e) => {

--- a/app/features/surah/[surahId]/page.tsx
+++ b/app/features/surah/[surahId]/page.tsx
@@ -27,11 +27,11 @@ import { buildAudioUrl } from '@/lib/audio/reciters';
 const DEFAULT_WORD_TRANSLATION_ID = 85;
 
 interface SurahPageProps {
-  params: { surahId: string };
+  params: Promise<{ surahId: string }>;
 }
 
 export default function SurahPage({ params }: SurahPageProps) {
-  const { surahId } = params;
+  const { surahId } = React.use(params);
   const [error, setError] = useState<string | null>(null);
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();

--- a/app/features/surah/__tests__/SurahPage.test.tsx
+++ b/app/features/surah/__tests__/SurahPage.test.tsx
@@ -75,7 +75,7 @@ const renderPage = () =>
         <SettingsProvider>
           <ThemeProvider>
             <SidebarProvider>
-              <SurahPage params={{ surahId: '1' }} />
+              <SurahPage params={{ surahId: '1' } as unknown as Promise<{ surahId: string }>} />
             </SidebarProvider>
           </ThemeProvider>
         </SettingsProvider>


### PR DESCRIPTION
## Summary
- unwrap dynamic route params with `React.use`
- avoid empty `img` sources in audio player

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check` *(fails: Cannot find module '@/app/context/ThemeContext'...)*

------
https://chatgpt.com/codex/tasks/task_b_68988282bb24832fbebe33ff2c60074b