### PR TITLE
Document exported interfaces in types directory

### DIFF
--- a/types/chapter.ts
+++ b/types/chapter.ts
@@ -1,3 +1,6 @@
+/**
+ * Metadata for a chapter (surah) of the Quran.
+ */
 export interface Chapter {
   id: number;
   name_simple: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,6 +8,9 @@ export * from './word';
 
 export type { TafsirResource } from '../lib/api';
 
+/**
+ * Mapping and metadata for a Juz (section) of the Quran.
+ */
 export interface Juz {
   id: number;
   juz_number: number;

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,3 +1,6 @@
+/**
+ * User preferences controlling fonts, translations and reading options.
+ */
 export interface Settings {
   translationId: number;
   tafsirIds: number[];

--- a/types/surah.ts
+++ b/types/surah.ts
@@ -1,3 +1,6 @@
+/**
+ * Summary information about a Surah of the Quran.
+ */
 export interface Surah {
   number: number;
   name: string;

--- a/types/tafsir.ts
+++ b/types/tafsir.ts
@@ -1,3 +1,6 @@
+/**
+ * Information about a tafsir resource available to the app.
+ */
 export interface TafsirResource {
   id: number;
   name: string;

--- a/types/translation.ts
+++ b/types/translation.ts
@@ -1,3 +1,6 @@
+/**
+ * Information about a translation resource available to the app.
+ */
 export interface TranslationResource {
   id: number;
   name: string;

--- a/types/verse.ts
+++ b/types/verse.ts
@@ -1,15 +1,24 @@
+/**
+ * Text of a verse translated by a specific resource.
+ */
 export interface Translation {
   id?: number;
   resource_id: number;
   text: string;
 }
 
+/**
+ * Audio recitation for a verse.
+ */
 export interface Audio {
   url: string;
 }
 
 import type { Word } from './word';
 
+/**
+ * A Quranic verse with optional translations, audio, and word data.
+ */
 export interface Verse {
   id: number;
   verse_key: string;

--- a/types/word.ts
+++ b/types/word.ts
@@ -1,5 +1,8 @@
 import type { LanguageCode } from '@/lib/text/languageCodes';
 
+/**
+ * A Quranic word with optionally localized text in multiple languages.
+ */
 export interface Word extends Partial<Record<Exclude<LanguageCode, 'id'>, string>> {
   id: number;
   uthmani: string;


### PR DESCRIPTION
## Summary
- document exported interfaces across `types` with TSDoc comments

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: TS errors in juz-related files)*

------
https://chatgpt.com/codex/tasks/task_b_689c60f37b30832fb97aac94c60f81f3