### PR TITLE
Reset active verse when closing player

### DIFF
--- a/app/(features)/player/context/AudioContext.tsx
+++ b/app/(features)/player/context/AudioContext.tsx
@@ -60,11 +60,12 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
   const closePlayer = useCallback(() => {
     setIsPlaying(false);
     setPlayingId(null);
+    setActiveVerse(null);
     if (audioRef.current) {
       audioRef.current.pause();
     }
     setPlayerVisible(false);
-  }, [setIsPlaying, setPlayingId, audioRef, setPlayerVisible]);
+  }, [setIsPlaying, setPlayingId, setActiveVerse, audioRef, setPlayerVisible]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- Reset `activeVerse` in `closePlayer` to fully clear player state

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run check`
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b44b542e4832fb8d86f684ee502c2