### PR TITLE
Add tests for surah and juz data integrity

### DIFF
--- a/data/__tests__/juzData.test.ts
+++ b/data/__tests__/juzData.test.ts
@@ -4,4 +4,10 @@ describe('juz.json', () => {
   it('has distinct ranges for first two juz', () => {
     expect(juzData[0].surahRange).not.toEqual(juzData[1].surahRange);
   });
+
+  it('has 30 unique entries', () => {
+    expect(juzData).toHaveLength(30);
+    const numbers = juzData.map((j) => j.number);
+    expect(new Set(numbers).size).toBe(30);
+  });
 });

--- a/data/__tests__/surahData.test.ts
+++ b/data/__tests__/surahData.test.ts
@@ -1,0 +1,17 @@
+import surahs from '@/data/surahs.json';
+
+describe('surahs.json', () => {
+  it('contains 114 surahs with required fields', () => {
+    expect(surahs).toHaveLength(114);
+    surahs.forEach((surah) => {
+      expect(surah).toEqual(
+        expect.objectContaining({
+          number: expect.any(Number),
+          arabicName: expect.any(String),
+          verses: expect.any(Number),
+          meaning: expect.any(String),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test surah data for 114 entries with required metadata
- verify juz data contains 30 unique entries

## Testing
- `npm run check`
- `npm test data/__tests__/surahData.test.ts data/__tests__/juzData.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_689b5588fa08832fa1934854d06e57f9