### PR TITLE
Format app directory guidelines

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,32 +1,27 @@
-App Directory Guidelines
-Feature Folders
-All user-facing routes live under app/(features)/*. Each folder represents a feature and should be named in lowercase.
+# App Directory Guidelines
 
-Place non-routing, reusable modules (e.g., the player) in app/shared or another shared directory; reserve app/(features) strictly for routed features.
+## Feature Folders
 
-A page.tsx entry file is only required for features with a root page (e.g., /surah). For features that only contain dynamic routes (e.g., /surah/[slug]), this file can be omitted. A layout.tsx is optional. Use [param] syntax for dynamic segments.
+- All user-facing routes live under `app/(features)/*`. Each folder represents a feature and should be named in lowercase.
+- Place non-routing, reusable modules (e.g., the player) in `app/shared` or another shared directory; reserve `app/(features)` strictly for routed features.
+- A `page.tsx` entry file is only required for features with a root page (e.g., `/surah`). For features that only contain dynamic routes (e.g., `/surah/[slug]`), this file can be omitted. A `layout.tsx` is optional. Use `[param]` syntax for dynamic segments.
+- Place feature-specific components in a `components/` subfolder.
 
-Place feature-specific components in a components/ subfolder.
+## Tests
 
-Tests
-Feature tests reside in a __tests__/ folder inside the feature directory.
+- Feature tests reside in a `__tests__/` folder inside the feature directory.
+- Name test files in PascalCase with a `.test.tsx` suffix.
+- Wrap tested components or pages with all required providers (e.g., `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, `BookmarkProvider`) from `app/providers` or feature contexts.
 
-Name test files in PascalCase with a .test.tsx suffix.
+## Providers
 
-Wrap tested components or pages with all required providers (e.g., ThemeProvider, SettingsProvider, SidebarProvider, BookmarkProvider) from app/providers or feature contexts.
+- Runtime pages receive `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, and `BookmarkProvider` via `ClientProviders` in the root layout.
+- Features needing additional context must import and apply the relevant provider in their layout or tests.
+- Audio context is scoped to the player feature; use its `AudioProvider` only within `app/(features)/player` layouts or tests.
+- Avoid creating new global contexts inside feature folders; reuse providers from `app/providers` or existing feature contexts.
 
-Providers
-Runtime pages receive ThemeProvider, SettingsProvider, SidebarProvider, and BookmarkProvider via ClientProviders in the root layout.
+## Naming & Structure
 
-Features needing additional context must import and apply the relevant provider in their layout or tests.
-
-Audio context is scoped to the player feature; use its AudioProvider only within app/(features)/player layouts or tests.
-
-Avoid creating new global contexts inside feature folders; reuse providers from app/providers or existing feature contexts.
-
-Naming & Structure
-Keep component files in PascalCase and feature folder names singular and lowercase.
-
-Use default exports only for Next.js page.tsx and layout.tsx files.
-
-Tests should mirror component or page names (e.g., HomePage.test.tsx).
+- Keep component files in PascalCase and feature folder names singular and lowercase.
+- Use default exports only for Next.js `page.tsx` and `layout.tsx` files.
+- Tests should mirror component or page names (e.g., `HomePage.test.tsx`).


### PR DESCRIPTION
## Summary
- style: rewrite app directory guidelines as structured markdown

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: cannot find module '@/app/(features)/player/context/AudioContext')*

------
https://chatgpt.com/codex/tasks/task_b_689c6fb83c18832fadd80db715ca4469