### PR TITLE
feat: redesign translation and tafsir panels

### DIFF
--- a/app/(features)/surah/[surahId]/components/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/TafsirPanel.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ArrowLeftIcon, SearchSolidIcon } from '@/app/shared/icons';
+import { ArrowLeftIcon, CloseIcon, SearchSolidIcon } from '@/app/shared/icons';
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { TafsirResource } from '@/types';
@@ -32,13 +32,22 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
     }, {});
   }, [data, searchTerm]);
 
+  const selectedTafsirs = useMemo(
+    () => (data || []).filter((t) => settings.tafsirIds.includes(t.id)),
+    [data, settings.tafsirIds]
+  );
+
+  const sortedLanguages = useMemo(() => Object.keys(grouped).sort(), [grouped]);
+  const languages = ['All', ...sortedLanguages];
+  const [activeLang, setActiveLang] = useState('All');
+
   return (
     <div
       className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
       }`}
     >
-      <div className="flex items-center justify-between p-4 border-b border-gray-200/80 mb-4">
+      <div className="flex items-center justify-between p-4 border-b border-gray-200/80">
         <button
           aria-label="Back"
           onClick={onClose}
@@ -48,6 +57,35 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
         </button>
         <h2 className="font-bold text-lg text-[var(--foreground)]">{t('tafsir_panel_title')}</h2>
         <div className="w-8"></div>
+      </div>
+      <div className="px-4 py-3 border-b border-gray-200/80">
+        <h3 className="text-xs font-semibold text-gray-500 mb-2">{t('my_selections')}</h3>
+        <div className="space-y-2 min-h-[40px] bg-gray-100 dark:bg-gray-800/50 rounded-lg p-2">
+          {selectedTafsirs.length > 0 ? (
+            selectedTafsirs.map((opt) => (
+              <div
+                key={opt.id}
+                className="flex items-center justify-between bg-white dark:bg-gray-700 p-2 rounded-md text-sm text-[var(--foreground)]"
+              >
+                <span className="truncate">{opt.name}</span>
+                <button
+                  onClick={() =>
+                    setSettings({
+                      ...settings,
+                      tafsirIds: settings.tafsirIds.filter((id) => id !== opt.id),
+                    })
+                  }
+                  className="p-1 text-gray-400 hover:text-red-500"
+                  aria-label={t('close')}
+                >
+                  <CloseIcon size={14} />
+                </button>
+              </div>
+            ))
+          ) : (
+            <p className="text-center text-sm text-gray-400">{t('no_tafsirs_selected')}</p>
+          )}
+        </div>
       </div>
       <div className="p-3 border-b border-gray-200/80">
         <div className="relative">
@@ -64,38 +102,76 @@ export const TafsirPanel = ({ isOpen, onClose }: TafsirPanelProps) => {
           />
         </div>
       </div>
-      <div className="flex-grow overflow-y-auto">
-        {Object.keys(grouped).map((lang) => (
-          <div key={lang}>
-            <h3 className="sticky top-0 px-4 py-2 font-bold text-gray-700 text-sm my-4 bg-gray-100 dark:bg-gray-700 dark:text-teal-300">
+      <div className="sticky top-0 z-10 bg-[var(--background)] px-4 pt-2 pb-1 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center space-x-2 overflow-x-auto">
+          {languages.map((lang) => (
+            <button
+              key={lang}
+              onClick={() => setActiveLang(lang)}
+              className={`flex-shrink-0 px-3 py-1.5 text-sm font-semibold border-b-2 transition-colors ${
+                activeLang === lang
+                  ? 'border-teal-600 text-teal-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
               {lang}
-            </h3>
-            <div className="p-2 space-y-1">
-              {grouped[lang].map((opt) => (
-                <label
-                  key={opt.id}
-                  className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    className="form-checkbox h-4 w-4 text-teal-600"
-                    checked={settings.tafsirIds.includes(opt.id)}
-                    onChange={() => {
-                      const exists = settings.tafsirIds.includes(opt.id);
-                      const ids = exists
-                        ? settings.tafsirIds.filter((id) => id !== opt.id)
-                        : settings.tafsirIds.length < 3
-                          ? [...settings.tafsirIds, opt.id]
-                          : settings.tafsirIds;
-                      setSettings({ ...settings, tafsirIds: ids });
-                    }}
-                  />
-                  <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-        ))}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex-grow overflow-y-auto px-4 pb-4">
+        {activeLang === 'All'
+          ? languages.slice(1).map((lang) => (
+              <div key={lang}>
+                <h3 className="text-lg font-bold text-gray-700 dark:text-gray-300 py-2">{lang}</h3>
+                <div className="space-y-1">
+                  {(grouped[lang] || []).map((opt) => (
+                    <label
+                      key={opt.id}
+                      className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        className="form-checkbox h-4 w-4 text-teal-600"
+                        checked={settings.tafsirIds.includes(opt.id)}
+                        onChange={() => {
+                          const exists = settings.tafsirIds.includes(opt.id);
+                          const ids = exists
+                            ? settings.tafsirIds.filter((id) => id !== opt.id)
+                            : settings.tafsirIds.length < 3
+                              ? [...settings.tafsirIds, opt.id]
+                              : settings.tafsirIds;
+                          setSettings({ ...settings, tafsirIds: ids });
+                        }}
+                      />
+                      <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))
+          : (grouped[activeLang] || []).map((opt) => (
+              <label
+                key={opt.id}
+                className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  className="form-checkbox h-4 w-4 text-teal-600"
+                  checked={settings.tafsirIds.includes(opt.id)}
+                  onChange={() => {
+                    const exists = settings.tafsirIds.includes(opt.id);
+                    const ids = exists
+                      ? settings.tafsirIds.filter((id) => id !== opt.id)
+                      : settings.tafsirIds.length < 3
+                        ? [...settings.tafsirIds, opt.id]
+                        : settings.tafsirIds;
+                    setSettings({ ...settings, tafsirIds: ids });
+                  }}
+                />
+                <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
+              </label>
+            ))}
       </div>
     </div>
   );

--- a/app/(features)/surah/[surahId]/components/TranslationPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/TranslationPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ArrowLeftIcon, SearchSolidIcon } from '@/app/shared/icons';
 import { useTranslation } from 'react-i18next';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { TranslationResource } from '@/types';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
@@ -24,6 +24,7 @@ export const TranslationPanel = ({
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
   const { isHidden } = useHeaderVisibility();
+
   const sortedLanguages = useMemo(() => {
     return Object.keys(groupedTranslations).sort((a, b) => {
       const aLower = a.toLowerCase();
@@ -46,6 +47,15 @@ export const TranslationPanel = ({
     });
   }, [groupedTranslations]);
 
+  const allTranslations = useMemo(
+    () => Object.values(groupedTranslations).flat(),
+    [groupedTranslations]
+  );
+  const selectedTranslation = allTranslations.find((t) => t.id === settings.translationId);
+
+  const languages = ['All', ...sortedLanguages];
+  const [activeLang, setActiveLang] = useState('All');
+
   return (
     <>
       {/* Removed the overlay div */}
@@ -67,6 +77,18 @@ export const TranslationPanel = ({
           </h2>
           <div className="w-8"></div>
         </div>
+        <div className="px-4 py-3 border-b border-gray-200/80">
+          <h3 className="text-xs font-semibold text-gray-500 mb-2">{t('my_selections')}</h3>
+          <div className="space-y-2 min-h-[40px] bg-gray-100 dark:bg-gray-800/50 rounded-lg p-2">
+            {selectedTranslation ? (
+              <div className="p-2 bg-white dark:bg-gray-700 rounded-md text-sm text-[var(--foreground)]">
+                {selectedTranslation.name}
+              </div>
+            ) : (
+              <p className="text-center text-sm text-gray-400">{t('no_translations_selected')}</p>
+            )}
+          </div>
+        </div>
         <div className="p-3 border-b border-gray-200/80">
           <div className="relative">
             <SearchSolidIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
@@ -79,35 +101,70 @@ export const TranslationPanel = ({
             />
           </div>
         </div>
-        <div className="flex-grow overflow-y-auto">
-          {groupedTranslations &&
-            sortedLanguages.map((lang) => (
-              <div key={lang}>
-                <h3 className="sticky top-0 px-4 py-2 font-bold text-gray-700 text-sm bg-gray-100 dark:bg-gray-700 dark:text-teal-300">
-                  {lang.charAt(0).toUpperCase() + lang.slice(1)}
-                </h3>
-                <div className="p-2 space-y-1">
-                  {groupedTranslations[lang].map((opt) => (
-                    <label
-                      key={opt.id}
-                      className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
-                    >
-                      <input
-                        type="radio"
-                        name="translation"
-                        className="form-radio h-4 w-4 text-teal-600"
-                        checked={settings.translationId === opt.id}
-                        onChange={() => {
-                          setSettings({ ...settings, translationId: opt.id });
-                          onClose();
-                        }}
-                      />
-                      <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
-                    </label>
-                  ))}
-                </div>
-              </div>
+        <div className="sticky top-0 z-10 bg-[var(--background)] px-4 pt-2 pb-1 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center space-x-2 overflow-x-auto">
+            {languages.map((lang) => (
+              <button
+                key={lang}
+                onClick={() => setActiveLang(lang)}
+                className={`flex-shrink-0 px-3 py-1.5 text-sm font-semibold border-b-2 transition-colors ${
+                  activeLang === lang
+                    ? 'border-teal-600 text-teal-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                {lang}
+              </button>
             ))}
+          </div>
+        </div>
+        <div className="flex-grow overflow-y-auto px-4 pb-4">
+          {activeLang === 'All'
+            ? sortedLanguages.map((lang) => (
+                <div key={lang}>
+                  <h3 className="text-lg font-bold text-gray-700 dark:text-gray-300 py-2">
+                    {lang.charAt(0).toUpperCase() + lang.slice(1)}
+                  </h3>
+                  <div className="space-y-1">
+                    {groupedTranslations[lang].map((opt) => (
+                      <label
+                        key={opt.id}
+                        className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+                      >
+                        <input
+                          type="radio"
+                          name="translation"
+                          className="form-radio h-4 w-4 text-teal-600"
+                          checked={settings.translationId === opt.id}
+                          onChange={() => {
+                            setSettings({ ...settings, translationId: opt.id });
+                            onClose();
+                          }}
+                        />
+                        <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))
+            : (groupedTranslations[activeLang] || []).map((opt) => (
+                <label
+                  key={opt.id}
+                  className="flex items-center space-x-3 p-2 rounded-md hover:bg-teal-50 cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    name="translation"
+                    className="form-radio h-4 w-4 text-teal-600"
+                    checked={settings.translationId === opt.id}
+                    onChange={() => {
+                      setSettings({ ...settings, translationId: opt.id });
+                      onClose();
+                    }}
+                  />
+                  <span className="text-sm text-[var(--foreground)]">{opt.name}</span>
+                </label>
+              ))}
         </div>
       </div>
     </>

--- a/public/locales/bn/common.json
+++ b/public/locales/bn/common.json
@@ -79,5 +79,8 @@
   "repeat_each": "প্রতিটি পুনরাবৃত্তি",
   "delay_seconds": "বিলম্ব (সেকেন্ড)",
   "play_entire_surah_continuously": "সম্পূর্ণ সূরা ধারাবাহিকভাবে চালান।",
-  "search_reciter": "ক্বারি অনুসন্ধান করুন"
+  "search_reciter": "ক্বারি অনুসন্ধান করুন",
+  "my_selections": "আমার নির্বাচনসমূহ",
+  "no_translations_selected": "কোন অনুবাদ নির্বাচন করা হয়নি",
+  "no_tafsirs_selected": "কোন তাফসির নির্বাচন করা হয়নি"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -80,5 +80,8 @@
   "repeat_each": "Repeat each",
   "delay_seconds": "Delay (s)",
   "play_entire_surah_continuously": "Play the entire surah continuously.",
-  "search_reciter": "Search reciter"
+  "search_reciter": "Search reciter",
+  "my_selections": "My selections",
+  "no_translations_selected": "No translations selected",
+  "no_tafsirs_selected": "No tafsir selected"
 }


### PR DESCRIPTION
## Summary
- enhance translation selector with persistent selections, search, and language tabs
- revamp tafsir picker with removable selections and filtered language tabs
- localize new UI strings for English and Bengali

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689d35d3056c832fa0ae356fa32550af