### PR TITLE
chore: remove Open Sans line from font license

### DIFF
--- a/public/fonts/LICENSES.md
+++ b/public/fonts/LICENSES.md
@@ -13,8 +13,6 @@ The following fonts are licensed under the SIL Open Font License 1.1:
 - **Noto Nastaliq Urdu.ttf** — Source: [Google Noto Fonts](http://www.google.com/get/noto/)
 
 ```
-Copyright 2020 The Open Sans Project Authors (https://github.com/googlefonts/opensans)
-
 -----------------------------------------------------------
 SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
 -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove extraneous Open Sans attribution and commentary from font licenses

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Cannot find module '@/app/(features)/player/context/AudioContext')*


------
https://chatgpt.com/codex/tasks/task_b_689c726d5d88832fb9a60909eb6ba624