### PR TITLE
Document bookmark and translation providers

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -10,12 +10,13 @@
 
 - Feature tests reside in a `__tests__/` folder inside the feature directory.
 - Name test files in PascalCase with a `.test.tsx` suffix.
-- Wrap tested components or pages with all required providers (e.g., `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, `AudioProvider`) from `app/providers` or feature contexts.
+- Wrap tested components or pages with all required providers (e.g., `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, `BookmarkProvider`) from `app/providers` or feature contexts.
 
 ## Providers
 
-- Runtime pages receive `ThemeProvider`, `SettingsProvider`, and `SidebarProvider` via `ClientProviders` in the root layout.
+- Runtime pages receive `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, and `BookmarkProvider` via `ClientProviders` in the root layout.
 - Features needing additional context must import and apply the relevant provider in their layout or tests.
+- Audio context is scoped to the player feature; use its `AudioProvider` only within `app/(features)/player` layouts or tests.
 - Avoid creating new global contexts inside feature folders; reuse providers from `app/providers` or existing feature contexts.
 
 ## Naming & Structure

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ This document explains the main folders in the repository and how pages use the 
 
 ## Feature Pages and Contexts
 
-Pages inside `app/(features)/` define user-facing routes. Many of these routes wrap their content with providers from `app/providers` such as `AudioProvider` or `SettingsProvider`. The root `app/layout.tsx` applies `ThemeProvider`, `SettingsProvider` and `SidebarProvider` so any component can access theme, settings and sidebar state via the corresponding hooks.
+Pages inside `app/(features)/` define user-facing routes. Many of these routes wrap their content with providers from `app/providers` such as `BookmarkProvider`, `TranslationProvider`, or `SettingsProvider`. Audio-related context lives under `app/(features)/player` rather than in `app/providers`. The root `app/layout.tsx` applies `TranslationProvider` and `ClientProviders` (which sets up `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, and `BookmarkProvider`) so any component can access translation, theme, settings, sidebar, and bookmark state via the corresponding hooks.
 
 Feature components typically reside in a `components` subfolder. They import hooks like `useSettings`, `useAudio` or `useSidebar` to read and update context values.
 


### PR DESCRIPTION
## Summary
- clarify app guidelines to mention BookmarkProvider and scope audio context to player feature
- include BookmarkProvider and TranslationProvider in architecture docs and note player context location

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: TypeScript errors in juz feature)*

------
https://chatgpt.com/codex/tasks/task_b_689c6246e858832f9156d0746788b7f2