### PR TITLE
Refactor tafsir data hooks

### DIFF
--- a/app/(features)/tafsir/hooks/useTafsirOptions.ts
+++ b/app/(features)/tafsir/hooks/useTafsirOptions.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { useTranslation } from 'react-i18next';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { getTafsirResources } from '@/lib/api';
+import { TafsirResource } from '@/types';
+
+export const useTafsirOptions = () => {
+  const { t } = useTranslation();
+  const { settings } = useSettings();
+
+  const { data } = useSWR('tafsirs', getTafsirResources);
+  const tafsirOptions: TafsirResource[] = useMemo(() => data || [], [data]);
+
+  const tafsirResource = useMemo(
+    () => tafsirOptions.find((t) => t.id === settings.tafsirIds[0]),
+    [tafsirOptions, settings.tafsirIds]
+  );
+
+  const selectedTafsirName = useMemo(() => {
+    const names = settings.tafsirIds
+      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
+      .filter(Boolean)
+      .slice(0, 3);
+    return names.length ? names.join(', ') : t('select_tafsir');
+  }, [settings.tafsirIds, tafsirOptions, t]);
+
+  return { tafsirOptions, tafsirResource, selectedTafsirName };
+};

--- a/app/(features)/tafsir/hooks/useTafsirVerseData.ts
+++ b/app/(features)/tafsir/hooks/useTafsirVerseData.ts
@@ -1,83 +1,20 @@
-import { useMemo, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
 import useSWR from 'swr';
-import { useTranslation } from 'react-i18next';
 import { useSettings } from '@/app/providers/SettingsContext';
-import { useSidebar } from '@/app/providers/SidebarContext';
-import {
-  getTranslations,
-  getTafsirResources,
-  getWordTranslations,
-  getVersesByChapter,
-  getTafsirByVerse,
-} from '@/lib/api';
-import { Verse as VerseType, TranslationResource, TafsirResource, Surah } from '@/types';
-import { WORD_LANGUAGE_LABELS } from '@/lib/text/wordLanguages';
-import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
-import type { LanguageCode } from '@/lib/text/languageCodes';
-import surahs from '@/data/surahs.json';
-
-const DEFAULT_WORD_TRANSLATION_ID = 85;
+import { getVersesByChapter, getTafsirByVerse } from '@/lib/api';
+import { Verse as VerseType } from '@/types';
+import { useTranslationOptions } from './useTranslationOptions';
+import { useTafsirOptions } from './useTafsirOptions';
+import { useWordTranslations } from './useWordTranslations';
+import { useVerseNavigation } from './useVerseNavigation';
 
 export const useTafsirVerseData = (surahId: string, ayahId: string) => {
-  const router = useRouter();
-  const { t } = useTranslation();
-  const { settings, setSettings } = useSettings();
-  const { setSurahListOpen } = useSidebar();
+  const { settings } = useSettings();
 
-  const { data: translationOptionsData } = useSWR('translations', getTranslations);
-  const translationOptions: TranslationResource[] = useMemo(
-    () => translationOptionsData || [],
-    [translationOptionsData]
-  );
-
-  const { data: tafsirOptionsData } = useSWR('tafsirs', getTafsirResources);
-  const tafsirOptions: TafsirResource[] = useMemo(
-    () => tafsirOptionsData || [],
-    [tafsirOptionsData]
-  );
-
-  const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
-  const wordLanguageMap = useMemo(() => {
-    const map: Record<string, number> = {};
-    (wordTranslationOptionsData || []).forEach((o) => {
-      const name = o.language_name.toLowerCase();
-      if (!map[name]) {
-        map[name] = o.id;
-      }
-    });
-    return map;
-  }, [wordTranslationOptionsData]);
-  const wordLanguageOptions = useMemo(
-    () =>
-      Object.keys(wordLanguageMap)
-        .filter((name) => WORD_LANGUAGE_LABELS[name])
-        .map((name) => ({ name: WORD_LANGUAGE_LABELS[name], id: wordLanguageMap[name] })),
-    [wordLanguageMap]
-  );
-
-  const selectedTranslationName = useMemo(
-    () =>
-      translationOptions.find((o) => o.id === settings.translationId)?.name ||
-      t('select_translation'),
-    [settings.translationId, translationOptions, t]
-  );
-  const selectedTafsirName = useMemo(() => {
-    const names = settings.tafsirIds
-      .map((id) => tafsirOptions.find((o) => o.id === id)?.name)
-      .filter(Boolean)
-      .slice(0, 3);
-    return names.length ? names.join(', ') : t('select_tafsir');
-  }, [settings.tafsirIds, tafsirOptions, t]);
-  const selectedWordLanguageName = useMemo(
-    () =>
-      wordLanguageOptions.find(
-        (o) =>
-          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
-          settings.wordLang
-      )?.name || t('select_word_translation'),
-    [settings.wordLang, wordLanguageOptions, t]
-  );
+  const { translationOptions, selectedTranslationName } = useTranslationOptions();
+  const { tafsirResource, selectedTafsirName } = useTafsirOptions();
+  const { wordLanguageOptions, wordLanguageMap, selectedWordLanguageName, resetWordSettings } =
+    useWordTranslations();
+  const { prev, next, navigate, currentSurah } = useVerseNavigation(surahId, ayahId);
 
   const { data: verseData } = useSWR(
     surahId && ayahId
@@ -88,53 +25,10 @@ export const useTafsirVerseData = (surahId: string, ayahId: string) => {
   );
   const verse: VerseType | undefined = verseData;
 
-  const tafsirResource = useMemo(
-    () => tafsirOptions.find((t) => t.id === settings.tafsirIds[0]),
-    [tafsirOptions, settings.tafsirIds]
-  );
-
   const { data: tafsirHtml } = useSWR(
     verse && tafsirResource ? ['tafsir', verse.verse_key, tafsirResource.id] : null,
     ([, key, id]) => getTafsirByVerse(key as string, id as number)
   );
-
-  const surahList = surahs as Surah[];
-  const totalSurahs = surahList.length;
-  const currentSurahIndex = Number(surahId) - 1;
-  const currentAyahNum = Number(ayahId);
-
-  const prev =
-    currentAyahNum > 1
-      ? { surahId, ayahId: currentAyahNum - 1 }
-      : currentSurahIndex > 0
-        ? { surahId: String(Number(surahId) - 1), ayahId: surahList[currentSurahIndex - 1].verses }
-        : null;
-
-  const next =
-    currentAyahNum < surahList[currentSurahIndex].verses
-      ? { surahId, ayahId: currentAyahNum + 1 }
-      : currentSurahIndex < totalSurahs - 1
-        ? { surahId: String(Number(surahId) + 1), ayahId: 1 }
-        : null;
-
-  const navigate = useCallback(
-    (target: { surahId: string; ayahId: number } | null) => {
-      if (!target) return;
-      setSurahListOpen(false);
-      router.push(`/tafsir/${target.surahId}/${target.ayahId}`);
-    },
-    [router, setSurahListOpen]
-  );
-
-  const currentSurah = surahList.find((s) => s.number === Number(surahId));
-
-  const resetWordSettings = useCallback(() => {
-    setSettings({
-      ...settings,
-      wordLang: 'en',
-      wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
-    });
-  }, [settings, setSettings, wordLanguageMap]);
 
   return {
     verse,

--- a/app/(features)/tafsir/hooks/useTranslationOptions.ts
+++ b/app/(features)/tafsir/hooks/useTranslationOptions.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { useTranslation } from 'react-i18next';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { getTranslations } from '@/lib/api';
+import { TranslationResource } from '@/types';
+
+export const useTranslationOptions = () => {
+  const { t } = useTranslation();
+  const { settings } = useSettings();
+
+  const { data } = useSWR('translations', getTranslations);
+  const translationOptions: TranslationResource[] = useMemo(() => data || [], [data]);
+
+  const selectedTranslationName = useMemo(
+    () =>
+      translationOptions.find((o) => o.id === settings.translationId)?.name ||
+      t('select_translation'),
+    [translationOptions, settings.translationId, t]
+  );
+
+  return { translationOptions, selectedTranslationName };
+};

--- a/app/(features)/tafsir/hooks/useVerseNavigation.ts
+++ b/app/(features)/tafsir/hooks/useVerseNavigation.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSidebar } from '@/app/providers/SidebarContext';
+import type { Surah } from '@/types';
+import surahs from '@/data/surahs.json';
+
+export const useVerseNavigation = (surahId: string, ayahId: string) => {
+  const router = useRouter();
+  const { setSurahListOpen } = useSidebar();
+
+  const surahList = surahs as Surah[];
+  const totalSurahs = surahList.length;
+  const currentSurahIndex = Number(surahId) - 1;
+  const currentAyahNum = Number(ayahId);
+
+  const prev =
+    currentAyahNum > 1
+      ? { surahId, ayahId: currentAyahNum - 1 }
+      : currentSurahIndex > 0
+        ? { surahId: String(Number(surahId) - 1), ayahId: surahList[currentSurahIndex - 1].verses }
+        : null;
+
+  const next =
+    currentAyahNum < surahList[currentSurahIndex].verses
+      ? { surahId, ayahId: currentAyahNum + 1 }
+      : currentSurahIndex < totalSurahs - 1
+        ? { surahId: String(Number(surahId) + 1), ayahId: 1 }
+        : null;
+
+  const navigate = useCallback(
+    (target: { surahId: string; ayahId: number } | null) => {
+      if (!target) return;
+      setSurahListOpen(false);
+      router.push(`/tafsir/${target.surahId}/${target.ayahId}`);
+    },
+    [router, setSurahListOpen]
+  );
+
+  const currentSurah = useMemo(
+    () => surahList.find((s) => s.number === Number(surahId)),
+    [surahList, surahId]
+  );
+
+  return { prev, next, navigate, currentSurah };
+};

--- a/app/(features)/tafsir/hooks/useWordTranslations.ts
+++ b/app/(features)/tafsir/hooks/useWordTranslations.ts
@@ -1,0 +1,61 @@
+import { useMemo, useCallback } from 'react';
+import useSWR from 'swr';
+import { useTranslation } from 'react-i18next';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { getWordTranslations } from '@/lib/api';
+import { WORD_LANGUAGE_LABELS } from '@/lib/text/wordLanguages';
+import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
+import type { LanguageCode } from '@/lib/text/languageCodes';
+
+const DEFAULT_WORD_TRANSLATION_ID = 85;
+
+export const useWordTranslations = () => {
+  const { t } = useTranslation();
+  const { settings, setSettings } = useSettings();
+
+  const { data } = useSWR('wordTranslations', getWordTranslations);
+
+  const wordLanguageMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    (data || []).forEach((o) => {
+      const name = o.language_name.toLowerCase();
+      if (!map[name]) {
+        map[name] = o.id;
+      }
+    });
+    return map;
+  }, [data]);
+
+  const wordLanguageOptions = useMemo(
+    () =>
+      Object.keys(wordLanguageMap)
+        .filter((name) => WORD_LANGUAGE_LABELS[name])
+        .map((name) => ({ name: WORD_LANGUAGE_LABELS[name], id: wordLanguageMap[name] })),
+    [wordLanguageMap]
+  );
+
+  const selectedWordLanguageName = useMemo(
+    () =>
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
+    [wordLanguageOptions, settings.wordLang, t]
+  );
+
+  const resetWordSettings = useCallback(() => {
+    setSettings({
+      ...settings,
+      wordLang: 'en',
+      wordTranslationId: wordLanguageMap['english'] ?? DEFAULT_WORD_TRANSLATION_ID,
+    });
+  }, [settings, setSettings, wordLanguageMap]);
+
+  return {
+    wordLanguageOptions,
+    wordLanguageMap,
+    selectedWordLanguageName,
+    resetWordSettings,
+  };
+};


### PR DESCRIPTION
## Summary
- extract translation options logic into `useTranslationOptions`
- extract tafsir options logic into `useTafsirOptions`
- extract word translation logic into `useWordTranslations`
- move verse navigation into `useVerseNavigation`
- simplify `useTafsirVerseData` to compose new hooks

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint` (fails: prettier formatting issues in unrelated files)
- `npm run check` (fails: existing type errors in unrelated modules)


------
https://chatgpt.com/codex/tasks/task_b_689c577740c8832f99a028fec90cc931