### PR TITLE
Handle missing next verse in player

### DIFF
--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -133,21 +133,25 @@ export default function PagePage({ params }: PagePageProps) {
   }, [activeVerse]);
 
   const handleNext = () => {
-    if (!activeVerse) return;
+    if (!activeVerse) return false;
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex < verses.length - 1) {
       setActiveVerse(verses[currentIndex + 1]);
       openPlayer();
+      return true;
     }
+    return false;
   };
 
   const handlePrev = () => {
-    if (!activeVerse) return;
+    if (!activeVerse) return false;
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex > 0) {
       setActiveVerse(verses[currentIndex - 1]);
       openPlayer();
+      return true;
     }
+    return false;
   };
 
   const track = activeVerse

--- a/app/(features)/player/QuranAudioPlayer.tsx
+++ b/app/(features)/player/QuranAudioPlayer.tsx
@@ -33,8 +33,8 @@ import type { Track } from './types';
 
 type Props = {
   track?: Track | null;
-  onPrev?: () => void;
-  onNext?: () => void;
+  onPrev?: () => boolean;
+  onNext?: () => boolean;
 };
 
 export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
@@ -203,13 +203,14 @@ export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
         src={track?.src || ''}
         preload="metadata"
         onEnded={() => {
-          if (onNext) {
-            onNext();
-            return;
-          }
-          pause();
-          setIsPlaying(false);
-          setPlayingId(null);
+          const hasNext = onNext?.() ?? false;
+          setTimeout(() => {
+            if (!hasNext || !internalAudioRef.current?.src) {
+              pause();
+              setIsPlaying(false);
+              setPlayingId(null);
+            }
+          }, 0);
         }}
       >
         <track kind="captions" />

--- a/app/(features)/surah/[surahId]/page.tsx
+++ b/app/(features)/surah/[surahId]/page.tsx
@@ -133,21 +133,25 @@ export default function SurahPage({ params }: SurahPageProps) {
   }, [activeVerse]);
 
   const handleNext = () => {
-    if (!activeVerse) return;
+    if (!activeVerse) return false;
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex < verses.length - 1) {
       setActiveVerse(verses[currentIndex + 1]);
       openPlayer();
+      return true;
     }
+    return false;
   };
 
   const handlePrev = () => {
-    if (!activeVerse) return;
+    if (!activeVerse) return false;
     const currentIndex = verses.findIndex((v) => v.id === activeVerse.id);
     if (currentIndex > 0) {
       setActiveVerse(verses[currentIndex - 1]);
       openPlayer();
+      return true;
     }
+    return false;
   };
 
   const track = activeVerse


### PR DESCRIPTION
## Summary
- ensure audio player stops when next verse isn't loaded
- return success booleans from page and surah navigation helpers

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689b44ae35d4832fbae9750b49b1f770