### PR TITLE
docs: require commit prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Security audits run in CI. Optionally run `npm audit --omit=dev` locally to chec
 ## Commit Messages
 
 - Use a short summary in the imperative mood ("Add feature" not "Added" or "Adds").
+- Prefix the summary with a type such as `feat:` or `fix:` (for example, `feat: add audio player`).
 - Keep the first line under 50 characters.
 - Separate the summary from any additional details with a blank line.
 - Commit messages are automatically checked by Husky's `commit-msg` hook using commitlint.


### PR DESCRIPTION
## Summary
- document commit message prefixes and give an example

## Testing
- `npm install`
- `npm run format`
- `npm run check` *(fails: Cannot find module '@/app/(features)/player/context/AudioContext')*

------
https://chatgpt.com/codex/tasks/task_b_689c6fb8563c832f9413f74f89925a46