### PR TITLE
Clamp repeat range in player options

### DIFF
--- a/app/(features)/player/components/PlaybackOptionsModal.tsx
+++ b/app/(features)/player/components/PlaybackOptionsModal.tsx
@@ -35,7 +35,12 @@ export default function PlaybackOptionsModal({
   const commitOptions = () => {
     const newReciter = RECITERS.find((r) => r.id.toString() === localReciter);
     if (newReciter) setReciter(newReciter);
-    setRepeatOptions(localRepeat);
+    const start = Math.max(1, localRepeat.start ?? 1);
+    const end = Math.max(start, localRepeat.end ?? start);
+    if (start !== localRepeat.start || end !== localRepeat.end) {
+      alert('Start and end values adjusted to a valid range.');
+    }
+    setRepeatOptions({ ...localRepeat, start, end });
     onClose();
   };
   if (!open) return null;


### PR DESCRIPTION
## Summary
- clamp repeat start and end values before applying options
- alert when repeat range is adjusted

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_689b3deb83a0832f904d4681c2200122