### PR TITLE
Clarify shared module placement

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -3,6 +3,7 @@
 ## Feature Folders
 
 - All user-facing routes live under `app/(features)/*`. Each folder represents a feature and should be named in lowercase.
+- Place non-routing, reusable modules (e.g., the player) in `app/shared` or another shared directory; reserve `app/(features)` strictly for routed features.
 - Every feature folder must include a `page.tsx` entry file and may include a `layout.tsx`. Use `[param]` syntax for dynamic segments.
 - Place feature-specific components in a `components/` subfolder.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document explains the main folders in the repository and how pages use the 
 
 ## Directory Purpose
 
-- **`app/`** – Next.js app directory with route segments, shared components and context providers. Feature pages live under `app/(features)/*`.
+- **`app/`** – Next.js app directory with route segments, shared components and context providers. Feature pages live under `app/(features)/*`, while reusable modules without routes (e.g., the player) belong in `app/shared` or another shared directory.
 - **`lib/`** – Utility modules and API helpers.
 - **`types/`** – TypeScript type definitions shared across the project.
 - **`scripts/`** – Stand-alone Node.js scripts such as `fetchData.ts` used for data preparation.


### PR DESCRIPTION
## Summary
- direct reusable, non-route modules (e.g., player) to `app/shared`
- emphasize that `app/(features)` is reserved solely for routed features

## Testing
- `npm install`
- `npm audit --omit=dev`
- `npm run format`
- `npm run lint` *(warning: next/no-img-element in TrackInfo.tsx)*
- `npm run check` *(fails: type errors in juz feature)*

------
https://chatgpt.com/codex/tasks/task_b_689c6261e070832fb724c4e398c13643