### PR TITLE
test: cover selectable resources hook

### DIFF
--- a/lib/hooks/__tests__/useSelectableResources.test.ts
+++ b/lib/hooks/__tests__/useSelectableResources.test.ts
@@ -11,33 +11,57 @@ const resources: Item[] = [
   { id: 1, name: 'Eng A', lang: 'English' },
   { id: 2, name: 'Eng B', lang: 'English' },
   { id: 3, name: 'Arb A', lang: 'Arabic' },
+  { id: 4, name: 'Arb B', lang: 'Arabic' },
 ];
 
 describe('useSelectableResources', () => {
-  it('handles search and grouping', () => {
+  it('respects selection limits and supports reordering', () => {
     const { result } = renderHook(() =>
       useSelectableResources<Item>({ resources, selectionLimit: 2 })
     );
-    expect(result.current.languages).toEqual(['All', 'Arabic', 'English']);
-    act(() => result.current.setSearchTerm('arb'));
-    expect(result.current.groupedResources['Arabic']).toHaveLength(1);
-    expect(result.current.groupedResources['English']).toBeUndefined();
-  });
 
-  it('enforces selection limit and supports ordering', () => {
-    const { result } = renderHook(() =>
-      useSelectableResources<Item>({ resources, selectionLimit: 2 })
-    );
     act(() => result.current.handleSelectionToggle(1));
     act(() => result.current.handleSelectionToggle(2));
+    expect(result.current.orderedSelection).toEqual([1, 2]);
+
     let added = false;
     act(() => {
       added = result.current.handleSelectionToggle(3);
     });
     expect(added).toBe(false);
     expect(result.current.selectedIds.size).toBe(2);
-    act(() => result.current.handleDragStart({ dataTransfer: { effectAllowed: '' } } as any, 1));
-    act(() => result.current.handleDrop({ preventDefault: () => {} } as any, 2));
-    expect(result.current.orderedSelection).toEqual([2, 1]);
+
+    act(() => result.current.handleSelectionToggle(1));
+    expect(result.current.selectedIds.has(1)).toBe(false);
+
+    act(() => {
+      added = result.current.handleSelectionToggle(3);
+    });
+    expect(added).toBe(true);
+    expect(result.current.orderedSelection).toEqual([2, 3]);
+
+    act(() => result.current.handleDragStart({ dataTransfer: { effectAllowed: '' } } as any, 2));
+    act(() => result.current.handleDrop({ preventDefault: () => {} } as any, 3));
+    expect(result.current.orderedSelection).toEqual([3, 2]);
+  });
+
+  it('filters by search term and active language', () => {
+    const { result } = renderHook(() =>
+      useSelectableResources<Item>({ resources, selectionLimit: 2 })
+    );
+
+    expect(result.current.languages).toEqual(['All', 'Arabic', 'English']);
+
+    act(() => result.current.setSearchTerm('arb'));
+    expect(Object.keys(result.current.groupedResources)).toEqual(['Arabic']);
+
+    act(() => result.current.setSearchTerm(''));
+    act(() => result.current.setActiveFilter('Arabic'));
+    const activeArabic = result.current.groupedResources[result.current.activeFilter];
+    expect(activeArabic?.map((r) => r.id)).toEqual([3, 4]);
+
+    act(() => result.current.setActiveFilter('English'));
+    const activeEnglish = result.current.groupedResources[result.current.activeFilter];
+    expect(activeEnglish?.map((r) => r.id)).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary
- add tests for useSelectableResources to verify selection limits, drag ordering, search, and language filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689ec315c3fc832fac169de86a99d26d