### PR TITLE
Add types contribution guidelines

### DIFF
--- a/types/AGENTS.md
+++ b/types/AGENTS.md
@@ -1,0 +1,16 @@
+# Types Guidelines
+
+## Naming
+
+- Use PascalCase for interfaces and type aliases.
+- Use singular, kebab-case file names matching the type (e.g., `verse.ts` for `Verse`).
+
+## Exports
+
+- Declare each interface or type in its own file within this directory.
+- Export it from the file using named exports.
+- Re-export all public types through `types/index.ts` so they can be imported from a single entry point.
+
+## Documentation
+
+- Add TSDoc comments (`/** ... */`) for every public type or interface.


### PR DESCRIPTION
## Summary
- document naming conventions and export expectations for `types`
- require re-export through `types/index.ts`
- note that public types need TSDoc comments

## Testing
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689b557a0b40832fb3c14a03609306de