### PR TITLE
fix: remove home search ring and revert shared

### DIFF
--- a/app/(features)/home/components/HomeSearch.tsx
+++ b/app/(features)/home/components/HomeSearch.tsx
@@ -10,11 +10,11 @@ interface HomeSearchProps {
 export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchProps) {
   const { theme } = useTheme();
   const shortcutSurahs = ['Al-Mulk', 'Al-Kahf', 'Ya-Sin', 'Al-Ikhlas'];
-  
+
   const searchBarClasses =
     theme === 'light'
-      ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
+      ? 'bg-white text-gray-700 border-none placeholder-gray-400'
+      : 'bg-gray-800 text-gray-200 border-none placeholder-gray-400';
 
   return (
     <>
@@ -29,7 +29,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
             placeholder="What do you want to read?"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full pl-12 pr-4 py-3 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 text-lg ${searchBarClasses}`}
+            className={`w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses}`}
           />
         </div>
       </div>

--- a/app/(features)/surah/[surahId]/components/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/TafsirPanel.tsx
@@ -51,7 +51,10 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
       </div>
       <div className="p-3 border-b border-gray-200/80">
         <div className="relative">
-          <SearchSolidIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+          <SearchSolidIcon
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400"
+            size={18}
+          />
           <input
             type="text"
             placeholder={t('search')}

--- a/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TranslationIcon, BookReaderIcon, ChevronDownIcon } from '@/app/shared/icons';
+import { TranslationIcon, BookReaderIcon } from '@/app/shared/icons';
 import { CollapsibleSection } from './CollapsibleSection';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { useFontSize } from '../../hooks/useFontSize';
@@ -92,7 +92,7 @@ export const TranslationSettings = ({
             <SelectionBox
               label={t('select_tafsir')}
               value={selectedTafsirName || ''}
-              onClick={onTafsirPanelOpen}
+              onClick={() => onTafsirPanelOpen?.()}
             />
             <div>
               <div className="flex justify-between mb-1 text-sm">

--- a/app/shared/HeaderSearch.tsx
+++ b/app/shared/HeaderSearch.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const HeaderSearch = ({ query, setQuery, placeholder, onKeyDown }: Props) => {
   const { theme } = useTheme();
-  
+
   const searchBarClasses =
     theme === 'light'
       ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'

--- a/app/shared/SelectionBox.tsx
+++ b/app/shared/SelectionBox.tsx
@@ -10,7 +10,7 @@ interface SelectionBoxProps {
 
 const SelectionBox = ({ label, value, onClick }: SelectionBoxProps) => {
   const { theme } = useTheme();
-  
+
   const boxClasses =
     theme === 'light'
       ? 'bg-white border border-gray-200 text-gray-700'
@@ -18,9 +18,7 @@ const SelectionBox = ({ label, value, onClick }: SelectionBoxProps) => {
 
   return (
     <div>
-      <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">
-        {label}
-      </label>
+      <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">{label}</label>
       <button
         onClick={onClick}
         className={`w-full flex justify-between items-center ${boxClasses} rounded-lg p-2.5 text-sm text-left focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600`}


### PR DESCRIPTION
## Summary
- drop default ring and border from home page search bar
- restore shared search inputs so surah pages keep existing styles
- handle optional tafsir panel callback safely

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689cc9a60638832fad4f35ec5d3c9015