### PR TITLE
Enforce integer-only repeat options

### DIFF
--- a/app/(features)/player/__tests__/PlaybackOptionsModal.test.tsx
+++ b/app/(features)/player/__tests__/PlaybackOptionsModal.test.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PlaybackOptionsModal from '@/app/(features)/player/components/PlaybackOptionsModal';
+import { ThemeProvider } from '@/app/providers/ThemeContext';
+import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { SidebarProvider } from '@/app/providers/SidebarContext';
+import { AudioProvider, useAudio } from '@/app/(features)/player/context/AudioContext';
+
+const Providers = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider>
+    <SettingsProvider>
+      <SidebarProvider>
+        <AudioProvider>{children}</AudioProvider>
+      </SidebarProvider>
+    </SettingsProvider>
+  </ThemeProvider>
+);
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+test('coerces decimal input to integer', async () => {
+  const onClose = jest.fn();
+  render(
+    <Providers>
+      <PlaybackOptionsModal
+        open
+        onClose={onClose}
+        theme="light"
+        activeTab="repeat"
+        setActiveTab={() => {}}
+      />
+    </Providers>
+  );
+
+  const startInput = screen.getByLabelText('Start') as HTMLInputElement;
+  expect(startInput).toHaveAttribute('step', '1');
+  fireEvent.change(startInput, { target: { value: '3.7' } });
+  expect(startInput.value).toBe('3');
+});
+
+test('rejects decimal repeat values', async () => {
+  const onClose = jest.fn();
+
+  const Wrapper = () => {
+    const { setRepeatOptions } = useAudio();
+    useEffect(() => {
+      setRepeatOptions((prev) => ({ ...prev, start: 1.5 }));
+    }, [setRepeatOptions]);
+    return (
+      <PlaybackOptionsModal
+        open
+        onClose={onClose}
+        theme="light"
+        activeTab="repeat"
+        setActiveTab={() => {}}
+      />
+    );
+  };
+
+  render(
+    <Providers>
+      <Wrapper />
+    </Providers>
+  );
+
+  await screen.findByDisplayValue('1.5');
+  await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+  expect(onClose).not.toHaveBeenCalled();
+  expect(screen.getByText('Please enter whole numbers only.')).toBeInTheDocument();
+});

--- a/app/(features)/player/components/PlaybackOptionsModal.tsx
+++ b/app/(features)/player/components/PlaybackOptionsModal.tsx
@@ -37,6 +37,22 @@ export default function PlaybackOptionsModal({
   }, [open]);
 
   const commitOptions = () => {
+    const numericKeys: (keyof RepeatOptions)[] = [
+      'start',
+      'end',
+      'playCount',
+      'repeatEach',
+      'delay',
+    ];
+    if (
+      numericKeys.some((key) => {
+        const val = localRepeat[key];
+        return val !== undefined && !Number.isInteger(val);
+      })
+    ) {
+      setRangeWarning('Please enter whole numbers only.');
+      return;
+    }
     const newReciter = RECITERS.find((r) => r.id.toString() === localReciter);
     if (newReciter) setReciter(newReciter);
     const start = Math.max(1, localRepeat.start ?? 1);
@@ -335,8 +351,9 @@ function NumberField({
         type="number"
         value={Number.isFinite(value) ? value : 0}
         min={min}
+        step={1}
         onChange={(e) => {
-          const v = parseFloat(e.target.value);
+          const v = parseInt(e.target.value, 10);
           onChange(Number.isNaN(v) ? (min ?? value) : v);
         }}
         className={`w-full rounded-xl border px-3 py-2 focus:outline-none focus:ring-2 ${


### PR DESCRIPTION
## Summary
- prevent decimals in repeat options by parsing integers and validating input
- reject non-integer repeat values before applying changes
- test repeat options modal against decimal input

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689bbc90134c832fb1044bf1c9468f72