### PR TITLE
Simplify keyboard interaction effect dependencies

### DIFF
--- a/app/(features)/player/QuranAudioPlayer.tsx
+++ b/app/(features)/player/QuranAudioPlayer.tsx
@@ -128,7 +128,7 @@ export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [current, duration, interactable, isPlaying, setSeek, togglePlay, setVolume]);
+  }, [current, duration, setSeek, togglePlay, setVolume]);
 
   const elapsed = useMemo(() => mmss(current), [current]);
   const total = useMemo(() => mmss(duration || 0), [duration]);


### PR DESCRIPTION
## Summary
- remove unused `interactable` and `isPlaying` from keyboard event listener deps

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689b44efcbbc832fab5d5891cf316225