### PR TITLE
Move NotFound tests into app/__tests__

### DIFF
--- a/app/__tests__/not-found.bn.test.tsx
+++ b/app/__tests__/not-found.bn.test.tsx
@@ -2,23 +2,23 @@ import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import NotFound from '@/app/not-found';
 import TranslationProvider from '@/app/providers/TranslationProvider';
+import i18n from '@/app/i18n';
 
-// Mock next/link for testing environment
 jest.mock('next/link', () => {
-  // eslint-disable-next-line react/display-name
   return ({ children, href }: { children: ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   );
 });
 
-describe('NotFound page', () => {
-  it('renders translated text', () => {
+describe('NotFound page in Bengali', () => {
+  it('renders Bengali text', async () => {
+    await i18n.changeLanguage('bn');
     render(
       <TranslationProvider>
         <NotFound />
       </TranslationProvider>
     );
-    expect(screen.getByText('Page not found')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+    expect(screen.getByText('পৃষ্ঠা পাওয়া যায় নি')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'বাড়ি' })).toHaveAttribute('href', '/');
   });
 });

--- a/app/__tests__/not-found.test.tsx
+++ b/app/__tests__/not-found.test.tsx
@@ -2,24 +2,22 @@ import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import NotFound from '@/app/not-found';
 import TranslationProvider from '@/app/providers/TranslationProvider';
-import i18n from '@/app/i18n';
 
+// Mock next/link for testing environment
 jest.mock('next/link', () => {
-  // eslint-disable-next-line react/display-name
   return ({ children, href }: { children: ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   );
 });
 
-describe('NotFound page in Bengali', () => {
-  it('renders Bengali text', async () => {
-    await i18n.changeLanguage('bn');
+describe('NotFound page', () => {
+  it('renders translated text', () => {
     render(
       <TranslationProvider>
         <NotFound />
       </TranslationProvider>
     );
-    expect(screen.getByText('পৃষ্ঠা পাওয়া যায় নি')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'বাড়ি' })).toHaveAttribute('href', '/');
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
   });
 });


### PR DESCRIPTION
## Summary
- create `app/__tests__/` and move NotFound tests into it
- clean up unused ESLint directives in NotFound tests

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Cannot find module '../[surahId]/_components/SettingsSidebar')*
- `npm test` *(fails: Cannot find module '../[surahId]/_components/SettingsSidebar')*


------
https://chatgpt.com/codex/tasks/task_b_68989812c7b0832fbf085785a0d53d69