### PR TITLE
Add openPlayer and check player visibility

### DIFF
--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -39,7 +39,7 @@ export default function PagePage({ params }: PagePageProps) {
   const [coverUrl, setCoverUrl] = useState<string | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-  const { activeVerse, setActiveVerse, reciter } = useAudio();
+  const { activeVerse, setActiveVerse, reciter, isPlayerVisible, openPlayer } = useAudio();
 
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
@@ -137,6 +137,7 @@ export default function PagePage({ params }: PagePageProps) {
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex < verses.length - 1) {
       setActiveVerse(verses[currentIndex + 1]);
+      openPlayer();
     }
   };
 
@@ -145,6 +146,7 @@ export default function PagePage({ params }: PagePageProps) {
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex > 0) {
       setActiveVerse(verses[currentIndex - 1]);
+      openPlayer();
     }
   };
 
@@ -215,7 +217,7 @@ export default function PagePage({ params }: PagePageProps) {
           });
         }}
       />
-      {activeVerse && (
+      {activeVerse && isPlayerVisible && (
         <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
           <QuranAudioPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
         </div>

--- a/app/(features)/player/context/AudioContext.tsx
+++ b/app/(features)/player/context/AudioContext.tsx
@@ -32,6 +32,7 @@ interface AudioContextType {
   playbackRate: number;
   setPlaybackRate: React.Dispatch<React.SetStateAction<number>>;
   isPlayerVisible: boolean;
+  openPlayer: () => void;
   closePlayer: () => void;
 }
 
@@ -60,6 +61,10 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
   const [volume, setVolume] = useState(0.9);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [isPlayerVisible, setPlayerVisible] = useState(true);
+
+  const openPlayer = () => {
+    setPlayerVisible(true);
+  };
 
   const closePlayer = () => {
     setIsPlaying(false);
@@ -90,6 +95,7 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
       playbackRate,
       setPlaybackRate,
       isPlayerVisible,
+      openPlayer,
       closePlayer,
     }),
     [

--- a/app/(features)/surah/[surahId]/components/Verse.tsx
+++ b/app/(features)/surah/[surahId]/components/Verse.tsx
@@ -27,6 +27,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
     setActiveVerse,
     audioRef,
     setIsPlaying,
+    openPlayer,
   } = useAudio();
   const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
   const router = useRouter();
@@ -49,8 +50,18 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
       setPlayingId(verse.id);
       setLoadingId(verse.id);
       setIsPlaying(true);
+      openPlayer();
     }
-  }, [playingId, verse, audioRef, setActiveVerse, setPlayingId, setLoadingId, setIsPlaying]);
+  }, [
+    playingId,
+    verse,
+    audioRef,
+    setActiveVerse,
+    setPlayingId,
+    setLoadingId,
+    setIsPlaying,
+    openPlayer,
+  ]);
 
   const handleBookmark = useCallback(() => {
     toggleBookmark(String(verse.id));

--- a/app/(features)/surah/[surahId]/page.tsx
+++ b/app/(features)/surah/[surahId]/page.tsx
@@ -42,7 +42,7 @@ export default function SurahPage({ params }: SurahPageProps) {
   const [coverUrl, setCoverUrl] = useState<string | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-  const { activeVerse, setActiveVerse, reciter } = useAudio();
+  const { activeVerse, setActiveVerse, reciter, isPlayerVisible, openPlayer } = useAudio();
 
   const { data: translationOptionsData } = useSWR('translations', getTranslations);
   const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
@@ -137,6 +137,7 @@ export default function SurahPage({ params }: SurahPageProps) {
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex < verses.length - 1) {
       setActiveVerse(verses[currentIndex + 1]);
+      openPlayer();
     }
   };
 
@@ -145,6 +146,7 @@ export default function SurahPage({ params }: SurahPageProps) {
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex > 0) {
       setActiveVerse(verses[currentIndex - 1]);
+      openPlayer();
     }
   };
 
@@ -215,7 +217,7 @@ export default function SurahPage({ params }: SurahPageProps) {
           });
         }}
       />
-      {activeVerse && (
+      {activeVerse && isPlayerVisible && (
         <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
           <QuranAudioPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
         </div>


### PR DESCRIPTION
## Summary
- expose audio player visibility and add `openPlayer` helper
- call `openPlayer` on verse selection so the player reappears
- hide player container when the player is closed

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689aff4ad1f8832f872332903f655519