### PR TITLE
Call onNext before pausing audio

### DIFF
--- a/app/(features)/player/QuranAudioPlayer.tsx
+++ b/app/(features)/player/QuranAudioPlayer.tsx
@@ -203,7 +203,10 @@ export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
         src={track?.src || ''}
         preload="metadata"
         onEnded={() => {
-          onNext?.();
+          if (onNext) {
+            onNext();
+            return;
+          }
           pause();
           setIsPlaying(false);
           setPlayingId(null);


### PR DESCRIPTION
## Summary
- call onNext and return when audio ends and onNext exists
- pause and reset player only if no onNext callback

## Testing
- `npm test`
- `npm run lint`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_689b3de7907c832f92a874a6e0287588