### PR TITLE
Handle API pagination

### DIFF
--- a/lib/api/__tests__/fetch-verses.test.ts
+++ b/lib/api/__tests__/fetch-verses.test.ts
@@ -16,7 +16,7 @@ describe('fetchVerses', () => {
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ meta: { total_pages: 2 }, verses: [mockVerse] }),
+      json: () => Promise.resolve({ pagination: { total_pages: 2 }, verses: [mockVerse] }),
     }) as jest.Mock;
 
     const result = await fetchVerses('by_chapter', 1, 20, 1, 1, 'en');

--- a/lib/api/__tests__/paginate-verses.test.ts
+++ b/lib/api/__tests__/paginate-verses.test.ts
@@ -17,7 +17,7 @@ describe('getVersesByChapter', () => {
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
+      json: () => Promise.resolve({ pagination: { total_pages: 1 }, verses: [mockVerse] }),
     }) as jest.Mock;
 
     await getVersesByChapter(1, 20, 1, 1, 'tr');
@@ -42,7 +42,7 @@ describe('getVersesByJuz', () => {
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
+      json: () => Promise.resolve({ pagination: { total_pages: 1 }, verses: [mockVerse] }),
     }) as jest.Mock;
 
     await getVersesByJuz(1, 20, 1, 1, 'en');
@@ -67,7 +67,7 @@ describe('getVersesByPage', () => {
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ meta: { total_pages: 1 }, verses: [mockVerse] }),
+      json: () => Promise.resolve({ pagination: { total_pages: 1 }, verses: [mockVerse] }),
     }) as jest.Mock;
 
     await getVersesByPage(1, 20, 1, 1, 'en');

--- a/lib/api/verses.ts
+++ b/lib/api/verses.ts
@@ -41,7 +41,11 @@ export async function fetchVerses(
   wordLang: string = 'en'
 ): Promise<PaginatedVerses> {
   const lang = wordLang as LanguageCode;
-  const data = await apiFetch<{ verses: ApiVerse[]; meta: { total_pages: number } }>(
+  const data = await apiFetch<{
+    verses: ApiVerse[];
+    meta?: { total_pages: number };
+    pagination?: { total_pages: number };
+  }>(
     `verses/${type}/${id}`,
     {
       language: lang,
@@ -55,8 +59,9 @@ export async function fetchVerses(
     },
     'Failed to fetch verses'
   );
+  const totalPages = data.meta?.total_pages ?? data.pagination?.total_pages ?? 1;
   return {
-    totalPages: data.meta.total_pages,
+    totalPages,
     verses: data.verses.map((v) => normalizeVerse(v, lang)),
   };
 }


### PR DESCRIPTION
## Summary
- support `pagination.total_pages` in verse fetcher
- adjust verse API tests for pagination responses

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '../../player/context/AudioContext')*
- `npm run check` *(fails: Cannot find module '@/app/(features)/player/context/AudioContext')*

------
https://chatgpt.com/codex/tasks/task_b_689c6cca6fc0832f8fe5f750c669245f