### PR TITLE
Handle abort errors in audio player

### DIFF
--- a/app/(features)/player/hooks/useAudioPlayer.ts
+++ b/app/(features)/player/hooks/useAudioPlayer.ts
@@ -17,6 +17,7 @@ export default function useAudioPlayer(options: Options = {}) {
     const a = audioRef.current;
     if (!a) return;
     a.play().catch((err) => {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       if (onError) onError(err);
       else console.error(err);
     });
@@ -60,6 +61,7 @@ export default function useAudioPlayer(options: Options = {}) {
     if (!a) return;
     if (isPlaying) {
       a.play().catch((err) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
         if (onError) onError(err);
         else console.error(err);
       });


### PR DESCRIPTION
## Summary
- skip logging abort errors when playing audio
- add same abort error handling in replay effect

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689b5560a2c4832fbce2c7e8583b3ab7