### PR TITLE
fix: drop borders and rings from search inputs

### DIFF
--- a/app/(features)/home/components/HomeSearch.tsx
+++ b/app/(features)/home/components/HomeSearch.tsx
@@ -10,11 +10,11 @@ interface HomeSearchProps {
 export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchProps) {
   const { theme } = useTheme();
   const shortcutSurahs = ['Al-Mulk', 'Al-Kahf', 'Ya-Sin', 'Al-Ikhlas'];
-  
+
   const searchBarClasses =
     theme === 'light'
-      ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
+      ? 'bg-white text-gray-700 border-none placeholder-gray-400'
+      : 'bg-gray-800 text-gray-200 border-none placeholder-gray-400';
 
   return (
     <>
@@ -29,7 +29,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
             placeholder="What do you want to read?"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full pl-12 pr-4 py-3 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 text-lg ${searchBarClasses}`}
+            className={`w-full pl-12 pr-4 py-3 rounded-lg focus:outline-none transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses}`}
           />
         </div>
       </div>

--- a/app/shared/HeaderSearch.tsx
+++ b/app/shared/HeaderSearch.tsx
@@ -11,11 +11,11 @@ interface Props {
 
 const HeaderSearch = ({ query, setQuery, placeholder, onKeyDown }: Props) => {
   const { theme } = useTheme();
-  
+
   const searchBarClasses =
     theme === 'light'
-      ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
+      ? 'bg-white text-gray-700 border-none placeholder-gray-400'
+      : 'bg-gray-800 text-gray-200 border-none placeholder-gray-400';
 
   return (
     <div className="relative">
@@ -29,7 +29,7 @@ const HeaderSearch = ({ query, setQuery, placeholder, onKeyDown }: Props) => {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={onKeyDown}
-        className={`w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 ${searchBarClasses}`}
+        className={`w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none transition-all duration-300 hover:shadow-lg ${searchBarClasses}`}
       />
     </div>
   );

--- a/app/shared/components/SearchInput.tsx
+++ b/app/shared/components/SearchInput.tsx
@@ -21,8 +21,8 @@ export const SearchInput = ({
   const { theme } = useTheme();
   const searchBarClasses =
     theme === 'light'
-      ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
+      ? 'bg-white text-gray-700 border-none placeholder-gray-400'
+      : 'bg-gray-800 text-gray-200 border-none placeholder-gray-400';
 
   return (
     <div className={`relative ${className}`}>
@@ -36,7 +36,7 @@ export const SearchInput = ({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         onKeyDown={onKeyDown}
-        className={`w-full pl-9 pr-3 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 ${searchBarClasses}`}
+        className={`w-full pl-9 pr-3 py-2 rounded-lg focus:outline-none transition-all duration-300 hover:shadow-lg ${searchBarClasses}`}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- remove borders from search bar variants
- strip focus/hover ring styles from search inputs

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Type '(() => void) | undefined' is not assignable to type '() => void')*

------
https://chatgpt.com/codex/tasks/task_b_689cc9a60638832fad4f35ec5d3c9015