### PR TITLE
Refactor tafsir verse page into hook and components

### DIFF
--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/AyahNavigation.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/AyahNavigation.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { Surah } from '@/types';
+
+interface NavTarget {
+  surahId: string;
+  ayahId: number;
+}
+
+interface AyahNavigationProps {
+  prev: NavTarget | null;
+  next: NavTarget | null;
+  navigate: (target: NavTarget | null) => void;
+  currentSurah?: Surah;
+  ayahId: string;
+}
+
+export const AyahNavigation = ({
+  prev,
+  next,
+  navigate,
+  currentSurah,
+  ayahId,
+}: AyahNavigationProps) => (
+  <div className="flex items-center justify-between rounded-full bg-teal-600 text-white p-2">
+    <button
+      aria-label="Previous"
+      disabled={!prev}
+      onClick={() => navigate(prev)}
+      className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
+    >
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-white mr-2">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5 text-teal-600"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M11.707 15.293a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L8.414 10l3.293 3.293a1 1 0 001.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+    </button>
+    <div className="text-white font-bold">
+      {currentSurah ? (
+        <>
+          <span className="font-bold">{currentSurah.name}</span> : {ayahId}
+        </>
+      ) : (
+        ''
+      )}
+    </div>
+    <button
+      aria-label="Next"
+      disabled={!next}
+      onClick={() => navigate(next)}
+      className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
+    >
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-white ml-2">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5 text-teal-600"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8.293 4.707a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L11.586 10l-3.293-3.293a1 1 0 00-1.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+    </button>
+  </div>
+);
+
+export default AyahNavigation;

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { Verse as VerseType, TafsirResource } from '@/types';
+import { Verse as VerseComponent } from '@/app/(features)/surah/[surahId]/components/Verse';
+import TafsirTabs from './TafsirTabs';
+import { useSettings } from '@/app/providers/SettingsContext';
+
+interface TafsirViewerProps {
+  verse?: VerseType;
+  tafsirResource?: TafsirResource;
+  tafsirHtml?: string;
+}
+
+export const TafsirViewer = ({ verse, tafsirResource, tafsirHtml }: TafsirViewerProps) => {
+  const { settings } = useSettings();
+
+  if (!verse) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-4"></div>
+      <VerseComponent verse={verse} />
+      {settings.tafsirIds.length > 1 ? (
+        <TafsirTabs verseKey={verse.verse_key} tafsirIds={settings.tafsirIds} />
+      ) : (
+        tafsirResource && (
+          <div key={verse.verse_key} className="p-4">
+            <h2 className="mb-4 text-center text-xl font-bold text-[var(--foreground)]">
+              {tafsirResource.name}
+            </h2>
+            <div
+              className="prose max-w-none whitespace-pre-wrap"
+              style={{ fontSize: `${settings.tafsirFontSize}px` }}
+              dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
+            />
+          </div>
+        )
+      )}
+    </div>
+  );
+};
+
+export default TafsirViewer;

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TranslationSelector.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TranslationSelector.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { TranslationResource } from '@/types';
+import { TranslationPanel } from '@/app/(features)/surah/[surahId]/components/TranslationPanel';
+
+interface TranslationSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  translationOptions: TranslationResource[];
+}
+
+export const TranslationSelector = ({
+  isOpen,
+  onClose,
+  translationOptions,
+}: TranslationSelectorProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const groupedTranslations = useMemo(
+    () =>
+      translationOptions
+        .filter((o) => o.name.toLowerCase().includes(searchTerm.toLowerCase()))
+        .reduce<Record<string, TranslationResource[]>>((acc, tr) => {
+          (acc[tr.language_name] ||= []).push(tr);
+          return acc;
+        }, {}),
+    [translationOptions, searchTerm]
+  );
+
+  return (
+    <TranslationPanel
+      isOpen={isOpen}
+      onClose={onClose}
+      groupedTranslations={groupedTranslations}
+      searchTerm={searchTerm}
+      onSearchTermChange={setSearchTerm}
+    />
+  );
+};
+
+export default TranslationSelector;

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
@@ -1,0 +1,118 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
+import type { LanguageCode } from '@/lib/text/languageCodes';
+import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
+import { FaArrowLeft, FaSearch } from '@/app/shared/SvgIcons';
+
+interface LanguageOption {
+  name: string;
+  id: number;
+}
+
+interface WordTranslationPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  languages: LanguageOption[];
+  onReset: () => void;
+}
+
+export const WordTranslationPanel = ({
+  isOpen,
+  onClose,
+  languages,
+  onReset,
+}: WordTranslationPanelProps) => {
+  const { settings, setSettings } = useSettings();
+  const { t } = useTranslation();
+  const { isHidden } = useHeaderVisibility();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const sortedLanguages = useMemo(
+    () => [...languages].sort((a, b) => a.name.localeCompare(b.name)),
+    [languages]
+  );
+  const filtered = useMemo(
+    () =>
+      sortedLanguages.filter((lang) => lang.name.toLowerCase().includes(searchTerm.toLowerCase())),
+    [sortedLanguages, searchTerm]
+  );
+
+  return (
+    <div
+      className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
+        isOpen ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
+        <button
+          aria-label="Back"
+          onClick={onClose}
+          className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+        >
+          <FaArrowLeft size={18} />
+        </button>
+        <h2 className="font-bold text-lg text-[var(--foreground)]">
+          {t('word_by_word_panel_title')}
+        </h2>
+        <div className="w-8"></div>
+      </div>
+      <div className="p-3 border-b border-gray-200/80">
+        <div className="relative">
+          <FaSearch className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            placeholder={t('search')}
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none bg-[var(--background)] text-[var(--foreground)]"
+          />
+        </div>
+      </div>
+      <div className="flex-grow overflow-y-auto">
+        {filtered.map((lang) => (
+          <label
+            key={lang.id}
+            className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+          >
+            <input
+              type="radio"
+              name="wordLanguage"
+              className="form-radio h-4 w-4 text-teal-600"
+              checked={
+                settings.wordLang ===
+                (LANGUAGE_CODES as Record<string, LanguageCode>)[lang.name.toLowerCase()]
+              }
+              onChange={() => {
+                setSettings({
+                  ...settings,
+                  wordLang:
+                    (LANGUAGE_CODES as Record<string, LanguageCode>)[lang.name.toLowerCase()] ??
+                    settings.wordLang,
+                  wordTranslationId: lang.id,
+                });
+                onClose();
+              }}
+            />
+            <span className="text-sm text-[var(--foreground)]">{lang.name}</span>
+          </label>
+        ))}
+      </div>
+      <div className="p-4 border-t border-gray-200/80">
+        <button
+          onClick={() => {
+            onReset();
+            onClose();
+          }}
+          className="w-full py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 text-sm hover:border-teal-500"
+        >
+          {t('reset')}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WordTranslationPanel;

--- a/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
@@ -1,31 +1,12 @@
 'use client';
-import React, { useState, useMemo, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useTranslation } from 'react-i18next';
-import { Verse as VerseComponent } from '@/app/(features)/surah/[surahId]/components/Verse';
+import React, { useState } from 'react';
 import { SettingsSidebar } from '@/app/(features)/surah/[surahId]/components/SettingsSidebar';
-import { TranslationPanel } from '@/app/(features)/surah/[surahId]/components/TranslationPanel';
 import { TafsirPanel } from '@/app/(features)/surah/[surahId]/components/TafsirPanel';
-import { WordLanguagePanel } from '@/app/(features)/surah/[surahId]/components/WordLanguagePanel';
-import TafsirTabs from './components/TafsirTabs';
-import {
-  getVersesByChapter,
-  getTranslations,
-  getWordTranslations,
-  getTafsirResources,
-  getTafsirByVerse,
-} from '@/lib/api';
-import { Verse as VerseType, TranslationResource, TafsirResource } from '@/types';
-import { useSettings } from '@/app/providers/SettingsContext';
-import { useSidebar } from '@/app/providers/SidebarContext';
-import { WORD_LANGUAGE_LABELS } from '@/lib/text/wordLanguages';
-import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
-import type { LanguageCode } from '@/lib/text/languageCodes';
-import useSWR from 'swr';
-import surahs from '@/data/surahs.json';
-import type { Surah } from '@/types';
-
-const DEFAULT_WORD_TRANSLATION_ID = 85;
+import { useTafsirVerseData } from '../../hooks/useTafsirVerseData';
+import AyahNavigation from './components/AyahNavigation';
+import TranslationSelector from './components/TranslationSelector';
+import TafsirViewer from './components/TafsirViewer';
+import WordTranslationPanel from './components/WordTranslationPanel';
 
 interface TafsirVersePageProps {
   params: Promise<{ surahId: string; ayahId: string }>;
@@ -33,234 +14,41 @@ interface TafsirVersePageProps {
 
 export default function TafsirVersePage({ params }: TafsirVersePageProps) {
   const { surahId, ayahId } = React.use(params);
-  const router = useRouter();
-  const { t } = useTranslation();
-  const { settings, setSettings } = useSettings();
-  const { setSurahListOpen } = useSidebar();
+  const {
+    verse,
+    tafsirHtml,
+    tafsirResource,
+    translationOptions,
+    wordLanguageOptions,
+    selectedTranslationName,
+    selectedTafsirName,
+    selectedWordLanguageName,
+    prev,
+    next,
+    navigate,
+    currentSurah,
+    resetWordSettings,
+  } = useTafsirVerseData(surahId, ayahId);
 
-  // Panels state
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
-  const [translationSearchTerm, setTranslationSearchTerm] = useState('');
   const [isTafsirPanelOpen, setIsTafsirPanelOpen] = useState(false);
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
-  const [wordTranslationSearchTerm, setWordTranslationSearchTerm] = useState('');
-
-  // Options and memoized helpers
-  const { data: translationOptionsData } = useSWR('translations', getTranslations);
-  const translationOptions: TranslationResource[] = useMemo(
-    () => translationOptionsData || [],
-    [translationOptionsData]
-  );
-
-  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
-  const tafsirOptions: TafsirResource[] = useMemo(
-    () => tafsirOptionsData || [],
-    [tafsirOptionsData]
-  );
-
-  const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
-  const wordLanguageMap = useMemo(() => {
-    const map: Record<string, number> = {};
-    (wordTranslationOptionsData || []).forEach((o) => {
-      const name = o.language_name.toLowerCase();
-      if (!map[name]) {
-        map[name] = o.id;
-      }
-    });
-    return map;
-  }, [wordTranslationOptionsData]);
-  const wordLanguageOptions = useMemo(
-    () =>
-      Object.keys(wordLanguageMap)
-        .filter((name) => WORD_LANGUAGE_LABELS[name])
-        .map((name) => ({ name: WORD_LANGUAGE_LABELS[name], id: wordLanguageMap[name] })),
-    [wordLanguageMap]
-  );
-
-  const selectedTranslationName = useMemo(
-    () =>
-      translationOptions.find((o) => o.id === settings.translationId)?.name ||
-      t('select_translation'),
-    [settings.translationId, translationOptions, t]
-  );
-  const selectedTafsirName = useMemo(() => {
-    const names = settings.tafsirIds
-      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
-      .filter(Boolean)
-      .slice(0, 3);
-    return names.length ? names.join(', ') : t('select_tafsir');
-  }, [settings.tafsirIds, tafsirOptions, t]);
-  const selectedWordLanguageName = useMemo(
-    () =>
-      wordLanguageOptions.find(
-        (o) =>
-          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
-          settings.wordLang
-      )?.name || t('select_word_translation'),
-    [settings.wordLang, wordLanguageOptions, t]
-  );
-
-  const groupedTranslations = useMemo(
-    () =>
-      translationOptions
-        .filter((o) => o.name.toLowerCase().includes(translationSearchTerm.toLowerCase()))
-        .reduce<Record<string, TranslationResource[]>>((acc, tr) => {
-          (acc[tr.language_name] ||= []).push(tr);
-          return acc;
-        }, {}),
-    [translationOptions, translationSearchTerm]
-  );
-  const filteredWordLanguages = useMemo(
-    () =>
-      wordLanguageOptions.filter((o) =>
-        o.name.toLowerCase().includes(wordTranslationSearchTerm.toLowerCase())
-      ),
-    [wordLanguageOptions, wordTranslationSearchTerm]
-  );
-
-  // Translation selection and sync
-  const [translationId, setTranslationId] = useState(settings.translationId);
-  useEffect(() => {
-    setTranslationId(settings.translationId);
-  }, [settings.translationId]);
-
-  // Tafsir resource selection
-  const tafsirResource = useMemo(
-    () => tafsirOptions.find((t) => t.id === settings.tafsirIds[0]),
-    [tafsirOptions, settings.tafsirIds]
-  );
-
-  // Verse and tafsir text data fetching
-  const { data: verseData } = useSWR(
-    surahId && ayahId ? ['verse', surahId, ayahId, translationId, settings.wordLang] : null,
-    ([, s, a, trId, wordLang]) =>
-      getVersesByChapter(s, trId, Number(a), 1, wordLang).then((d) => d.verses[0])
-  );
-  const verse: VerseType | undefined = verseData;
-
-  const { data: tafsirHtml } = useSWR(
-    verse && tafsirResource ? ['tafsir', verse.verse_key, tafsirResource.id] : null,
-    ([, key, id]) => getTafsirByVerse(key as string, id as number)
-  );
-
-  // Ayah navigation helpers
-  const surahList = surahs as Surah[];
-  const totalSurahs = surahList.length;
-  const currentSurahIndex = Number(surahId) - 1;
-  const currentAyahNum = Number(ayahId);
-
-  const prev =
-    currentAyahNum > 1
-      ? { surahId, ayahId: currentAyahNum - 1 }
-      : currentSurahIndex > 0
-        ? { surahId: String(Number(surahId) - 1), ayahId: surahList[currentSurahIndex - 1].verses }
-        : null;
-
-  const next =
-    currentAyahNum < surahList[currentSurahIndex].verses
-      ? { surahId, ayahId: currentAyahNum + 1 }
-      : currentSurahIndex < totalSurahs - 1
-        ? { surahId: String(Number(surahId) + 1), ayahId: 1 }
-        : null;
-
-  const navigate = (target: { surahId: string; ayahId: number } | null) => {
-    if (!target) return;
-    setSurahListOpen(false);
-    router.push(`/tafsir/${target.surahId}/${target.ayahId}`);
-  };
-
-  const currentSurah = surahList.find((surah) => surah.number === Number(surahId));
 
   return (
     <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] overflow-hidden min-h-0">
       <main className="flex-grow bg-white dark:bg-[var(--background)] overflow-y-auto p-6 lg:p-10 homepage-scrollable-area">
         <div className="w-full space-y-6">
-          {/* Ayah Navigation */}
-          <div className="flex items-center justify-between rounded-full bg-teal-600 text-white p-2">
-            <button
-              aria-label="Previous"
-              disabled={!prev}
-              onClick={() => navigate(prev)}
-              className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
-            >
-              <div className="flex items-center justify-center w-8 h-8 rounded-full bg-white mr-2">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-5 w-5 text-teal-600"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M11.707 15.293a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L8.414 10l3.293 3.293a1 1 0 010 1.414z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              </div>
-            </button>
-            <div className="text-white font-bold">
-              {currentSurah ? (
-                <>
-                  <span className="font-bold">{currentSurah.name}</span> : {ayahId}
-                </>
-              ) : (
-                ''
-              )}
-            </div>
-            <button
-              aria-label="Next"
-              disabled={!next}
-              onClick={() => navigate(next)}
-              className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
-            >
-              <div className="flex items-center justify-center w-8 h-8 rounded-full bg-white ml-2">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-5 w-5 text-teal-600"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M8.293 4.707a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L11.586 10l-3.293-3.293a1 1 0 010-1.414z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              </div>
-            </button>
-          </div>
-
-          {/* Translation selection */}
-          <div className="space-y-4">
-            <div className="flex flex-wrap gap-4"></div>
-
-            {/* Ayah display */}
-            {verse && <VerseComponent verse={verse} />}
-
-            {/* Tafsir display */}
-            {verse && settings.tafsirIds.length > 1 ? (
-              <TafsirTabs verseKey={verse.verse_key} tafsirIds={settings.tafsirIds} />
-            ) : (
-              tafsirResource && (
-                <div key={verse?.verse_key} className="p-4">
-                  <h2 className="mb-4 text-center text-xl font-bold text-[var(--foreground)]">
-                    {tafsirResource.name}
-                  </h2>
-                  <div
-                    className="prose max-w-none whitespace-pre-wrap"
-                    style={{
-                      fontSize: `${settings.tafsirFontSize}px`,
-                    }}
-                    dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
-                  />
-                </div>
-              )
-            )}
-          </div>
+          <AyahNavigation
+            prev={prev}
+            next={next}
+            navigate={navigate}
+            currentSurah={currentSurah}
+            ayahId={ayahId}
+          />
+          <TafsirViewer verse={verse} tafsirResource={tafsirResource} tafsirHtml={tafsirHtml} />
         </div>
       </main>
 
-      {/* Sidebars and Panels */}
       <SettingsSidebar
         onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
         onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
@@ -270,27 +58,16 @@ export default function TafsirVersePage({ params }: TafsirVersePageProps) {
         selectedWordLanguageName={selectedWordLanguageName}
         showTafsirSetting
       />
-      <TranslationPanel
+      <TranslationSelector
         isOpen={isTranslationPanelOpen}
         onClose={() => setIsTranslationPanelOpen(false)}
-        groupedTranslations={groupedTranslations}
-        searchTerm={translationSearchTerm}
-        onSearchTermChange={setTranslationSearchTerm}
+        translationOptions={translationOptions}
       />
-      <WordLanguagePanel
+      <WordTranslationPanel
         isOpen={isWordPanelOpen}
         onClose={() => setIsWordPanelOpen(false)}
-        languages={filteredWordLanguages}
-        searchTerm={wordTranslationSearchTerm}
-        onSearchTermChange={setWordTranslationSearchTerm}
-        onReset={() => {
-          setWordTranslationSearchTerm('');
-          setSettings({
-            ...settings,
-            wordLang: 'en',
-            wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
-          });
-        }}
+        languages={wordLanguageOptions}
+        onReset={resetWordSettings}
       />
       <TafsirPanel isOpen={isTafsirPanelOpen} onClose={() => setIsTafsirPanelOpen(false)} />
     </div>

--- a/app/(features)/tafsir/hooks/useTafsirVerseData.ts
+++ b/app/(features)/tafsir/hooks/useTafsirVerseData.ts
@@ -1,0 +1,155 @@
+import { useMemo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+import { useTranslation } from 'react-i18next';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { useSidebar } from '@/app/providers/SidebarContext';
+import {
+  getTranslations,
+  getTafsirResources,
+  getWordTranslations,
+  getVersesByChapter,
+  getTafsirByVerse,
+} from '@/lib/api';
+import { Verse as VerseType, TranslationResource, TafsirResource, Surah } from '@/types';
+import { WORD_LANGUAGE_LABELS } from '@/lib/text/wordLanguages';
+import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
+import type { LanguageCode } from '@/lib/text/languageCodes';
+import surahs from '@/data/surahs.json';
+
+const DEFAULT_WORD_TRANSLATION_ID = 85;
+
+export const useTafsirVerseData = (surahId: string, ayahId: string) => {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { settings, setSettings } = useSettings();
+  const { setSurahListOpen } = useSidebar();
+
+  const { data: translationOptionsData } = useSWR('translations', getTranslations);
+  const translationOptions: TranslationResource[] = useMemo(
+    () => translationOptionsData || [],
+    [translationOptionsData]
+  );
+
+  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
+  const tafsirOptions: TafsirResource[] = useMemo(
+    () => tafsirOptionsData || [],
+    [tafsirOptionsData]
+  );
+
+  const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
+  const wordLanguageMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    (wordTranslationOptionsData || []).forEach((o) => {
+      const name = o.language_name.toLowerCase();
+      if (!map[name]) {
+        map[name] = o.id;
+      }
+    });
+    return map;
+  }, [wordTranslationOptionsData]);
+  const wordLanguageOptions = useMemo(
+    () =>
+      Object.keys(wordLanguageMap)
+        .filter((name) => WORD_LANGUAGE_LABELS[name])
+        .map((name) => ({ name: WORD_LANGUAGE_LABELS[name], id: wordLanguageMap[name] })),
+    [wordLanguageMap]
+  );
+
+  const selectedTranslationName = useMemo(
+    () =>
+      translationOptions.find((o) => o.id === settings.translationId)?.name ||
+      t('select_translation'),
+    [settings.translationId, translationOptions, t]
+  );
+  const selectedTafsirName = useMemo(() => {
+    const names = settings.tafsirIds
+      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
+      .filter(Boolean)
+      .slice(0, 3);
+    return names.length ? names.join(', ') : t('select_tafsir');
+  }, [settings.tafsirIds, tafsirOptions, t]);
+  const selectedWordLanguageName = useMemo(
+    () =>
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
+    [settings.wordLang, wordLanguageOptions, t]
+  );
+
+  const { data: verseData } = useSWR(
+    surahId && ayahId
+      ? ['verse', surahId, ayahId, settings.translationId, settings.wordLang]
+      : null,
+    ([, s, a, trId, wordLang]) =>
+      getVersesByChapter(s, trId, Number(a), 1, wordLang).then((d) => d.verses[0])
+  );
+  const verse: VerseType | undefined = verseData;
+
+  const tafsirResource = useMemo(
+    () => tafsirOptions.find((t) => t.id === settings.tafsirIds[0]),
+    [tafsirOptions, settings.tafsirIds]
+  );
+
+  const { data: tafsirHtml } = useSWR(
+    verse && tafsirResource ? ['tafsir', verse.verse_key, tafsirResource.id] : null,
+    ([, key, id]) => getTafsirByVerse(key as string, id as number)
+  );
+
+  const surahList = surahs as Surah[];
+  const totalSurahs = surahList.length;
+  const currentSurahIndex = Number(surahId) - 1;
+  const currentAyahNum = Number(ayahId);
+
+  const prev =
+    currentAyahNum > 1
+      ? { surahId, ayahId: currentAyahNum - 1 }
+      : currentSurahIndex > 0
+        ? { surahId: String(Number(surahId) - 1), ayahId: surahList[currentSurahIndex - 1].verses }
+        : null;
+
+  const next =
+    currentAyahNum < surahList[currentSurahIndex].verses
+      ? { surahId, ayahId: currentAyahNum + 1 }
+      : currentSurahIndex < totalSurahs - 1
+        ? { surahId: String(Number(surahId) + 1), ayahId: 1 }
+        : null;
+
+  const navigate = useCallback(
+    (target: { surahId: string; ayahId: number } | null) => {
+      if (!target) return;
+      setSurahListOpen(false);
+      router.push(`/tafsir/${target.surahId}/${target.ayahId}`);
+    },
+    [router, setSurahListOpen]
+  );
+
+  const currentSurah = surahList.find((s) => s.number === Number(surahId));
+
+  const resetWordSettings = useCallback(() => {
+    setSettings({
+      ...settings,
+      wordLang: 'en',
+      wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
+    });
+  }, [settings, setSettings, wordLanguageMap]);
+
+  return {
+    verse,
+    tafsirHtml,
+    tafsirResource,
+    translationOptions,
+    wordLanguageOptions,
+    wordLanguageMap,
+    selectedTranslationName,
+    selectedTafsirName,
+    selectedWordLanguageName,
+    prev,
+    next,
+    navigate,
+    currentSurah,
+    resetWordSettings,
+  };
+};


### PR DESCRIPTION
## Summary
- move SWR data fetching and navigation helpers into `useTafsirVerseData`
- break tafsir verse page into `AyahNavigation`, `TranslationSelector`, `TafsirViewer`, and `WordTranslationPanel`

## Testing
- `npm audit --omit=dev`
- `npm run lint -- --dir app/(features)/tafsir`
- `npm run type-check`
- `npm test`
- `npm run check` *(fails: prettier/prettier in app/(features)/player/QuranAudioPlayer.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_689c50ec7f14832f8d892474b0a7d5a7