### PR TITLE
Split bookmark handling into BookmarkContext

### DIFF
--- a/app/(features)/bookmarks/__tests__/Bookmarks.test.tsx
+++ b/app/(features)/bookmarks/__tests__/Bookmarks.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import BookmarkedVersesList from '@/app/(features)/bookmarks/components/BookmarkedVersesList';
 import BookmarksPage from '@/app/(features)/bookmarks/page';
 import * as api from '@/lib/api';
@@ -15,7 +16,9 @@ describe('Bookmarked verses components', () => {
   test('BookmarkedVersesList shows empty message', () => {
     render(
       <SettingsProvider>
-        <BookmarkedVersesList />
+        <BookmarkProvider>
+          <BookmarkedVersesList />
+        </BookmarkProvider>
       </SettingsProvider>
     );
     expect(screen.getByText('No verses bookmarked yet.')).toBeInTheDocument();
@@ -32,7 +35,9 @@ describe('Bookmarked verses components', () => {
     localStorage.setItem('quranAppBookmarks', JSON.stringify(['1']));
     render(
       <SettingsProvider>
-        <BookmarkedVersesList />
+        <BookmarkProvider>
+          <BookmarkedVersesList />
+        </BookmarkProvider>
       </SettingsProvider>
     );
     expect(await screen.findByText('translation')).toBeInTheDocument();
@@ -43,7 +48,9 @@ describe('Bookmarked verses components', () => {
     localStorage.setItem('quranAppBookmarks', JSON.stringify(['1']));
     render(
       <SettingsProvider>
-        <BookmarkedVersesList />
+        <BookmarkProvider>
+          <BookmarkedVersesList />
+        </BookmarkProvider>
       </SettingsProvider>
     );
     expect(await screen.findByText('Failed to load bookmarked verses. boom')).toBeInTheDocument();
@@ -52,7 +59,9 @@ describe('Bookmarked verses components', () => {
   test('BookmarksPage renders heading', () => {
     render(
       <SettingsProvider>
-        <BookmarksPage />
+        <BookmarkProvider>
+          <BookmarksPage />
+        </BookmarkProvider>
       </SettingsProvider>
     );
     expect(screen.getByText('Bookmarked Verses')).toBeInTheDocument();

--- a/app/(features)/bookmarks/components/BookmarkedVersesList.tsx
+++ b/app/(features)/bookmarks/components/BookmarkedVersesList.tsx
@@ -1,13 +1,15 @@
 // app/(features)/bookmarks/components/BookmarkedVersesList.tsx
 'use client';
 import { useEffect, useState } from 'react';
+import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { getVerseById } from '@/lib/api';
 import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 import { Verse } from '@/types';
 
 const BookmarkedVersesList = () => {
-  const { bookmarkedVerses, settings } = useSettings();
+  const { bookmarkedVerses } = useBookmarks();
+  const { settings } = useSettings();
   const [verses, setVerses] = useState<Verse[]>([]);
   const [error, setError] = useState<string | null>(null);
 

--- a/app/(features)/juz/__tests__/JuzPage.test.tsx
+++ b/app/(features)/juz/__tests__/JuzPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
 import { SidebarProvider } from '@/app/providers/SidebarContext';
 import { ThemeProvider } from '@/app/providers/ThemeContext';
@@ -71,14 +72,16 @@ const renderPage = () =>
   render(
     <AudioProvider>
       <SettingsProvider>
-        <ThemeProvider>
-          <SidebarProvider>
-            <JuzPage
-              params={{ juzId: '1' } as unknown as Promise<{ juzId: string }>}
-              searchParams={{}}
-            />
-          </SidebarProvider>
-        </ThemeProvider>
+        <BookmarkProvider>
+          <ThemeProvider>
+            <SidebarProvider>
+              <JuzPage
+                params={{ juzId: '1' } as unknown as Promise<{ juzId: string }>}
+                searchParams={{}}
+              />
+            </SidebarProvider>
+          </ThemeProvider>
+        </BookmarkProvider>
       </SettingsProvider>
     </AudioProvider>
   );

--- a/app/(features)/page/__tests__/PagePage.test.tsx
+++ b/app/(features)/page/__tests__/PagePage.test.tsx
@@ -1,5 +1,6 @@
 import { render, act } from '@testing-library/react';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
 import { SidebarProvider } from '@/app/providers/SidebarContext';
 import { ThemeProvider } from '@/app/providers/ThemeContext';
@@ -65,11 +66,13 @@ const renderPage = () =>
   render(
     <AudioProvider>
       <SettingsProvider>
-        <ThemeProvider>
-          <SidebarProvider>
-            <QuranPage params={{ pageId: '1' } as unknown as Promise<{ pageId: string }>} />
-          </SidebarProvider>
-        </ThemeProvider>
+        <BookmarkProvider>
+          <ThemeProvider>
+            <SidebarProvider>
+              <QuranPage params={{ pageId: '1' } as unknown as Promise<{ pageId: string }>} />
+            </SidebarProvider>
+          </ThemeProvider>
+        </BookmarkProvider>
       </SettingsProvider>
     </AudioProvider>
   );

--- a/app/(features)/player/QuranAudioPlayer.tsx
+++ b/app/(features)/player/QuranAudioPlayer.tsx
@@ -14,185 +14,184 @@ import IconBtn from './components/IconBtn';
 import type { Track } from './types';
 
 /**
- * Clean minimal music/Quran player – Tailwind CSS + Next.js + TypeScript
- *
- * FIX: Guarded against undefined/null `track` to resolve
- * `TypeError: Cannot read properties of undefined (reading 'durationSec')`.
- * - `track` prop is optional.
- * - All reads use optional chaining + fallbacks.
- * - Disabled/skeleton state when no track is provided.
- * - Effects & sliders handle 0-duration safely.
- *
- * NEW (Quran features in same design language):
- * - Options sheet with two tabs: Reciter list & Verse Repeat.
- * - Reciter grid with radio selection.
- * - Repeat modes: off / single verse / range (A–B) / surah, with play count, repeat each, delay.
- * - ADDED: Playback speed control directly in the player bar.
- * - REMOVED: Shuffle and Repeat icons from main bar for a cleaner look.
- */
+ * Clean minimal music/Quran player – Tailwind CSS + Next.js + TypeScript
+ *
+ * FIX: Guarded against undefined/null `track` to resolve
+ * `TypeError: Cannot read properties of undefined (reading 'durationSec')`.
+ * - `track` prop is optional.
+ * - All reads use optional chaining + fallbacks.
+ * - Disabled/skeleton state when no track is provided.
+ * - Effects & sliders handle 0-duration safely.
+ *
+ * NEW (Quran features in same design language):
+ * - Options sheet with two tabs: Reciter list & Verse Repeat.
+ * - Reciter grid with radio selection.
+ * - Repeat modes: off / single verse / range (A–B) / surah, with play count, repeat each, delay.
+ * - ADDED: Playback speed control directly in the player bar.
+ * - REMOVED: Shuffle and Repeat icons from main bar for a cleaner look.
+ */
 
 type Props = {
-  track?: Track | null;
-  onPrev?: () => boolean;
-  onNext?: () => boolean;
+  track?: Track | null;
+  onPrev?: () => boolean;
+  onNext?: () => boolean;
 };
 
 export default function QuranAudioPlayer({ track, onPrev, onNext }: Props) {
-  const { theme } = useTheme();
-  const {
-    isPlayerVisible,
-    closePlayer,
-    audioRef,
-    isPlaying,
-    setIsPlaying,
-    setPlayingId,
-    activeVerse,
-    volume,
-    setVolume,
-    playbackRate,
-    repeatOptions,
-  } = useAudio();
-  const [current, setCurrent] = useState(0);
-  const [duration, setDuration] = useState<number>(track?.durationSec ?? 0);
+  const { theme } = useTheme();
+  const {
+    isPlayerVisible,
+    closePlayer,
+    audioRef,
+    isPlaying,
+    setIsPlaying,
+    setPlayingId,
+    activeVerse,
+    volume,
+    setVolume,
+    playbackRate,
+    repeatOptions,
+  } = useAudio();
+  const [current, setCurrent] = useState(0);
+  const [duration, setDuration] = useState<number>(track?.durationSec ?? 0);
 
-  const {
-    audioRef: internalAudioRef,
-    play,
-    pause,
-    seek,
-    setVolume: setPlayerVolume,
-    setPlaybackRate: setPlayerPlaybackRate,
-  } = useAudioPlayer({
-    src: track?.src,
-    defaultDuration: track?.durationSec,
-    onTimeUpdate: setCurrent,
-    onLoadedMetadata: setDuration,
-  });
+  const {
+    audioRef: internalAudioRef,
+    play,
+    pause,
+    seek,
+    setVolume: setPlayerVolume,
+    setPlaybackRate: setPlayerPlaybackRate,
+  } = useAudioPlayer({
+    src: track?.src,
+    defaultDuration: track?.durationSec,
+    onTimeUpdate: setCurrent,
+    onLoadedMetadata: setDuration,
+  });
 
-  useEffect(() => {
-    audioRef.current = internalAudioRef.current;
-  }, [audioRef, internalAudioRef]);
+  useEffect(() => {
+    audioRef.current = internalAudioRef.current;
+  }, [audioRef, internalAudioRef]);
 
-  const interactable = Boolean(track?.src);
+  const interactable = Boolean(track?.src);
 
-  useEffect(() => {
-    setCurrent(0);
-    setDuration(track?.durationSec ?? 0);
-  }, [track?.src, track?.durationSec]);
+  useEffect(() => {
+    setCurrent(0);
+    setDuration(track?.durationSec ?? 0);
+  }, [track?.src, track?.durationSec]);
 
-  useEffect(() => {
-    if (isPlaying) play();
-    if (!isPlaying) pause();
-  }, [isPlaying, play, pause]);
+  useEffect(() => {
+    if (isPlaying) play();
+    if (!isPlaying) pause();
+  }, [isPlaying, play, pause]);
 
-  useEffect(() => {
-    setPlayerVolume(volume);
-  }, [volume, setPlayerVolume]);
+  useEffect(() => {
+    setPlayerVolume(volume);
+  }, [volume, setPlayerVolume]);
 
-  useEffect(() => {
-    setPlayerPlaybackRate(playbackRate);
-  }, [playbackRate, setPlayerPlaybackRate]);
+  useEffect(() => {
+    setPlayerPlaybackRate(playbackRate);
+  }, [playbackRate, setPlayerPlaybackRate]);
 
-  const togglePlay = useCallback(() => {
-    if (!interactable) return;
-    const newPlaying = !isPlaying;
-    setIsPlaying(newPlaying);
-    if (newPlaying) {
-      if (activeVerse) setPlayingId(activeVerse.id);
-    } else {
-      setPlayingId(null);
-    }
-  }, [activeVerse, interactable, isPlaying, setIsPlaying, setPlayingId]);
+  const togglePlay = useCallback(() => {
+    if (!interactable) return;
+    const newPlaying = !isPlaying;
+    setIsPlaying(newPlaying);
+    if (newPlaying) {
+      if (activeVerse) setPlayingId(activeVerse.id);
+    } else {
+      setPlayingId(null);
+    }
+  }, [activeVerse, interactable, isPlaying, setIsPlaying, setPlayingId]);
 
-  const setSeek = useCallback(
-    (sec: number) => {
-      seek(sec);
-    },
-    [seek]
-  );
+  const setSeek = useCallback(
+    (sec: number) => {
+      seek(sec);
+    },
+    [seek]
+  );
 
-  usePlayerKeyboard({ current, duration, setSeek, togglePlay, setVolume });
+  usePlayerKeyboard({ current, duration, setSeek, togglePlay, setVolume });
 
-  const handleEnded = usePlaybackCompletion({
-    audioRef: internalAudioRef,
-    repeatOptions,
-    activeVerse,
-    onNext,
-    onPrev,
-    seek,
-    play,
-    pause,
-    setIsPlaying,
-    setPlayingId,
-  });
+  const handleEnded = usePlaybackCompletion({
+    audioRef: internalAudioRef,
+    repeatOptions,
+    activeVerse,
+    onNext,
+    onPrev,
+    seek,
+    play,
+    pause,
+    setIsPlaying,
+    setPlayingId,
+  });
 
-  const elapsed = useMemo(() => mmss(current), [current]);
-  const total = useMemo(() => mmss(duration || 0), [duration]);
+  const elapsed = useMemo(() => mmss(current), [current]);
+  const total = useMemo(() => mmss(duration || 0), [duration]);
 
-  const title = track?.title ?? 'No track selected';
-  const artist = track?.artist ?? '';
-  const cover =
-    track?.coverUrl ||
-    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><rect width='100%' height='100%' rx='12' ry='12' fill='%23e5e7eb'/><text x='50%' y='52%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, system-ui, sans-serif' font-size='12' fill='%239ca3af'>No cover</text></svg>";
+  const title = track?.title ?? 'No track selected';
+  const artist = track?.artist ?? '';
+  const cover =
+    track?.coverUrl ||
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><rect width='100%' height='100%' rx='12' ry='12' fill='%23e5e7eb'/><text x='50%' y='52%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, system-ui, sans-serif' font-size='12' fill='%239ca3af'>No cover</text></svg>";
 
-  if (!isPlayerVisible) return null;
+  if (!isPlayerVisible) return null;
 
-  return (
-    <div className="relative w-full">
-      {/* Card */}
-      <div
-        className={`mx-auto w-full rounded-2xl px-4 py-4 flex items-center gap-4 ${
-          theme === 'dark'
-            ? 'bg-slate-800 shadow-[0_10px_30px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] border-slate-700'
-            : 'bg-white shadow-[0_10px_30px_rgba(2,6,23,0.06),0_1px_2px_rgba(2,6,23,0.04)] border-slate-200/80'
-        } border`}
-        role="region"
-        aria-label="Player"
-      >
-        {/* Left media block */}
-        <TrackInfo cover={cover} title={title} artist={artist} theme={theme} />
-
-        {/* Transport controls */}
-        <TransportControls
-          isPlaying={isPlaying}
-          interactable={interactable}
-          onPrev={onPrev}
-          onNext={onNext}
-          togglePlay={togglePlay}
-          theme={theme}
-        />
-
-        {/* Timeline & Time Labels */}
-        <Timeline
-          current={current}
-          duration={duration}
-          setSeek={setSeek}
-          interactable={interactable}
-          theme={theme}
-          elapsed={elapsed}
-          total={total}
-        />
-
-        {/* Utilities */}
-        <div className="flex items-center gap-2">
-          <PlayerOptions theme={theme} />
-          <IconBtn aria-label="Close player" onClick={closePlayer} theme={theme}>
-            <X />
-          </IconBtn>
-        </div>
-      </div>
-
-      {/* Hidden audio element */}
-      <audio ref={internalAudioRef} src={track?.src || ''} preload="metadata" onEnded={handleEnded}>
-        <track kind="captions" />
-      </audio>
-    </div>
-  );
+  return (
+    <div className="relative w-full">
+            {/* Card */}     {' '}
+      <div
+        className={`mx-auto w-full rounded-2xl px-4 py-4 flex items-center gap-4 ${
+          theme === 'dark'
+            ? 'bg-slate-800 shadow-[0_10px_30px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] border-slate-700'
+            : 'bg-white shadow-[0_10px_30px_rgba(2,6,23,0.06),0_1px_2px_rgba(2,6,23,0.04)] border-slate-200/80'
+        } border`}
+        role="region"
+        aria-label="Player"
+      >
+                {/* Left media block */}
+                <TrackInfo cover={cover} title={title} artist={artist} theme={theme} />       {' '}
+        {/* Transport controls */}       {' '}
+        <TransportControls
+          isPlaying={isPlaying}
+          interactable={interactable}
+          onPrev={onPrev}
+          onNext={onNext}
+          togglePlay={togglePlay}
+          theme={theme}
+        />
+                {/* Timeline & Time Labels */}       {' '}
+        <Timeline
+          current={current}
+          duration={duration}
+          setSeek={setSeek}
+          interactable={interactable}
+          theme={theme}
+          elapsed={elapsed}
+          total={total}
+        />
+                {/* Utilities */}       {' '}
+        <div className="flex items-center gap-2">
+                    <PlayerOptions theme={theme} />         {' '}
+          <IconBtn aria-label="Close player" onClick={closePlayer} theme={theme}>
+                        <X />         {' '}
+          </IconBtn>
+                 {' '}
+        </div>
+             {' '}
+      </div>
+            {/* Hidden audio element */}     {' '}
+      <audio ref={internalAudioRef} src={track?.src || ''} preload="metadata" onEnded={handleEnded}>
+                <track kind="captions" />     {' '}
+      </audio>
+         {' '}
+    </div>
+  );
 }
 
 function mmss(t: number) {
-  t = Math.max(0, Math.floor(t || 0));
-  const m = Math.floor(t / 60);
-  const s = t % 60;
-  return `${m}:${s.toString().padStart(2, '0')}`;
+  t = Math.max(0, Math.floor(t || 0));
+  const m = Math.floor(t / 60);
+  const s = t % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
 }

--- a/app/(features)/surah/[surahId]/components/Verse.tsx
+++ b/app/(features)/surah/[surahId]/components/Verse.tsx
@@ -3,90 +3,98 @@ import { memo, useCallback } from 'react';
 import { Verse as VerseType, Translation } from '@/types';
 import { useAudio } from '@/app/(features)/player/context/AudioContext';
 import { useSettings } from '@/app/providers/SettingsContext';
+import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 import VerseActions from '@/app/shared/VerseActions';
 import VerseArabic from '@/app/shared/VerseArabic';
-import Spinner from '@/app/shared/Spinner';
 
 interface VerseProps {
-  verse: VerseType;
+  verse: VerseType;
 }
 
 /**
- * Memoized to prevent unnecessary rerenders when `verse` prop
- * and context values are stable.
- */
+ * Memoized to prevent unnecessary rerenders when `verse` prop
+ * and context values are stable.
+ */
 export const Verse = memo(function Verse({ verse }: VerseProps) {
-  const {
-    playingId,
-    setPlayingId,
-    loadingId,
-    setLoadingId,
-    setActiveVerse,
-    audioRef,
-    setIsPlaying,
-    openPlayer,
-  } = useAudio();
-  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
-  const isPlaying = playingId === verse.id;
-  const isLoadingAudio = loadingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
+  const {
+    playingId,
+    setPlayingId,
+    loadingId,
+    setLoadingId,
+    setActiveVerse,
+    audioRef,
+    setIsPlaying,
+    openPlayer,
+  } = useAudio();
+  const { settings } = useSettings();
+  const { bookmarkedVerses, toggleBookmark } = useBookmarks();
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
 
-  const handlePlayPause = useCallback(() => {
-    if (playingId === verse.id) {
-      audioRef.current?.pause();
-      setPlayingId(null);
-      setLoadingId(null);
-      setActiveVerse(null);
-      setIsPlaying(false);
-    } else {
-      setActiveVerse(verse);
-      setPlayingId(verse.id);
-      setLoadingId(verse.id);
-      setIsPlaying(true);
-      openPlayer();
-    }
-  }, [
-    playingId,
-    verse,
-    audioRef,
-    setActiveVerse,
-    setPlayingId,
-    setLoadingId,
-    setIsPlaying,
-    openPlayer,
-  ]);
+  const handlePlayPause = useCallback(() => {
+    if (playingId === verse.id) {
+      audioRef.current?.pause();
+      setPlayingId(null);
+      setLoadingId(null);
+      setActiveVerse(null);
+      setIsPlaying(false);
+    } else {
+      setActiveVerse(verse);
+      setPlayingId(verse.id);
+      setLoadingId(verse.id);
+      setIsPlaying(true);
+      openPlayer();
+    }
+  }, [
+    playingId,
+    verse,
+    audioRef,
+    setActiveVerse,
+    setPlayingId,
+    setLoadingId,
+    setIsPlaying,
+    openPlayer,
+  ]);
 
-  const handleBookmark = useCallback(() => {
-    toggleBookmark(String(verse.id));
-  }, [toggleBookmark, verse.id]);
+  const handleBookmark = useCallback(() => {
+    toggleBookmark(String(verse.id));
+  }, [toggleBookmark, verse.id]);
 
-  return (
-    <>
-      <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
-        <VerseActions
-          verseKey={verse.verse_key}
-          isPlaying={isPlaying}
-          isLoadingAudio={isLoadingAudio}
-          isBookmarked={isBookmarked}
-          onPlayPause={handlePlayPause}
-          onBookmark={handleBookmark}
-          className="w-16 pt-1"
-        />
-        <div className="flex-grow space-y-6">
-          <VerseArabic verse={verse} />
-          {/* TRANSLATIONS */}
-          {verse.translations?.map((t: Translation) => (
-            <div key={t.resource_id}>
-              <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
-                style={{ fontSize: `${settings.translationFontSize}px` }}
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
-    </>
-  );
+  return (
+    <>
+           {' '}
+      <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
+               {' '}
+        <VerseActions
+          verseKey={verse.verse_key}
+          isPlaying={isPlaying}
+          isLoadingAudio={isLoadingAudio}
+          isBookmarked={isBookmarked}
+          onPlayPause={handlePlayPause}
+          onBookmark={handleBookmark}
+          className="w-16 pt-1"
+        />
+               {' '}
+        <div className="flex-grow space-y-6">
+                    <VerseArabic verse={verse} />          {/* TRANSLATIONS */}         {' '}
+          {verse.translations?.map((t: Translation) => (
+            <div key={t.resource_id}>
+                           {' '}
+              <p
+                className="text-left leading-relaxed text-[var(--foreground)]"
+                style={{ fontSize: `${settings.translationFontSize}px` }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
+              />
+                         {' '}
+            </div>
+          ))}
+                 {' '}
+        </div>
+             {' '}
+      </div>
+         {' '}
+    </>
+  );
 });

--- a/app/(features)/surah/__tests__/SurahPage.test.tsx
+++ b/app/(features)/surah/__tests__/SurahPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
 import { ThemeProvider } from '@/app/providers/ThemeContext';
 import { SidebarProvider } from '@/app/providers/SidebarContext';
@@ -73,11 +74,13 @@ const renderPage = () =>
     <SWRConfig value={{ provider: () => new Map() }}>
       <AudioProvider>
         <SettingsProvider>
-          <ThemeProvider>
-            <SidebarProvider>
-              <SurahPage params={{ surahId: '1' } as unknown as Promise<{ surahId: string }>} />
-            </SidebarProvider>
-          </ThemeProvider>
+          <BookmarkProvider>
+            <ThemeProvider>
+              <SidebarProvider>
+                <SurahPage params={{ surahId: '1' } as unknown as Promise<{ surahId: string }>} />
+              </SidebarProvider>
+            </ThemeProvider>
+          </BookmarkProvider>
         </SettingsProvider>
       </AudioProvider>
     </SWRConfig>

--- a/app/(features)/surah/__tests__/Verse.test.tsx
+++ b/app/(features)/surah/__tests__/Verse.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { Verse as VerseComponent } from '@/app/(features)/surah/[surahId]/components/Verse';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
 import TranslationProvider from '@/app/providers/TranslationProvider';
 import { Verse } from '@/types';
@@ -24,7 +25,9 @@ const renderVerse = () =>
     <TranslationProvider>
       <AudioProvider>
         <SettingsProvider>
-          <VerseComponent verse={verse} />
+          <BookmarkProvider>
+            <VerseComponent verse={verse} />
+          </BookmarkProvider>
         </SettingsProvider>
       </AudioProvider>
     </TranslationProvider>

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FaChevronDown } from '@/app/shared/SvgIcons';
+import { ChevronDownIcon } from '@/app/shared/icons';
 import Spinner from '@/app/shared/Spinner';
 import { applyArabicFont } from '@/lib/tafsir/applyArabicFont';
 import { useSettings } from '@/app/providers/SettingsContext';
@@ -25,7 +25,7 @@ export const TafsirPanels = ({ verseKey, tafsirIds }: TafsirPanelsProps) => {
               className="w-full flex items-center justify-between py-3 text-left"
             >
               <span className="font-semibold text-[var(--foreground)]">Tafsir {id}</span>
-              <FaChevronDown
+              <ChevronDownIcon
                 size={16}
                 className={`text-gray-500 transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
               />

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
@@ -2,52 +2,61 @@
 import { Verse as VerseType, Translation } from '@/types';
 import { useAudio } from '@/app/(features)/player/context/AudioContext';
 import { useSettings } from '@/app/providers/SettingsContext';
+import { useBookmarks } from '@/app/providers/BookmarkContext';
 import VerseActions from '@/app/shared/VerseActions';
 import VerseArabic from '@/app/shared/VerseArabic';
 import { TafsirPanels } from './TafsirPanels';
 import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 
 interface TafsirVerseProps {
-  verse: VerseType;
-  tafsirIds: number[];
+  verse: VerseType;
+  tafsirIds: number[];
 }
 
 export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
-  const { playingId, setPlayingId, loadingId } = useAudio();
-  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
+  const { playingId, setPlayingId, loadingId } = useAudio();
+  const { settings } = useSettings();
+  const { bookmarkedVerses, toggleBookmark } = useBookmarks();
 
-  const isPlaying = playingId === verse.id;
-  const isLoadingAudio = loadingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-start gap-x-6 pb-8 border-b border-[var(--border-color)]">
-        <VerseActions
-          verseKey={verse.verse_key}
-          isPlaying={isPlaying}
-          isLoadingAudio={isLoadingAudio}
-          isBookmarked={isBookmarked}
-          onPlayPause={() =>
-            setPlayingId((currentId) => (currentId === verse.id ? null : verse.id))
-          }
-          onBookmark={() => toggleBookmark(String(verse.id))}
-          className="w-16 pt-1"
-        />
-        <div className="flex-grow space-y-6">
-          <VerseArabic verse={verse} />
-          {verse.translations?.map((t: Translation) => (
-            <div key={t.resource_id}>
-              <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
-                style={{ fontSize: `${settings.translationFontSize}px` }}
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
-      <TafsirPanels verseKey={verse.verse_key} tafsirIds={tafsirIds} />
-    </div>
-  );
+  return (
+    <div className="space-y-6">
+           {' '}
+      <div className="flex items-start gap-x-6 pb-8 border-b border-[var(--border-color)]">
+               {' '}
+        <VerseActions
+          verseKey={verse.verse_key}
+          isPlaying={isPlaying}
+          isLoadingAudio={isLoadingAudio}
+          isBookmarked={isBookmarked}
+          onPlayPause={() =>
+            setPlayingId((currentId) => (currentId === verse.id ? null : verse.id))
+          }
+          onBookmark={() => toggleBookmark(String(verse.id))}
+          className="w-16 pt-1"
+        />
+               {' '}
+        <div className="flex-grow space-y-6">
+                    <VerseArabic verse={verse} />         {' '}
+          {verse.translations?.map((t: Translation) => (
+            <div key={t.resource_id}>
+                           {' '}
+              <p
+                className="text-left leading-relaxed text-[var(--foreground)]"
+                style={{ fontSize: `${settings.translationFontSize}px` }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
+              />
+                         {' '}
+            </div>
+          ))}
+                 {' '}
+        </div>
+             {' '}
+      </div>
+            <TafsirPanels verseKey={verse.verse_key} tafsirIds={tafsirIds} />   {' '}
+    </div>
+  );
 };

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
@@ -2,45 +2,53 @@
 import { Verse as VerseType, Translation } from '@/types';
 import { useAudio } from '@/app/(features)/player/context/AudioContext';
 import { useSettings } from '@/app/providers/SettingsContext';
+import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
 import VerseActions from '@/app/shared/VerseActions';
 import VerseArabic from '@/app/shared/VerseArabic';
 
 interface VerseCardProps {
-  verse: VerseType;
+  verse: VerseType;
 }
 
 export default function VerseCard({ verse }: VerseCardProps) {
-  const { playingId, setPlayingId, loadingId } = useAudio();
-  const { settings, bookmarkedVerses, toggleBookmark } = useSettings();
+  const { playingId, setPlayingId, loadingId } = useAudio();
+  const { settings } = useSettings();
+  const { bookmarkedVerses, toggleBookmark } = useBookmarks();
 
-  const isPlaying = playingId === verse.id;
-  const isLoadingAudio = loadingId === verse.id;
-  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
+  const isPlaying = playingId === verse.id;
+  const isLoadingAudio = loadingId === verse.id;
+  const isBookmarked = bookmarkedVerses.includes(String(verse.id));
 
-  return (
-    <div className="relative flex bg-white rounded-md border shadow p-6">
-      <VerseActions
-        verseKey={verse.verse_key}
-        isPlaying={isPlaying}
-        isLoadingAudio={isLoadingAudio}
-        isBookmarked={isBookmarked}
-        onPlayPause={() => setPlayingId((id) => (id === verse.id ? null : verse.id))}
-        onBookmark={() => toggleBookmark(String(verse.id))}
-        className="w-14 mr-4 pt-2 text-gray-500"
-      />
-      <div className="flex-grow space-y-6">
-        <VerseArabic verse={verse} />
-        {verse.translations?.map((t: Translation) => (
-          <div key={t.resource_id}>
-            <p
-              className="text-left leading-relaxed"
-              style={{ fontSize: `${settings.translationFontSize}px` }}
-              dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
-            />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return (
+    <div className="relative flex bg-white rounded-md border shadow p-6">
+           {' '}
+      <VerseActions
+        verseKey={verse.verse_key}
+        isPlaying={isPlaying}
+        isLoadingAudio={isLoadingAudio}
+        isBookmarked={isBookmarked}
+        onPlayPause={() => setPlayingId((id) => (id === verse.id ? null : verse.id))}
+        onBookmark={() => toggleBookmark(String(verse.id))}
+        className="w-14 mr-4 pt-2 text-gray-500"
+      />
+           {' '}
+      <div className="flex-grow space-y-6">
+                <VerseArabic verse={verse} />       {' '}
+        {verse.translations?.map((t: Translation) => (
+          <div key={t.resource_id}>
+                       {' '}
+            <p
+              className="text-left leading-relaxed"
+              style={{ fontSize: `${settings.translationFontSize}px` }}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
+            />
+                     {' '}
+          </div>
+        ))}
+             {' '}
+      </div>
+         {' '}
+    </div>
+  );
 }

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
@@ -5,7 +5,7 @@ import { useSettings } from '@/app/providers/SettingsContext';
 import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
 import type { LanguageCode } from '@/lib/text/languageCodes';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
-import { FaArrowLeft, FaSearch } from '@/app/shared/SvgIcons';
+import { ArrowLeftIcon, SearchIcon } from '@/app/shared/icons';
 
 interface LanguageOption {
   name: string;
@@ -52,7 +52,7 @@ export const WordTranslationPanel = ({
           onClick={onClose}
           className="p-2 rounded-full hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
         >
-          <FaArrowLeft size={18} />
+          <ArrowLeftIcon size={18} />
         </button>
         <h2 className="font-bold text-lg text-[var(--foreground)]">
           {t('word_by_word_panel_title')}
@@ -61,7 +61,11 @@ export const WordTranslationPanel = ({
       </div>
       <div className="p-3 border-b border-gray-200/80">
         <div className="relative">
-          <FaSearch className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+          <SearchIcon
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400"
+            width={18}
+            height={18}
+          />
           <input
             type="text"
             placeholder={t('search')}

--- a/app/(features)/tafsir/__tests__/TafsirVerseCard.test.tsx
+++ b/app/(features)/tafsir/__tests__/TafsirVerseCard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import VerseCard from '@/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
 import { Verse } from '@/types';
 
@@ -20,7 +21,9 @@ const renderCard = () =>
   render(
     <AudioProvider>
       <SettingsProvider>
-        <VerseCard verse={verse} />
+        <BookmarkProvider>
+          <VerseCard verse={verse} />
+        </BookmarkProvider>
       </SettingsProvider>
     </AudioProvider>
   );
@@ -75,7 +78,9 @@ it('strips malicious tags from content', () => {
   render(
     <AudioProvider>
       <SettingsProvider>
-        <VerseCard verse={maliciousVerse} />
+        <BookmarkProvider>
+          <VerseCard verse={maliciousVerse} />
+        </BookmarkProvider>
       </SettingsProvider>
     </AudioProvider>
   );

--- a/app/(features)/tafsir/__tests__/TafsirVersePage.test.tsx
+++ b/app/(features)/tafsir/__tests__/TafsirVersePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TafsirVersePage from '@/app/(features)/tafsir/[surahId]/[ayahId]/page';
 import { SettingsProvider } from '@/app/providers/SettingsContext';
+import { BookmarkProvider } from '@/app/providers/BookmarkContext';
 import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
 import { SidebarProvider } from '@/app/providers/SidebarContext';
 import { ThemeProvider } from '@/app/providers/ThemeContext';
@@ -78,18 +79,20 @@ const renderPage = (surahId = '1', ayahId = '1') =>
   render(
     <AudioProvider>
       <SettingsProvider>
-        <ThemeProvider>
-          <SidebarProvider>
-            <TafsirVersePage
-              params={
-                { surahId, ayahId } as unknown as Promise<{
-                  surahId: string;
-                  ayahId: string;
-                }>
-              }
-            />
-          </SidebarProvider>
-        </ThemeProvider>
+        <BookmarkProvider>
+          <ThemeProvider>
+            <SidebarProvider>
+              <TafsirVersePage
+                params={
+                  { surahId, ayahId } as unknown as Promise<{
+                    surahId: string;
+                    ayahId: string;
+                  }>
+                }
+              />
+            </SidebarProvider>
+          </ThemeProvider>
+        </BookmarkProvider>
       </SettingsProvider>
     </AudioProvider>
   );

--- a/app/providers/BookmarkContext.tsx
+++ b/app/providers/BookmarkContext.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+// Debounce interval for persisting bookmarks to localStorage.
+const PERSIST_DEBOUNCE_MS = 300;
+
+interface BookmarkContextType {
+  bookmarkedVerses: string[];
+  toggleBookmark: (verseId: string) => void;
+}
+
+const BookmarkContext = createContext<BookmarkContextType | undefined>(undefined);
+
+/**
+ * Provides global verse bookmark state.
+ * Wrap parts of the app that need bookmark access with this provider and
+ * use the {@link useBookmarks} hook to interact with it.
+ */
+export const BookmarkProvider = ({ children }: { children: React.ReactNode }) => {
+  const [bookmarkedVerses, setBookmarkedVerses] = useState<string[]>([]);
+  const bookmarksTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestBookmarks = useRef(bookmarkedVerses);
+
+  // Load bookmarks from localStorage on mount
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const savedBookmarks = localStorage.getItem('quranAppBookmarks');
+      if (savedBookmarks) {
+        try {
+          setBookmarkedVerses(JSON.parse(savedBookmarks));
+        } catch (error) {
+          console.error('Error parsing bookmarks from localStorage:', error);
+        }
+      }
+    }
+  }, []);
+
+  // Save bookmarks when changed (debounced)
+  useEffect(() => {
+    latestBookmarks.current = bookmarkedVerses;
+    if (typeof window === 'undefined') return;
+
+    bookmarksTimeoutRef.current = setTimeout(() => {
+      localStorage.setItem('quranAppBookmarks', JSON.stringify(bookmarkedVerses));
+      bookmarksTimeoutRef.current = null;
+    }, PERSIST_DEBOUNCE_MS);
+
+    return () => {
+      if (bookmarksTimeoutRef.current) clearTimeout(bookmarksTimeoutRef.current);
+    };
+  }, [bookmarkedVerses]);
+
+  // Flush any pending writes on unmount
+  useEffect(() => {
+    return () => {
+      if (typeof window === 'undefined') return;
+      if (bookmarksTimeoutRef.current) {
+        clearTimeout(bookmarksTimeoutRef.current);
+        localStorage.setItem('quranAppBookmarks', JSON.stringify(latestBookmarks.current));
+      }
+    };
+  }, []);
+
+  const toggleBookmark = useCallback(
+    (verseId: string) => {
+      setBookmarkedVerses((prev) =>
+        prev.includes(verseId) ? prev.filter((id) => id !== verseId) : [...prev, verseId]
+      );
+    },
+    [setBookmarkedVerses]
+  );
+
+  const value = useMemo(
+    () => ({ bookmarkedVerses, toggleBookmark }),
+    [bookmarkedVerses, toggleBookmark]
+  );
+
+  return <BookmarkContext.Provider value={value}>{children}</BookmarkContext.Provider>;
+};
+
+export const useBookmarks = () => {
+  const ctx = useContext(BookmarkContext);
+  if (!ctx) throw new Error('useBookmarks must be used within BookmarkProvider');
+  return ctx;
+};

--- a/app/providers/ClientProviders.tsx
+++ b/app/providers/ClientProviders.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { ThemeProvider, Theme } from './ThemeContext';
 import { SettingsProvider } from './SettingsContext';
+import { BookmarkProvider } from './BookmarkContext';
 import { SidebarProvider } from './SidebarContext';
 
 /**
@@ -19,7 +20,9 @@ export default function ClientProviders({
   return (
     <ThemeProvider initialTheme={initialTheme}>
       <SettingsProvider>
-        <SidebarProvider>{children}</SidebarProvider>
+        <BookmarkProvider>
+          <SidebarProvider>{children}</SidebarProvider>
+        </BookmarkProvider>
       </SettingsProvider>
     </ThemeProvider>
   );

--- a/app/providers/__tests__/BookmarkContext.test.tsx
+++ b/app/providers/__tests__/BookmarkContext.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BookmarkProvider, useBookmarks } from '@/app/providers/BookmarkContext';
+
+const BookmarkTest = () => {
+  const { bookmarkedVerses, toggleBookmark } = useBookmarks();
+  return (
+    <div>
+      <div data-testid="bookmarks">{JSON.stringify(bookmarkedVerses)}</div>
+      <button onClick={() => toggleBookmark('1:1')}>Toggle</button>
+    </div>
+  );
+};
+
+describe('BookmarkContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('adds a verse ID to bookmarks via toggleBookmark', async () => {
+    render(
+      <BookmarkProvider>
+        <BookmarkTest />
+      </BookmarkProvider>
+    );
+    await userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('bookmarks').textContent).toBe(JSON.stringify(['1:1']));
+      expect(JSON.parse(localStorage.getItem('quranAppBookmarks') || '[]')).toEqual(['1:1']);
+    });
+  });
+
+  it('persists bookmarks in localStorage across renders', async () => {
+    const { unmount } = render(
+      <BookmarkProvider>
+        <BookmarkTest />
+      </BookmarkProvider>
+    );
+    await userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('quranAppBookmarks') || '[]')).toEqual(['1:1']);
+    });
+    unmount();
+
+    render(
+      <BookmarkProvider>
+        <BookmarkTest />
+      </BookmarkProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('bookmarks').textContent).toBe(JSON.stringify(['1:1']));
+    });
+  });
+});

--- a/app/providers/__tests__/SettingsContext.test.tsx
+++ b/app/providers/__tests__/SettingsContext.test.tsx
@@ -2,16 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SettingsProvider, useSettings } from '@/app/providers/SettingsContext';
 
-const BookmarkTest = () => {
-  const { bookmarkedVerses, toggleBookmark } = useSettings();
-  return (
-    <div>
-      <div data-testid="bookmarks">{JSON.stringify(bookmarkedVerses)}</div>
-      <button onClick={() => toggleBookmark('1:1')}>Toggle</button>
-    </div>
-  );
-};
-
 const SettingsTest = () => {
   const { settings, setSettings } = useSettings();
   return (
@@ -26,47 +16,6 @@ const SettingsTest = () => {
     </div>
   );
 };
-
-describe('SettingsContext bookmarks', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('adds a verse ID to bookmarks via toggleBookmark', async () => {
-    render(
-      <SettingsProvider>
-        <BookmarkTest />
-      </SettingsProvider>
-    );
-    await userEvent.click(screen.getByRole('button'));
-    await waitFor(() => {
-      expect(screen.getByTestId('bookmarks').textContent).toBe(JSON.stringify(['1:1']));
-      expect(JSON.parse(localStorage.getItem('quranAppBookmarks') || '[]')).toEqual(['1:1']);
-    });
-  });
-
-  it('persists bookmarks in localStorage across renders', async () => {
-    const { unmount } = render(
-      <SettingsProvider>
-        <BookmarkTest />
-      </SettingsProvider>
-    );
-    await userEvent.click(screen.getByRole('button'));
-    await waitFor(() => {
-      expect(JSON.parse(localStorage.getItem('quranAppBookmarks') || '[]')).toEqual(['1:1']);
-    });
-    unmount();
-
-    render(
-      <SettingsProvider>
-        <BookmarkTest />
-      </SettingsProvider>
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('bookmarks').textContent).toBe(JSON.stringify(['1:1']));
-    });
-  });
-});
 
 describe('SettingsContext settings state', () => {
   beforeEach(() => {

--- a/app/shared/VerseActions.tsx
+++ b/app/shared/VerseActions.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FaPlay, FaPause, FaBookmark, FaRegBookmark, FaShare } from './SvgIcons';
+import { PlayIcon, PauseIcon, BookmarkIcon, BookmarkOutlineIcon, ShareIcon } from './icons';
 import Spinner from './Spinner';
 
 interface VerseActionsProps {
@@ -46,9 +46,9 @@ const VerseActions = ({
           {isLoadingAudio ? (
             <Spinner className="h-4 w-4 text-teal-600" />
           ) : isPlaying ? (
-            <FaPause size={18} />
+            <PauseIcon size={18} />
           ) : (
-            <FaPlay size={18} />
+            <PlayIcon size={18} />
           )}
         </button>
         <button
@@ -57,7 +57,7 @@ const VerseActions = ({
           onClick={onBookmark}
           className={`p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition ${isBookmarked ? 'text-teal-600' : 'hover:text-teal-600'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500`}
         >
-          {isBookmarked ? <FaBookmark size={18} /> : <FaRegBookmark size={18} />}
+          {isBookmarked ? <BookmarkIcon size={18} /> : <BookmarkOutlineIcon size={18} />}
         </button>
         <button
           aria-label="Share"
@@ -65,7 +65,7 @@ const VerseActions = ({
           onClick={handleShare}
           className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
         >
-          <FaShare size={18} />
+          <ShareIcon size={18} />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- extract bookmark state to new BookmarkContext with localStorage persistence
- streamline SettingsContext to focus on font and translation preferences
- update consumers and tests to use separate bookmark provider

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run check` *(fails: app/(features)/juz/[juzId]/page.tsx(129,19): Type 'RefObject<HTMLDivElement | null>' is not assignable to type 'RefObject<HTMLDivElement'.)*

------
https://chatgpt.com/codex/tasks/task_b_689c576d6304832f9499afa2eee44deb