### PR TITLE
Add tests for reciter audio URL builder

### DIFF
--- a/lib/audio/__tests__/reciters.test.ts
+++ b/lib/audio/__tests__/reciters.test.ts
@@ -1,0 +1,13 @@
+import { buildAudioUrl } from '@/lib/audio/reciters';
+
+describe('buildAudioUrl', () => {
+  it('builds correct URL for standard reciter paths', () => {
+    const url = buildAudioUrl('1:1', 'AbdulBaset/Murattal');
+    expect(url).toBe('https://verses.quran.com/AbdulBaset/Murattal/mp3/001001.mp3');
+  });
+
+  it('builds correct URL for fully-qualified reciter paths', () => {
+    const url = buildAudioUrl('1:1', 'https://example.com/recitations/');
+    expect(url).toBe('https://example.com/recitations/001001.mp3');
+  });
+});


### PR DESCRIPTION
## Summary
- test URL generation for standard reciter paths
- test URL generation for fully-qualified reciter paths

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b558295c4832f82b8d7982ad6e5a7