### PR TITLE
Point shared routes to new paths

### DIFF
--- a/app/shared/Header.tsx
+++ b/app/shared/Header.tsx
@@ -18,7 +18,7 @@ const Header = () => {
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && query.trim()) {
-      router.push(`/features/search?query=${encodeURIComponent(query.trim())}`);
+      router.push(`/search?query=${encodeURIComponent(query.trim())}`);
     }
   };
 

--- a/app/shared/IconSidebar.tsx
+++ b/app/shared/IconSidebar.tsx
@@ -7,9 +7,9 @@ import Link from 'next/link'; // Import Link
 const IconSidebar = () => {
   const { t } = useTranslation();
   const navItems = [
-    { icon: FaHome, label: t('home'), href: '/' }, // Added href
-    { icon: FaTh, label: t('all_surahs'), href: '/features/surah/1' },
-    { icon: FaRegBookmark, label: t('bookmarks'), href: '/features/bookmarks' },
+    { icon: FaHome, label: t('home'), href: '/' },
+    { icon: FaTh, label: t('all_surahs'), href: '/surah/1' },
+    { icon: FaRegBookmark, label: t('bookmarks'), href: '/bookmarks' },
   ];
 
   return (

--- a/app/shared/SurahListSidebar.tsx
+++ b/app/shared/SurahListSidebar.tsx
@@ -284,11 +284,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <li key={chapter.id}>
                     <Link
-                      href={
-                        isTafsirPath
-                          ? `/features/tafsir/${chapter.id}/1`
-                          : `/features/surah/${chapter.id}`
-                      }
+                      href={isTafsirPath ? `/tafsir/${chapter.id}/1` : `/surah/${chapter.id}`}
                       scroll={false}
                       data-active={isActive}
                       onClick={() => {
@@ -361,7 +357,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <li key={juz.number}>
                     <Link
-                      href={`/features/juz/${juz.number}`}
+                      href={`/juz/${juz.number}`}
                       scroll={false}
                       data-active={isActive}
                       onClick={() => {
@@ -432,7 +428,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <li key={p}>
                     <Link
-                      href={`/features/page/${p}`}
+                      href={`/page/${p}`}
                       scroll={false}
                       data-active={isActive}
                       onClick={() => {

--- a/app/shared/__tests__/IconSidebar.test.tsx
+++ b/app/shared/__tests__/IconSidebar.test.tsx
@@ -44,10 +44,10 @@ describe('IconSidebar', () => {
 
     const surahLink = screen.getByRole('link', { name: 'all_surahs' });
     expect(surahLink).toBeInTheDocument();
-    expect(surahLink).toHaveAttribute('href', '/features/surah/1');
+    expect(surahLink).toHaveAttribute('href', '/surah/1');
 
     const bookmarksLink = screen.getByRole('link', { name: 'bookmarks' });
     expect(bookmarksLink).toBeInTheDocument();
-    expect(bookmarksLink).toHaveAttribute('href', '/features/bookmarks');
+    expect(bookmarksLink).toHaveAttribute('href', '/bookmarks');
   });
 });

--- a/app/shared/__tests__/SurahListSidebar.test.tsx
+++ b/app/shared/__tests__/SurahListSidebar.test.tsx
@@ -66,7 +66,7 @@ beforeEach(() => {
   localStorage.clear();
   mockUseSWR.mockReturnValue({ data: chapters });
   useParams.mockReturnValue({});
-  usePathname.mockReturnValue('/features/surah');
+  usePathname.mockReturnValue('/surah');
 });
 
 describe('SurahListSidebar', () => {


### PR DESCRIPTION
## Summary
- point Header search to `/search`
- link sidebars directly to `/surah/:id` and `/bookmarks`
- update sidebar tests for new routes

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6898f5698dbc832fb99fc26be13a5e9c