### PR TITLE
Move page feature into route group

### DIFF
--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -1,3 +1,4 @@
+// app/(features)/page/[pageId]/page.tsx
 'use client';
 
 import React, { useEffect, useState, useMemo, useRef } from 'react';

--- a/app/(features)/page/__tests__/PagePage.test.tsx
+++ b/app/(features)/page/__tests__/PagePage.test.tsx
@@ -3,7 +3,7 @@ import { SettingsProvider } from '@/app/providers/SettingsContext';
 import { AudioProvider } from '@/app/features/player/context/AudioContext';
 import { SidebarProvider } from '@/app/providers/SidebarContext';
 import { ThemeProvider } from '@/app/providers/ThemeContext';
-import QuranPage from '@/app/features/page/[pageId]/page';
+import QuranPage from '@/app/(features)/page/[pageId]/page';
 import { Verse } from '@/types';
 import * as api from '@/lib/api';
 

--- a/app/(features)/page/layout.tsx
+++ b/app/(features)/page/layout.tsx
@@ -1,4 +1,4 @@
-// app/features/page/layout.tsx
+// app/(features)/page/layout.tsx
 'use client';
 import { AudioProvider } from '@/app/features/player/context/AudioContext';
 

--- a/app/features/home/components/HomePage.tsx
+++ b/app/features/home/components/HomePage.tsx
@@ -262,7 +262,7 @@ export default function HomePage() {
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                 {allPages.map((page) => (
                   <Link
-                    href={`/features/page/${page}`}
+                    href={`/page/${page}`}
                     key={page}
                     className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
                   >

--- a/app/shared/SurahListSidebar.tsx
+++ b/app/shared/SurahListSidebar.tsx
@@ -432,7 +432,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
                 return (
                   <li key={p}>
                     <Link
-                      href={`/features/page/${p}`}
+                      href={`/page/${p}`}
                       scroll={false}
                       data-active={isActive}
                       onClick={() => {


### PR DESCRIPTION
## Summary
- Move Quran page feature under app/(features) to remove /features segment from URLs
- Adjust imports and tests for new route location
- Update sidebar and home links to point to /page/:pageId

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6898f564b650832f911c6a79296e0c8a