### PR TITLE
feat: add reusable search input component

### DIFF
--- a/app/shared/Header.tsx
+++ b/app/shared/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { SearchSolidIcon, BarsIcon } from './icons';
+import { BarsIcon } from './icons';
+import { SearchInput } from './components/SearchInput';
 import { useTranslation } from 'react-i18next';
 import { useSidebar } from '@/app/providers/SidebarContext';
 import { useState } from 'react';
@@ -22,8 +23,6 @@ const Header = () => {
     }
   };
 
-  // Determine background classes based on the current theme
-  const searchBarBgClass = theme === 'light' ? 'bg-white' : 'bg-gray-800';
   // Use a stable header background based on the current theme
   const headerBgClass = theme === 'light' ? 'bg-white' : 'bg-[var(--background)]';
 
@@ -45,20 +44,13 @@ const Header = () => {
 
       {/* Column 2: Centered Search Bar */}
       <div className="flex justify-center">
-        <div className="relative w-full max-w-lg">
-          <SearchSolidIcon
-            size={18}
-            className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"
-          />
-          <input
-            type="text"
-            placeholder={t('search_placeholder')}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            className={`w-full ${searchBarBgClass} border border-gray-200 dark:border-gray-600 rounded-lg py-2 px-10 focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 text-gray-700 dark:text-gray-200 placeholder-gray-400`}
-          />
-        </div>
+        <SearchInput
+          value={query}
+          onChange={setQuery}
+          placeholder={t('search_placeholder')}
+          onKeyDown={handleKeyDown}
+          className="w-full max-w-lg"
+        />
       </div>
 
       {/* Column 3: Settings Button */}

--- a/app/shared/SurahListSidebar.tsx
+++ b/app/shared/SurahListSidebar.tsx
@@ -13,7 +13,7 @@ import Surah from './surah-sidebar/Surah';
 import Juz from './surah-sidebar/Juz';
 import Page from './surah-sidebar/Page';
 import SidebarTabs from './surah-sidebar/components/SidebarTabs';
-import SidebarSearch from './surah-sidebar/components/SidebarSearch';
+import { SearchInput } from './components/SearchInput';
 import useSelectionSync from './surah-sidebar/hooks/useSelectionSync';
 
 interface JuzSummary {
@@ -118,11 +118,10 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
           />
         </div>
         <div className="p-4 border-b border-[var(--border-color)]">
-          <SidebarSearch
-            searchTerm={searchTerm}
-            setSearchTerm={setSearchTerm}
+          <SearchInput
+            value={searchTerm}
+            onChange={setSearchTerm}
             placeholder={t('search_surah')}
-            theme={theme}
           />
         </div>
         <div ref={scrollRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-y-auto p-2">

--- a/app/shared/components/SearchInput.tsx
+++ b/app/shared/components/SearchInput.tsx
@@ -1,34 +1,43 @@
+'use client';
 import React from 'react';
-import { SearchSolidIcon } from '../../icons';
+import { SearchSolidIcon } from '../icons';
+import { useTheme } from '@/app/providers/ThemeContext';
 
-interface Props {
-  searchTerm: string;
-  setSearchTerm: (term: string) => void;
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
   placeholder: string;
-  theme: string;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  className?: string;
 }
 
-const SidebarSearch = ({ searchTerm, setSearchTerm, placeholder, theme }: Props) => {
+export const SearchInput = ({
+  value,
+  onChange,
+  placeholder,
+  onKeyDown,
+  className = '',
+}: SearchInputProps) => {
+  const { theme } = useTheme();
   const searchBarClasses =
     theme === 'light'
       ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
       : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
 
   return (
-    <div className="relative">
+    <div className={`relative ${className}`}>
       <SearchSolidIcon
-        size={16}
+        size={18}
         className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
       />
       <input
         type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
+        onKeyDown={onKeyDown}
         className={`w-full pl-9 pr-3 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 ${searchBarClasses}`}
       />
     </div>
   );
 };
-
-export default SidebarSearch;


### PR DESCRIPTION
## Summary
- add theme-aware SearchInput component for reuse
- use SearchInput in header and surah list sidebar
- remove obsolete SidebarSearch component

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689c79e39fe8832fb0755924ecdcf33c