### PR TITLE
fix: restore tafsir icon on verse page

### DIFF
--- a/app/(features)/juz/__tests__/IndexPage.test.tsx
+++ b/app/(features)/juz/__tests__/IndexPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import JuzIndexPage from '@/app/(features)/juz/page';
 import ClientProviders from '@/app/providers/ClientProviders';
-import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
+import { AudioProvider } from '@/app/shared/player/context/AudioContext';
 
 jest.mock('next/link', () => ({ href, children }: any) => <a href={href}>{children}</a>);
 

--- a/app/(features)/surah/__tests__/IndexPage.test.tsx
+++ b/app/(features)/surah/__tests__/IndexPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import SurahIndexPage from '@/app/(features)/surah/page';
 import ClientProviders from '@/app/providers/ClientProviders';
-import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
+import { AudioProvider } from '@/app/shared/player/context/AudioContext';
 
 jest.mock('next/link', () => ({ href, children }: any) => <a href={href}>{children}</a>);
 

--- a/app/(features)/tafsir/__tests__/IndexPage.test.tsx
+++ b/app/(features)/tafsir/__tests__/IndexPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import TafsirIndexPage from '@/app/(features)/tafsir/page';
 import ClientProviders from '@/app/providers/ClientProviders';
-import { AudioProvider } from '@/app/(features)/player/context/AudioContext';
+import { AudioProvider } from '@/app/shared/player/context/AudioContext';
 
 jest.mock('next/link', () => ({ href, children }: any) => <a href={href}>{children}</a>);
 

--- a/app/shared/VerseActions.tsx
+++ b/app/shared/VerseActions.tsx
@@ -1,5 +1,13 @@
 'use client';
-import { PlayIcon, PauseIcon, BookmarkIcon, BookmarkOutlineIcon, ShareIcon } from './icons';
+import Link from 'next/link';
+import {
+  PlayIcon,
+  PauseIcon,
+  BookmarkIcon,
+  BookmarkOutlineIcon,
+  ShareIcon,
+  BookReaderIcon,
+} from './icons';
 import Spinner from './Spinner';
 
 interface VerseActionsProps {
@@ -51,6 +59,14 @@ const VerseActions = ({
             <PlayIcon size={18} />
           )}
         </button>
+        <Link
+          href={`/tafsir/${verseKey.replace(':', '/')}`}
+          aria-label="View tafsir"
+          title="Tafsir"
+          className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-teal-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+        >
+          <BookReaderIcon size={18} />
+        </Link>
         <button
           aria-label={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
           title="Bookmark"

--- a/app/shared/__tests__/VerseActions.test.tsx
+++ b/app/shared/__tests__/VerseActions.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import VerseActions from '../VerseActions';
+
+const noop = () => {};
+
+test('renders tafsir link', () => {
+  render(
+    <VerseActions
+      verseKey="1:1"
+      isPlaying={false}
+      isLoadingAudio={false}
+      isBookmarked={false}
+      onPlayPause={noop}
+      onBookmark={noop}
+    />
+  );
+  const link = screen.getByRole('link', { name: 'View tafsir' });
+  expect(link).toHaveAttribute('href', '/tafsir/1/1');
+});


### PR DESCRIPTION
## Summary
- add tafsir link icon to verse actions
- test that verse actions render tafsir link
- fix audio context test imports

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689c71f42a1c832fa3b7e89fb7bb756a