### PR TITLE
Persist audio settings in localStorage

### DIFF
--- a/app/(features)/player/__tests__/AudioProvider.test.tsx
+++ b/app/(features)/player/__tests__/AudioProvider.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { AudioProvider, useAudio } from '../context/AudioContext';
+import { RECITERS } from '@/lib/audio/reciters';
+
+const Consumer = () => {
+  const { reciter, volume, playbackRate, setReciter, setVolume, setPlaybackRate } = useAudio();
+  return (
+    <>
+      <div data-testid="reciter">{reciter.id}</div>
+      <div data-testid="volume">{volume}</div>
+      <div data-testid="playbackRate">{playbackRate}</div>
+      <button onClick={() => setReciter(RECITERS[2])}>reciter</button>
+      <button onClick={() => setVolume(0.5)}>volume</button>
+      <button onClick={() => setPlaybackRate(1.5)}>playbackRate</button>
+    </>
+  );
+};
+
+test('settings persist after reload', async () => {
+  localStorage.clear();
+
+  const { getByText, unmount } = render(
+    <AudioProvider>
+      <Consumer />
+    </AudioProvider>
+  );
+
+  fireEvent.click(getByText('reciter'));
+  fireEvent.click(getByText('volume'));
+  fireEvent.click(getByText('playbackRate'));
+
+  await waitFor(() => {
+    expect(localStorage.getItem('reciterId')).toBe(String(RECITERS[2].id));
+    expect(localStorage.getItem('volume')).toBe('0.5');
+    expect(localStorage.getItem('playbackRate')).toBe('1.5');
+  });
+
+  unmount();
+
+  const { getByTestId } = render(
+    <AudioProvider>
+      <Consumer />
+    </AudioProvider>
+  );
+
+  expect(getByTestId('reciter').textContent).toBe(String(RECITERS[2].id));
+  expect(getByTestId('volume').textContent).toBe('0.5');
+  expect(getByTestId('playbackRate').textContent).toBe('1.5');
+});

--- a/app/(features)/player/context/AudioContext.tsx
+++ b/app/(features)/player/context/AudioContext.tsx
@@ -1,5 +1,13 @@
 'use client';
-import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Verse } from '@/types';
 import { RECITERS } from '@/lib/audio/reciters';
 import type { Reciter, RepeatOptions } from '@/app/(features)/player/types';
@@ -52,6 +60,48 @@ export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
   const [volume, setVolume] = useState(0.9);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [isPlayerVisible, setPlayerVisible] = useState(true);
+
+  // Load persisted settings on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const reciterId = localStorage.getItem('reciterId');
+      if (reciterId) {
+        const parsed = Number.parseInt(reciterId, 10);
+        const found = RECITERS.find((r) => r.id === parsed);
+        if (found) setReciter(found);
+        else localStorage.removeItem('reciterId');
+      }
+
+      const storedVolume = localStorage.getItem('volume');
+      if (storedVolume !== null) {
+        const parsed = Number.parseFloat(storedVolume);
+        if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 1) setVolume(parsed);
+        else localStorage.removeItem('volume');
+      }
+
+      const storedRate = localStorage.getItem('playbackRate');
+      if (storedRate !== null) {
+        const parsed = Number.parseFloat(storedRate);
+        if (!Number.isNaN(parsed) && parsed > 0) setPlaybackRate(parsed);
+        else localStorage.removeItem('playbackRate');
+      }
+    } catch {
+      // ignore corrupted localStorage entries
+    }
+  }, []);
+
+  // Persist settings when they change
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem('reciterId', String(reciter.id));
+      localStorage.setItem('volume', String(volume));
+      localStorage.setItem('playbackRate', String(playbackRate));
+    } catch {
+      // ignore write errors
+    }
+  }, [reciter.id, volume, playbackRate]);
 
   const openPlayer = useCallback(() => {
     setPlayerVisible(true);


### PR DESCRIPTION
## Summary
- load reciter, volume, and playback rate defaults from localStorage
- persist audio settings and handle corrupted entries
- test that audio settings survive provider remounts

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689bbc9a711c832fa4738787f551a21c