### PR TITLE
Refactor Juz page with data hook

### DIFF
--- a/app/(features)/juz/[juzId]/components/JuzHeader.tsx
+++ b/app/(features)/juz/[juzId]/components/JuzHeader.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import type { Juz } from '@/types';
+
+interface JuzHeaderProps {
+  juz?: Juz;
+}
+
+export function JuzHeader({ juz }: JuzHeaderProps) {
+  const { t } = useTranslation();
+  if (!juz) return null;
+  return (
+    <div className="mb-8 text-center">
+      <h1 className="text-3xl font-bold text-[var(--foreground)]">
+        {t('juz_number', { number: juz.juz_number })}
+      </h1>
+    </div>
+  );
+}
+
+export default JuzHeader;

--- a/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
+++ b/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Verse } from '@/app/(features)/surah/[surahId]/components/Verse';
+import type { Verse as VerseType } from '@/types';
+
+interface JuzVerseListProps {
+  verses: VerseType[];
+  loadMoreRef: React.RefObject<HTMLDivElement>;
+  isValidating: boolean;
+  isReachingEnd: boolean;
+}
+
+export function JuzVerseList({
+  verses,
+  loadMoreRef,
+  isValidating,
+  isReachingEnd,
+}: JuzVerseListProps) {
+  const { t } = useTranslation();
+
+  if (verses.length === 0) {
+    return <div className="text-center py-20 text-gray-500">{t('no_verses_found_in_juz')}</div>;
+  }
+
+  return (
+    <>
+      {verses.map((v) => (
+        <Verse key={v.id} verse={v} />
+      ))}
+      <div ref={loadMoreRef} className="py-4 text-center">
+        {isValidating && <span className="text-teal-600">{t('loading')}</span>}
+        {isReachingEnd && <span className="text-gray-500">{t('end_of_juz')}</span>}
+      </div>
+    </>
+  );
+}
+
+export default JuzVerseList;

--- a/app/(features)/juz/hooks/useJuzData.ts
+++ b/app/(features)/juz/hooks/useJuzData.ts
@@ -1,0 +1,23 @@
+import useSWR from 'swr';
+import { getJuz, getVersesByJuz } from '@/lib/api';
+import type { Juz } from '@/types';
+import useVerseListing from '@/app/(features)/surah/hooks/useVerseListing';
+
+export function useJuzData(juzId?: string) {
+  const verseListing = useVerseListing({ id: juzId, lookup: getVersesByJuz });
+
+  const { data: juz, error: juzError } = useSWR<Juz>(juzId ? ['juz', juzId] : null, ([, id]) =>
+    getJuz(id)
+  );
+
+  const isLoading = verseListing.isLoading || (!juz && !juzError);
+
+  return {
+    juz,
+    juzError,
+    isLoading,
+    ...verseListing,
+  } as const;
+}
+
+export default useJuzData;


### PR DESCRIPTION
## Summary
- extract Juz and verse loading into reusable `useJuzData`
- split Juz header and verse list into dedicated components
- simplify Juz page to use new hook and components

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint` *(fails: prettier errors in app/(features)/player/QuranAudioPlayer.tsx)*
- `npm run check` *(fails: prettier errors in app/(features)/player/QuranAudioPlayer.tsx)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c50ed1ea0832fa0ff2774523bd821