### PR TITLE
Refactor sidebar scroll behavior into reusable hooks

### DIFF
--- a/app/shared/surah-sidebar/useSidebarScroll.ts
+++ b/app/shared/surah-sidebar/useSidebarScroll.ts
@@ -1,5 +1,7 @@
-import { useRef, useLayoutEffect, useEffect } from 'react';
+import { useRef } from 'react';
 import { useSidebar } from '@/app/providers/SidebarContext';
+import useScrollPersistence from '@/lib/hooks/useScrollPersistence';
+import useScrollCentering from '@/lib/hooks/useScrollCentering';
 
 type TabKey = 'Surah' | 'Juz' | 'Page';
 
@@ -26,112 +28,53 @@ const useSidebarScroll = ({
     setPageScrollTop,
   } = useSidebar();
 
-  const shouldCenterRef = useRef<Record<TabKey, boolean>>({
-    Surah: true,
-    Juz: true,
-    Page: true,
+  const {
+    handleScroll,
+    prepareForTabSwitch: persistencePrepare,
+    rememberScroll: persistRememberScroll,
+  } = useScrollPersistence<TabKey>({
+    scrollRef,
+    activeTab,
+    scrollTops: {
+      Surah: surahScrollTop,
+      Juz: juzScrollTop,
+      Page: pageScrollTop,
+    },
+    setScrollTops: {
+      Surah: setSurahScrollTop,
+      Juz: setJuzScrollTop,
+      Page: setPageScrollTop,
+    },
+    storageKeys: {
+      Surah: 'surahScrollTop',
+      Juz: 'juzScrollTop',
+      Page: 'pageScrollTop',
+    },
   });
 
-  useLayoutEffect(() => {
-    const surahSkipped = sessionStorage.getItem('skipCenterSurah') === '1';
-    const juzSkipped = sessionStorage.getItem('skipCenterJuz') === '1';
-    const pageSkipped = sessionStorage.getItem('skipCenterPage') === '1';
-    if (surahSkipped) {
-      shouldCenterRef.current.Surah = false;
-      sessionStorage.removeItem('skipCenterSurah');
-    }
-    if (juzSkipped) {
-      shouldCenterRef.current.Juz = false;
-      sessionStorage.removeItem('skipCenterJuz');
-    }
-    if (pageSkipped) {
-      shouldCenterRef.current.Page = false;
-      sessionStorage.removeItem('skipCenterPage');
-    }
-  }, []);
-
-  useEffect(() => {
-    if (activeTab !== 'Surah') shouldCenterRef.current.Surah = true;
-  }, [selectedSurahId, activeTab]);
-  useEffect(() => {
-    if (activeTab !== 'Juz') shouldCenterRef.current.Juz = true;
-  }, [selectedJuzId, activeTab]);
-  useEffect(() => {
-    if (activeTab !== 'Page') shouldCenterRef.current.Page = true;
-  }, [selectedPageId, activeTab]);
-
-  useLayoutEffect(() => {
-    const sidebar = scrollRef.current;
-    if (!sidebar) return;
-
-    let top = 0;
-    if (activeTab === 'Surah') {
-      top = Number(sessionStorage.getItem('surahScrollTop')) || surahScrollTop;
-    } else if (activeTab === 'Juz') {
-      top = Number(sessionStorage.getItem('juzScrollTop')) || juzScrollTop;
-    } else {
-      top = Number(sessionStorage.getItem('pageScrollTop')) || pageScrollTop;
-    }
-    sidebar.scrollTop = top;
-
-    const activeEl = sidebar.querySelector<HTMLElement>('[data-active="true"]');
-    if (activeEl) {
-      const sidebarRect = sidebar.getBoundingClientRect();
-      const activeRect = activeEl.getBoundingClientRect();
-      const isOutside = activeRect.top < sidebarRect.top || activeRect.bottom > sidebarRect.bottom;
-
-      if (shouldCenterRef.current[activeTab] && (top === 0 || isOutside)) {
-        activeEl.scrollIntoView({ block: 'center' });
-      }
-    }
-    shouldCenterRef.current[activeTab] = false;
-  }, [
+  const { skipNextCentering, prepareForTabSwitch: centeringPrepare } = useScrollCentering<TabKey>({
+    scrollRef,
     activeTab,
-    surahScrollTop,
-    juzScrollTop,
-    pageScrollTop,
-    selectedSurahId,
-    selectedJuzId,
-    selectedPageId,
-  ]);
+    selectedIds: {
+      Surah: selectedSurahId,
+      Juz: selectedJuzId,
+      Page: selectedPageId,
+    },
+    scrollTops: {
+      Surah: surahScrollTop,
+      Juz: juzScrollTop,
+      Page: pageScrollTop,
+    },
+  });
 
-  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    const top = e.currentTarget.scrollTop;
-    if (activeTab === 'Surah') {
-      setSurahScrollTop(top);
-      sessionStorage.setItem('surahScrollTop', String(top));
-    } else if (activeTab === 'Juz') {
-      setJuzScrollTop(top);
-      sessionStorage.setItem('juzScrollTop', String(top));
-    } else {
-      setPageScrollTop(top);
-      sessionStorage.setItem('pageScrollTop', String(top));
-    }
+  const rememberScroll = (tab: TabKey) => {
+    persistRememberScroll(tab);
+    skipNextCentering(tab);
   };
 
   const prepareForTabSwitch = (nextTab: TabKey) => {
-    const top = scrollRef.current?.scrollTop ?? 0;
-    if (activeTab === 'Surah') setSurahScrollTop(top);
-    else if (activeTab === 'Juz') setJuzScrollTop(top);
-    else setPageScrollTop(top);
-    shouldCenterRef.current[nextTab] = true;
-  };
-
-  const rememberScroll = (tab: TabKey) => {
-    const top = scrollRef.current?.scrollTop ?? 0;
-    if (tab === 'Surah') {
-      setSurahScrollTop(top);
-      sessionStorage.setItem('surahScrollTop', String(top));
-      sessionStorage.setItem('skipCenterSurah', '1');
-    } else if (tab === 'Juz') {
-      setJuzScrollTop(top);
-      sessionStorage.setItem('juzScrollTop', String(top));
-      sessionStorage.setItem('skipCenterJuz', '1');
-    } else {
-      setPageScrollTop(top);
-      sessionStorage.setItem('pageScrollTop', String(top));
-      sessionStorage.setItem('skipCenterPage', '1');
-    }
+    persistencePrepare();
+    centeringPrepare(nextTab);
   };
 
   return { scrollRef, handleScroll, prepareForTabSwitch, rememberScroll };

--- a/lib/hooks/__tests__/useScrollCentering.test.ts
+++ b/lib/hooks/__tests__/useScrollCentering.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import useScrollCentering from '@/lib/hooks/useScrollCentering';
+
+type Tab = 'Surah' | 'Juz' | 'Page';
+
+const makeRect = (top: number, bottom: number): DOMRect => ({
+  top,
+  bottom,
+  left: 0,
+  right: 0,
+  width: 0,
+  height: bottom - top,
+  x: 0,
+  y: top,
+  toJSON: () => ({}),
+});
+
+describe('useScrollCentering', () => {
+  const scrollRef = { current: document.createElement('div') } as React.RefObject<HTMLDivElement>;
+
+  beforeEach(() => {
+    scrollRef.current!.innerHTML = '';
+    sessionStorage.clear();
+  });
+
+  const setup = () => {
+    const activeEl = document.createElement('div');
+    activeEl.dataset.active = 'true';
+    activeEl.scrollIntoView = jest.fn();
+    scrollRef.current!.appendChild(activeEl);
+    jest.spyOn(scrollRef.current!, 'getBoundingClientRect').mockReturnValue(makeRect(0, 100));
+    jest.spyOn(activeEl, 'getBoundingClientRect').mockReturnValue(makeRect(200, 250));
+    return activeEl;
+  };
+
+  it('centers active element when outside view', () => {
+    const activeEl = setup();
+    renderHook(() =>
+      useScrollCentering<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        selectedIds: { Surah: '1', Juz: null, Page: null },
+        scrollTops: { Surah: 0, Juz: 0, Page: 0 },
+      })
+    );
+    expect(activeEl.scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+  });
+
+  it('skips centering when flag is set', () => {
+    sessionStorage.setItem('skipCenterSurah', '1');
+    const activeEl = setup();
+    renderHook(() =>
+      useScrollCentering<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        selectedIds: { Surah: '1', Juz: null, Page: null },
+        scrollTops: { Surah: 0, Juz: 0, Page: 0 },
+      })
+    );
+    expect(activeEl.scrollIntoView).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('skipCenterSurah')).toBeNull();
+  });
+
+  it('exposes skipNextCentering', () => {
+    const { result } = renderHook(() =>
+      useScrollCentering<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        selectedIds: { Surah: '1', Juz: null, Page: null },
+        scrollTops: { Surah: 0, Juz: 0, Page: 0 },
+      })
+    );
+    result.current.skipNextCentering('Surah');
+    expect(sessionStorage.getItem('skipCenterSurah')).toBe('1');
+  });
+});

--- a/lib/hooks/__tests__/useScrollPersistence.test.ts
+++ b/lib/hooks/__tests__/useScrollPersistence.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react';
+import useScrollPersistence from '@/lib/hooks/useScrollPersistence';
+
+type Tab = 'Surah' | 'Juz' | 'Page';
+
+describe('useScrollPersistence', () => {
+  const scrollRef = { current: document.createElement('div') } as React.RefObject<HTMLDivElement>;
+  const scrollTops: Record<Tab, number> = { Surah: 0, Juz: 0, Page: 0 };
+  const setScrollTops: Record<Tab, jest.Mock> = {
+    Surah: jest.fn((top: number) => {
+      scrollTops.Surah = top;
+    }),
+    Juz: jest.fn((top: number) => {
+      scrollTops.Juz = top;
+    }),
+    Page: jest.fn((top: number) => {
+      scrollTops.Page = top;
+    }),
+  };
+  const storageKeys: Record<Tab, string> = {
+    Surah: 'surahScrollTop',
+    Juz: 'juzScrollTop',
+    Page: 'pageScrollTop',
+  };
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    Object.values(setScrollTops).forEach((fn) => fn.mockClear());
+    scrollTops.Surah = 0;
+    scrollTops.Juz = 0;
+    scrollTops.Page = 0;
+  });
+
+  it('restores scroll position from sessionStorage', () => {
+    sessionStorage.setItem('surahScrollTop', '30');
+    renderHook(() =>
+      useScrollPersistence<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        scrollTops,
+        setScrollTops,
+        storageKeys,
+      })
+    );
+    expect(scrollRef.current?.scrollTop).toBe(30);
+  });
+
+  it('stores scroll on scroll event', () => {
+    const { result } = renderHook(() =>
+      useScrollPersistence<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        scrollTops,
+        setScrollTops,
+        storageKeys,
+      })
+    );
+
+    act(() => {
+      result.current.handleScroll({
+        currentTarget: { scrollTop: 42 },
+      } as React.UIEvent<HTMLDivElement>);
+    });
+    expect(setScrollTops.Surah).toHaveBeenCalledWith(42);
+    expect(sessionStorage.getItem('surahScrollTop')).toBe('42');
+  });
+
+  it('prepares for tab switch', () => {
+    const { result } = renderHook(() =>
+      useScrollPersistence<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        scrollTops,
+        setScrollTops,
+        storageKeys,
+      })
+    );
+    act(() => {
+      scrollRef.current!.scrollTop = 15;
+      result.current.prepareForTabSwitch();
+    });
+    expect(setScrollTops.Surah).toHaveBeenCalledWith(15);
+  });
+
+  it('remembers scroll for a tab', () => {
+    const { result } = renderHook(() =>
+      useScrollPersistence<Tab>({
+        scrollRef,
+        activeTab: 'Surah',
+        scrollTops,
+        setScrollTops,
+        storageKeys,
+      })
+    );
+    act(() => {
+      scrollRef.current!.scrollTop = 25;
+      result.current.rememberScroll('Page');
+    });
+    expect(setScrollTops.Page).toHaveBeenCalledWith(25);
+    expect(sessionStorage.getItem('pageScrollTop')).toBe('25');
+  });
+});

--- a/lib/hooks/useScrollCentering.ts
+++ b/lib/hooks/useScrollCentering.ts
@@ -1,0 +1,78 @@
+import { RefObject, useEffect, useLayoutEffect, useRef } from 'react';
+
+interface ScrollCenteringOptions<T extends string> {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  activeTab: T;
+  selectedIds: Record<T, string | null>;
+  scrollTops: Record<T, number>;
+}
+
+interface ScrollCenteringResult<T extends string> {
+  skipNextCentering: (tab: T) => void;
+  prepareForTabSwitch: (nextTab: T) => void;
+}
+
+const useScrollCentering = <T extends string>({
+  scrollRef,
+  activeTab,
+  selectedIds,
+  scrollTops,
+}: ScrollCenteringOptions<T>): ScrollCenteringResult<T> => {
+  const tabs = Object.keys(selectedIds) as T[];
+  const shouldCenterRef = useRef<Record<T, boolean>>(
+    tabs.reduce((acc, t) => ({ ...acc, [t]: true }), {} as Record<T, boolean>)
+  );
+
+  useLayoutEffect(() => {
+    tabs.forEach((tab) => {
+      if (sessionStorage.getItem(`skipCenter${tab}`) === '1') {
+        shouldCenterRef.current[tab] = false;
+        sessionStorage.removeItem(`skipCenter${tab}`);
+      }
+    });
+  }, [tabs]);
+
+  const prevIds = useRef<Record<T, string | null>>(
+    tabs.reduce((acc, t) => ({ ...acc, [t]: selectedIds[t] }), {} as Record<T, string | null>)
+  );
+
+  useEffect(() => {
+    tabs.forEach((tab) => {
+      const currentId = selectedIds[tab];
+      if (prevIds.current[tab] !== currentId) {
+        if (activeTab !== tab) {
+          shouldCenterRef.current[tab] = true;
+        }
+        prevIds.current[tab] = currentId;
+      }
+    });
+  }, [activeTab, selectedIds, tabs]);
+
+  useLayoutEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const activeEl = container.querySelector<HTMLElement>('[data-active="true"]');
+    if (activeEl) {
+      const containerRect = container.getBoundingClientRect();
+      const activeRect = activeEl.getBoundingClientRect();
+      const isOutside =
+        activeRect.top < containerRect.top || activeRect.bottom > containerRect.bottom;
+      if (shouldCenterRef.current[activeTab] && (scrollTops[activeTab] === 0 || isOutside)) {
+        activeEl.scrollIntoView({ block: 'center' });
+      }
+    }
+    shouldCenterRef.current[activeTab] = false;
+  }, [activeTab, scrollRef, scrollTops, selectedIds]);
+
+  const skipNextCentering = (tab: T): void => {
+    sessionStorage.setItem(`skipCenter${tab}`, '1');
+  };
+
+  const prepareForTabSwitch = (nextTab: T): void => {
+    shouldCenterRef.current[nextTab] = true;
+  };
+
+  return { skipNextCentering, prepareForTabSwitch };
+};
+
+export default useScrollCentering;

--- a/lib/hooks/useScrollPersistence.ts
+++ b/lib/hooks/useScrollPersistence.ts
@@ -1,0 +1,52 @@
+import { RefObject, useLayoutEffect } from 'react';
+
+interface ScrollPersistenceOptions<T extends string> {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  activeTab: T;
+  scrollTops: Record<T, number>;
+  setScrollTops: Record<T, (top: number) => void>;
+  storageKeys: Record<T, string>;
+}
+
+interface ScrollPersistenceResult<T extends string> {
+  handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
+  prepareForTabSwitch: () => void;
+  rememberScroll: (tab: T) => void;
+}
+
+const useScrollPersistence = <T extends string>({
+  scrollRef,
+  activeTab,
+  scrollTops,
+  setScrollTops,
+  storageKeys,
+}: ScrollPersistenceOptions<T>): ScrollPersistenceResult<T> => {
+  useLayoutEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const storageKey = storageKeys[activeTab];
+    const top = Number(sessionStorage.getItem(storageKey)) || scrollTops[activeTab];
+    container.scrollTop = top;
+  }, [activeTab, scrollRef, scrollTops, storageKeys]);
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>): void => {
+    const top = e.currentTarget.scrollTop;
+    setScrollTops[activeTab](top);
+    sessionStorage.setItem(storageKeys[activeTab], String(top));
+  };
+
+  const prepareForTabSwitch = (): void => {
+    const top = scrollRef.current?.scrollTop ?? 0;
+    setScrollTops[activeTab](top);
+  };
+
+  const rememberScroll = (tab: T): void => {
+    const top = scrollRef.current?.scrollTop ?? 0;
+    setScrollTops[tab](top);
+    sessionStorage.setItem(storageKeys[tab], String(top));
+  };
+
+  return { handleScroll, prepareForTabSwitch, rememberScroll };
+};
+
+export default useScrollPersistence;


### PR DESCRIPTION
## Summary
- factor out scroll position storage into `useScrollPersistence`
- add `useScrollCentering` for centering active sidebar items
- compose both hooks in `surah-sidebar` wrapper and add unit tests

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: prettier errors in existing files)*
- `npm test` *(fails: missing module './SvgIcons')*
- `npx jest lib/hooks/__tests__/useScrollPersistence.test.ts lib/hooks/__tests__/useScrollCentering.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_689c57806b5c832fa22af16014ebd376