### PR TITLE
Move Juz interface to dedicated file

### DIFF
--- a/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
+++ b/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
@@ -5,7 +5,7 @@ import type { Verse as VerseType } from '@/types';
 
 interface JuzVerseListProps {
   verses: VerseType[];
-  loadMoreRef: React.RefObject<HTMLDivElement>;
+  loadMoreRef: React.RefObject<HTMLDivElement | null>;
   isValidating: boolean;
   isReachingEnd: boolean;
 }

--- a/app/(features)/juz/hooks/useJuzData.ts
+++ b/app/(features)/juz/hooks/useJuzData.ts
@@ -6,17 +6,19 @@ import useVerseListing from '@/app/(features)/surah/hooks/useVerseListing';
 export function useJuzData(juzId?: string) {
   const verseListing = useVerseListing({ id: juzId, lookup: getVersesByJuz });
 
-  const { data: juz, error: juzError } = useSWR<Juz>(juzId ? ['juz', juzId] : null, ([, id]) =>
-    getJuz(id)
+  const { data: juz, error: juzError } = useSWR<Juz>(
+    juzId ? ['juz', juzId] : null,
+    ([, id]: [string, string]) => getJuz(id)
   );
 
-  const isLoading = verseListing.isLoading || (!juz && !juzError);
+  const { isLoading: versesLoading, ...rest } = verseListing;
+  const isLoading = versesLoading || (!juz && !juzError);
 
   return {
     juz,
     juzError,
     isLoading,
-    ...verseListing,
+    ...rest,
   } as const;
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,14 +5,6 @@ export * from './tafsir';
 export * from './settings';
 export * from './surah';
 export * from './word';
+export * from './juz';
 
 export type { TafsirResource } from '../lib/api';
-
-export interface Juz {
-  id: number;
-  juz_number: number;
-  verse_mapping: Record<string, string>;
-  first_verse_id: number;
-  last_verse_id: number;
-  verses_count: number;
-}

--- a/types/juz.ts
+++ b/types/juz.ts
@@ -1,0 +1,11 @@
+/**
+ * Represents metadata for a Juz, one of thirty parts of the Quran.
+ */
+export interface Juz {
+  id: number;
+  juz_number: number;
+  verse_mapping: Record<string, string>;
+  first_verse_id: number;
+  last_verse_id: number;
+  verses_count: number;
+}


### PR DESCRIPTION
## Summary
- extract Juz interface into its own types/juz.ts with documentation
- re-export Juz from types index
- tidy Juz data hook and verse list types to satisfy TS checks

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c60e563b4832fb44dc22d15c83da2