### PR TITLE
Refactor settings sidebar into modular components

### DIFF
--- a/app/(features)/player/QuranAudioPlayer.tsx
+++ b/app/(features)/player/QuranAudioPlayer.tsx
@@ -328,7 +328,6 @@ export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
               pause,
               setIsPlaying,
               setPlayingId,
-              internalAudioRef,
               setVerseRepeatsLeft,
               setPlayRepeatsLeft,
             });

--- a/app/(features)/surah/[surahId]/components/FontSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/FontSettings.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaFontSetting, FaChevronDown } from '@/app/shared/SvgIcons';
+import { CollapsibleSection } from './CollapsibleSection';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { useFontSize } from '../../hooks/useFontSize';
+
+interface FontSettingsProps {
+  onArabicFontPanelOpen: () => void;
+}
+
+export const FontSettings = ({ onArabicFontPanelOpen }: FontSettingsProps) => {
+  const { settings, setSettings, arabicFonts } = useSettings();
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(true);
+  const { style: arabicStyle } = useFontSize(settings.arabicFontSize, 16, 48);
+  const { style: translationStyle } = useFontSize(settings.translationFontSize, 12, 28);
+
+  const selectedArabicFont =
+    arabicFonts.find((font) => font.value === settings.arabicFontFace)?.name || t('select_font');
+
+  return (
+    <CollapsibleSection
+      title={t('font_setting')}
+      icon={<FaFontSetting size={20} className="text-teal-700" />}
+      isLast
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+    >
+      <div className="space-y-4">
+        <div>
+          <div className="flex justify-between mb-1 text-sm">
+            <label className="text-[var(--foreground)]">{t('arabic_font_size')}</label>
+            <span className="font-semibold text-teal-700">{settings.arabicFontSize}</span>
+          </div>
+          <input
+            type="range"
+            min="16"
+            max="48"
+            value={settings.arabicFontSize}
+            onChange={(e) => setSettings({ ...settings, arabicFontSize: +e.target.value })}
+            style={arabicStyle}
+          />
+        </div>
+        <div>
+          <div className="flex justify-between mb-1 text-sm">
+            <label className="text-[var(--foreground)]">{t('translation_font_size')}</label>
+            <span className="font-semibold text-teal-700">{settings.translationFontSize}</span>
+          </div>
+          <input
+            type="range"
+            min="12"
+            max="28"
+            value={settings.translationFontSize}
+            onChange={(e) => setSettings({ ...settings, translationFontSize: +e.target.value })}
+            style={translationStyle}
+          />
+        </div>
+        <div>
+          <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+            {t('arabic_font_face')}
+          </label>
+          <button
+            onClick={onArabicFontPanelOpen}
+            className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
+          >
+            <span className="truncate text-[var(--foreground)]">{selectedArabicFont}</span>
+            <FaChevronDown className="text-gray-500" />
+          </button>
+        </div>
+      </div>
+    </CollapsibleSection>
+  );
+};

--- a/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export const ReadingSettings = () => (
+  <div className="text-center py-20 text-gray-500">Coming soon...</div>
+);

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -1,19 +1,15 @@
 'use client';
+
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  FaBookReader,
-  FaFontSetting,
-  FaChevronDown,
-  FaArrowLeft,
-  FaTranslation,
-} from '@/app/shared/SvgIcons';
-import { CollapsibleSection } from './CollapsibleSection';
-import { useSettings } from '@/app/providers/SettingsContext';
-import { ArabicFontPanel } from './ArabicFontPanel';
+import { FaArrowLeft } from '@/app/shared/SvgIcons';
 import { useSidebar } from '@/app/providers/SidebarContext';
 import { useTheme } from '@/app/providers/ThemeContext';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
+import { ArabicFontPanel } from './ArabicFontPanel';
+import { TranslationSettings } from './TranslationSettings';
+import { FontSettings } from './FontSettings';
+import { ReadingSettings } from './ReadingSettings';
 
 interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
@@ -36,28 +32,12 @@ export const SettingsSidebar = ({
   selectedWordLanguageName,
   showTafsirSetting = false,
 }: SettingsSidebarProps) => {
-  const { settings, setSettings, arabicFonts } = useSettings();
   const { t } = useTranslation();
-  const [isArabicFontPanelOpen, setIsArabicFontPanelOpen] = useState(false);
   const { isSettingsOpen, setSettingsOpen } = useSidebar();
   const { theme, setTheme } = useTheme();
-  const [activeTab, setActiveTab] = useState('translation');
-  const [openPanels, setOpenPanels] = useState<string[]>(['reading', 'font']);
   const { isHidden } = useHeaderVisibility();
-
-  // Helper function to calculate the slider's progress percentage
-  const getPercentage = (value: number, min: number, max: number) => {
-    return ((value - min) / (max - min)) * 100;
-  };
-
-  // Calculate percentages for each slider
-  const arabicSizePercent = getPercentage(settings.arabicFontSize, 16, 48);
-  const translationSizePercent = getPercentage(settings.translationFontSize, 12, 28);
-  const tafsirSizePercent = getPercentage(settings.tafsirFontSize, 12, 28);
-
-  // Find the selected Arabic font name for display
-  const selectedArabicFont =
-    arabicFonts.find((font) => font.value === settings.arabicFontFace)?.name || t('select_font');
+  const [activeTab, setActiveTab] = useState('translation');
+  const [isArabicFontPanelOpen, setIsArabicFontPanelOpen] = useState(false);
 
   const handleTabClick = (tab: 'translation' | 'reading') => {
     setActiveTab(tab);
@@ -66,25 +46,8 @@ export const SettingsSidebar = ({
     }
   };
 
-  const togglePanel = (panel: string) => {
-    setOpenPanels((prev) => {
-      if (prev.includes(panel)) {
-        return prev.filter((p) => p !== panel);
-      }
-      if (prev.length >= 2) {
-        return [prev[0], panel];
-      }
-      return [...prev, panel];
-    });
-  };
-
-  const isReadingOpen = openPanels.includes('reading');
-  const isTafsirOpen = openPanels.includes('tafsir');
-  const isFontOpen = openPanels.includes('font');
-
   return (
     <>
-      {/* This is the overlay for mobile view, which closes the sidebar when clicked. */}
       <div
         className={`fixed inset-0 bg-transparent z-30 lg:hidden ${isSettingsOpen ? '' : 'hidden'}`}
         role="button"
@@ -96,7 +59,6 @@ export const SettingsSidebar = ({
           }
         }}
       />
-      {/* This is the main settings sidebar container. */}
       <aside
         className={`fixed lg:static ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-all duration-300 z-40 lg:z-40 lg:h-full ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
@@ -119,189 +81,54 @@ export const SettingsSidebar = ({
           >
             <button
               onClick={() => handleTabClick('translation')}
-              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${activeTab === 'translation' ? (theme === 'light' ? 'bg-white shadow text-slate-900' : 'bg-slate-700 text-white shadow') : theme === 'light' ? 'text-slate-400 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}
+              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+                activeTab === 'translation'
+                  ? theme === 'light'
+                    ? 'bg-white shadow text-slate-900'
+                    : 'bg-slate-700 text-white shadow'
+                  : theme === 'light'
+                    ? 'text-slate-400 hover:text-slate-700'
+                    : 'text-slate-400 hover:text-white'
+              }`}
             >
               Translation
             </button>
             <button
               onClick={() => handleTabClick('reading')}
-              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${activeTab === 'reading' ? (theme === 'light' ? 'bg-white shadow text-slate-900' : 'bg-slate-700 text-white shadow') : theme === 'light' ? 'text-slate-400 hover:text-slate-700' : 'text-slate-400 hover:text-white'}`}
+              className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+                activeTab === 'reading'
+                  ? theme === 'light'
+                    ? 'bg-white shadow text-slate-900'
+                    : 'bg-slate-700 text-white shadow'
+                  : theme === 'light'
+                    ? 'text-slate-400 hover:text-slate-700'
+                    : 'text-slate-400 hover:text-white'
+              }`}
             >
               Reading
             </button>
           </div>
           {activeTab === 'translation' && (
-            <CollapsibleSection
-              title={t('reading_setting')}
-              icon={<FaTranslation size={20} className="text-teal-700" />}
-              isLast={false}
-              isOpen={isReadingOpen}
-              onToggle={() => togglePanel('reading')}
-            >
-              <div className="space-y-4">
-                <div className="flex items-center justify-between pt-2">
-                  <span className="text-sm text-[var(--foreground)]">{t('show_word_by_word')}</span>
-                  <button
-                    onClick={() => setSettings({ ...settings, showByWords: !settings.showByWords })}
-                    className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.showByWords ? 'bg-teal-600' : 'bg-gray-200'}`}
-                  >
-                    <span
-                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.showByWords ? 'translate-x-6' : 'translate-x-1'}`}
-                    />
-                  </button>
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-[var(--foreground)]">{t('apply_tajweed')}</span>
-                  <button
-                    onClick={() => setSettings({ ...settings, tajweed: !settings.tajweed })}
-                    className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.tajweed ? 'bg-teal-600' : 'bg-gray-200'}`}
-                  >
-                    <span
-                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.tajweed ? 'translate-x-6' : 'translate-x-1'}`}
-                    />
-                  </button>
-                </div>
-
-                {/* Translation selection */}
-                <div>
-                  <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
-                    {t('translations')}
-                  </label>
-                  <button
-                    onClick={onTranslationPanelOpen}
-                    className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
-                  >
-                    <span className="truncate text-[var(--foreground)]">
-                      {selectedTranslationName}
-                    </span>
-                    <FaChevronDown className="text-gray-500" />
-                  </button>
-                </div>
-
-                {/* Word-by-word language selection */}
-                <div>
-                  <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
-                    {t('word_by_word_language')}
-                  </label>
-                  <button
-                    onClick={onWordLanguagePanelOpen}
-                    className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
-                  >
-                    <span className="truncate text-[var(--foreground)]">
-                      {selectedWordLanguageName}
-                    </span>
-                    <FaChevronDown className="text-gray-500" />
-                  </button>
-                </div>
-              </div>
-            </CollapsibleSection>
+            <>
+              <TranslationSettings
+                onTranslationPanelOpen={onTranslationPanelOpen}
+                onWordLanguagePanelOpen={onWordLanguagePanelOpen}
+                onTafsirPanelOpen={onTafsirPanelOpen}
+                selectedTranslationName={selectedTranslationName}
+                selectedTafsirName={selectedTafsirName}
+                selectedWordLanguageName={selectedWordLanguageName}
+                showTafsirSetting={showTafsirSetting}
+              />
+              <FontSettings onArabicFontPanelOpen={() => setIsArabicFontPanelOpen(true)} />
+            </>
           )}
-          {activeTab === 'translation' && showTafsirSetting && (
-            <CollapsibleSection
-              title={t('tafsir_setting')}
-              icon={<FaBookReader size={20} className="text-teal-700" />}
-              isLast={false}
-              isOpen={isTafsirOpen}
-              onToggle={() => togglePanel('tafsir')}
-            >
-              <div className="space-y-4">
-                <div>
-                  <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
-                    {t('select_tafsir')}
-                  </label>
-                  <button
-                    onClick={onTafsirPanelOpen}
-                    className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
-                  >
-                    <span className="truncate text-[var(--foreground)]">{selectedTafsirName}</span>
-                    <FaChevronDown className="text-gray-500" />
-                  </button>
-                </div>
-                <div>
-                  <div className="flex justify-between mb-1 text-sm">
-                    <label className="text-[var(--foreground)]">{t('tafsir_font_size')}</label>
-                    <span className="font-semibold text-teal-700">{settings.tafsirFontSize}</span>
-                  </div>
-                  <input
-                    type="range"
-                    min="12"
-                    max="28"
-                    value={settings.tafsirFontSize}
-                    onChange={(e) => setSettings({ ...settings, tafsirFontSize: +e.target.value })}
-                    style={{ '--value-percent': `${tafsirSizePercent}%` } as React.CSSProperties}
-                  />
-                </div>
-              </div>
-            </CollapsibleSection>
-          )}
-          {activeTab === 'translation' && (
-            <CollapsibleSection
-              title={t('font_setting')}
-              icon={<FaFontSetting size={20} className="text-teal-700" />}
-              isLast={true}
-              isOpen={isFontOpen}
-              onToggle={() => togglePanel('font')}
-            >
-              <div className="space-y-4">
-                <div>
-                  <div className="flex justify-between mb-1 text-sm">
-                    <label className="text-[var(--foreground)]">{t('arabic_font_size')}</label>
-                    <span className="font-semibold text-teal-700">{settings.arabicFontSize}</span>
-                  </div>
-                  <input
-                    type="range"
-                    min="16"
-                    max="48"
-                    value={settings.arabicFontSize}
-                    onChange={(e) => setSettings({ ...settings, arabicFontSize: +e.target.value })}
-                    style={{ '--value-percent': `${arabicSizePercent}%` } as React.CSSProperties}
-                  />
-                </div>
-                <div>
-                  <div className="flex justify-between mb-1 text-sm">
-                    <label className="text-[var(--foreground)]">{t('translation_font_size')}</label>
-                    <span className="font-semibold text-teal-700">
-                      {settings.translationFontSize}
-                    </span>
-                  </div>
-                  <input
-                    type="range"
-                    min="12"
-                    max="28"
-                    value={settings.translationFontSize}
-                    onChange={(e) =>
-                      setSettings({ ...settings, translationFontSize: +e.target.value })
-                    }
-                    style={
-                      { '--value-percent': `${translationSizePercent}%` } as React.CSSProperties
-                    }
-                  />
-                </div>
-                {/* Arabic Font Face Selection Button */}
-                <div>
-                  <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
-                    {t('arabic_font_face')}
-                  </label>
-                  <button
-                    onClick={() => setIsArabicFontPanelOpen(true)}
-                    className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
-                  >
-                    <span className="truncate text-[var(--foreground)]">{selectedArabicFont}</span>
-                    <FaChevronDown className="text-gray-500" />
-                  </button>
-                </div>
-              </div>
-            </CollapsibleSection>
-          )}
-          {activeTab === 'reading' && (
-            <div className="text-center py-20 text-gray-500">Coming soon...</div>
-          )}
+          {activeTab === 'reading' && <ReadingSettings />}
         </div>
-        {/* Theme Toggle */}
         <div className="p-4">
           <div
-            className={`flex items-center p-1 rounded-full ${theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'}`}
+            className={`flex items-center p-1 rounded-full ${
+              theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'
+            }`}
           >
             <button
               onClick={() => setTheme('light')}
@@ -325,7 +152,6 @@ export const SettingsSidebar = ({
             </button>
           </div>
         </div>
-        {/* Arabic Font Panel */}
         <ArabicFontPanel
           isOpen={isArabicFontPanelOpen}
           onClose={() => setIsArabicFontPanelOpen(false)}

--- a/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaTranslation, FaBookReader, FaChevronDown } from '@/app/shared/SvgIcons';
+import { CollapsibleSection } from './CollapsibleSection';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { useFontSize } from '../../hooks/useFontSize';
+
+interface TranslationSettingsProps {
+  onTranslationPanelOpen: () => void;
+  onWordLanguagePanelOpen: () => void;
+  onTafsirPanelOpen?: () => void;
+  selectedTranslationName: string;
+  selectedTafsirName?: string;
+  selectedWordLanguageName: string;
+  showTafsirSetting?: boolean;
+}
+
+export const TranslationSettings = ({
+  onTranslationPanelOpen,
+  onWordLanguagePanelOpen,
+  onTafsirPanelOpen,
+  selectedTranslationName,
+  selectedTafsirName,
+  selectedWordLanguageName,
+  showTafsirSetting = false,
+}: TranslationSettingsProps) => {
+  const { settings, setSettings } = useSettings();
+  const { t } = useTranslation();
+  const [isReadingOpen, setReadingOpen] = useState(true);
+  const [isTafsirOpen, setTafsirOpen] = useState(false);
+  const { style: tafsirStyle } = useFontSize(settings.tafsirFontSize, 12, 28);
+
+  return (
+    <>
+      <CollapsibleSection
+        title={t('reading_setting')}
+        icon={<FaTranslation size={20} className="text-teal-700" />}
+        isLast={!showTafsirSetting}
+        isOpen={isReadingOpen}
+        onToggle={() => setReadingOpen(!isReadingOpen)}
+      >
+        <div className="space-y-4">
+          <div className="flex items-center justify-between pt-2">
+            <span className="text-sm text-[var(--foreground)]">{t('show_word_by_word')}</span>
+            <button
+              onClick={() => setSettings({ ...settings, showByWords: !settings.showByWords })}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.showByWords ? 'bg-teal-600' : 'bg-gray-200'}`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.showByWords ? 'translate-x-6' : 'translate-x-1'}`}
+              />
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-[var(--foreground)]">{t('apply_tajweed')}</span>
+            <button
+              onClick={() => setSettings({ ...settings, tajweed: !settings.tajweed })}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.tajweed ? 'bg-teal-600' : 'bg-gray-200'}`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.tajweed ? 'translate-x-6' : 'translate-x-1'}`}
+              />
+            </button>
+          </div>
+
+          <div>
+            <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+              {t('translations')}
+            </label>
+            <button
+              onClick={onTranslationPanelOpen}
+              className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
+            >
+              <span className="truncate text-[var(--foreground)]">{selectedTranslationName}</span>
+              <FaChevronDown className="text-gray-500" />
+            </button>
+          </div>
+
+          <div>
+            <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+              {t('word_by_word_language')}
+            </label>
+            <button
+              onClick={onWordLanguagePanelOpen}
+              className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
+            >
+              <span className="truncate text-[var(--foreground)]">{selectedWordLanguageName}</span>
+              <FaChevronDown className="text-gray-500" />
+            </button>
+          </div>
+        </div>
+      </CollapsibleSection>
+      {showTafsirSetting && (
+        <CollapsibleSection
+          title={t('tafsir_setting')}
+          icon={<FaBookReader size={20} className="text-teal-700" />}
+          isLast={false}
+          isOpen={isTafsirOpen}
+          onToggle={() => setTafsirOpen(!isTafsirOpen)}
+        >
+          <div className="space-y-4">
+            <div>
+              <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
+                {t('select_tafsir')}
+              </label>
+              <button
+                onClick={onTafsirPanelOpen}
+                className="w-full flex justify-between items-center bg-[var(--background)] border border-gray-200 dark:border-gray-600 rounded-lg p-2.5 text-sm text-left hover:border-teal-500 transition-shadow shadow-sm hover:shadow-md"
+              >
+                <span className="truncate text-[var(--foreground)]">{selectedTafsirName}</span>
+                <FaChevronDown className="text-gray-500" />
+              </button>
+            </div>
+            <div>
+              <div className="flex justify-between mb-1 text-sm">
+                <label className="text-[var(--foreground)]">{t('tafsir_font_size')}</label>
+                <span className="font-semibold text-teal-700">{settings.tafsirFontSize}</span>
+              </div>
+              <input
+                type="range"
+                min="12"
+                max="28"
+                value={settings.tafsirFontSize}
+                onChange={(e) => setSettings({ ...settings, tafsirFontSize: +e.target.value })}
+                style={tafsirStyle}
+              />
+            </div>
+          </div>
+        </CollapsibleSection>
+      )}
+    </>
+  );
+};

--- a/app/(features)/surah/hooks/useFontSize.ts
+++ b/app/(features)/surah/hooks/useFontSize.ts
@@ -1,0 +1,15 @@
+import { useMemo, CSSProperties } from 'react';
+
+export const useFontSize = (value: number, min: number, max: number) => {
+  const percentage = useMemo(() => ((value - min) / (max - min)) * 100, [value, min, max]);
+
+  const style = useMemo(
+    () =>
+      ({
+        '--value-percent': `${percentage}%`,
+      }) as CSSProperties,
+    [percentage]
+  );
+
+  return { percentage, style };
+};


### PR DESCRIPTION
## Summary
- split settings sidebar into TranslationSettings, ReadingSettings, and FontSettings components
- extract slider percentage logic to a useFontSize hook
- drop unused internalAudioRef arg from handleSurahRepeat

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689c3e4611b8832f99e9607876ac8af0