### PR TITLE
refactor: extract settings storage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This downloads the latest surah and juz information into `data/surahs.json` and 
 
 Font files should be placed in `public/fonts/`. Add your `.woff2`, `.woff`, `.otf`, or `.ttf` files there so they are served by Next.js.
 
-To make a font selectable in the application, edit `ARABIC_FONTS` in `app/providers/SettingsContext.tsx` and add a new entry, for example:
+To make a font selectable in the application, edit `ARABIC_FONTS` in `app/providers/settingsStorage.ts` and add a new entry, for example:
 
 ```ts
 { name: "My Font", value: '"My Font", serif', category: "Uthmani" }

--- a/app/providers/__tests__/fonts.test.ts
+++ b/app/providers/__tests__/fonts.test.ts
@@ -1,4 +1,4 @@
-import { ARABIC_FONTS } from '@/app/providers/SettingsContext';
+import { ARABIC_FONTS } from '@/app/providers/settingsStorage';
 
 describe('ARABIC_FONTS', () => {
   it('contains expected font names', () => {

--- a/app/providers/settingsReducer.ts
+++ b/app/providers/settingsReducer.ts
@@ -1,0 +1,35 @@
+import { Settings } from '@/types';
+
+export type Action =
+  | { type: 'SET_SETTINGS'; value: Settings }
+  | { type: 'SET_SHOW_BY_WORDS'; value: boolean }
+  | { type: 'SET_TAJWEED'; value: boolean }
+  | { type: 'SET_WORD_LANG'; value: string }
+  | { type: 'SET_WORD_TRANSLATION_ID'; value: number }
+  | { type: 'SET_TAFSIR_IDS'; value: number[] }
+  | { type: 'SET_TRANSLATION_IDS'; value: number[] };
+
+export const reducer = (state: Settings, action: Action): Settings => {
+  switch (action.type) {
+    case 'SET_SETTINGS':
+      return action.value;
+    case 'SET_SHOW_BY_WORDS':
+      return { ...state, showByWords: action.value };
+    case 'SET_TAJWEED':
+      return { ...state, tajweed: action.value };
+    case 'SET_WORD_LANG':
+      return { ...state, wordLang: action.value };
+    case 'SET_WORD_TRANSLATION_ID':
+      return { ...state, wordTranslationId: action.value };
+    case 'SET_TAFSIR_IDS':
+      return { ...state, tafsirIds: action.value };
+    case 'SET_TRANSLATION_IDS':
+      return {
+        ...state,
+        translationIds: action.value,
+        translationId: action.value.length > 0 ? action.value[0] : state.translationId,
+      };
+    default:
+      return state;
+  }
+};

--- a/app/providers/settingsStorage.ts
+++ b/app/providers/settingsStorage.ts
@@ -1,0 +1,73 @@
+import { Settings } from '@/types';
+
+export const ARABIC_FONTS = [
+  { name: 'KFGQPC Uthman Taha', value: '"KFGQPC-Uthman-Taha", serif', category: 'Uthmani' },
+  { name: 'Amiri', value: '"Amiri", serif', category: 'Uthmani' },
+  { name: 'Scheherazade New', value: '"Scheherazade New", serif', category: 'Uthmani' },
+  { name: 'Noto Naskh Arabic', value: '"Noto Naskh Arabic", serif', category: 'Uthmani' },
+  { name: 'Noto Nastaliq Urdu', value: '"Noto Nastaliq Urdu", serif', category: 'IndoPak' },
+  { name: 'Noor-e-Hira', value: '"Noor-e-Hira", serif', category: 'IndoPak' },
+  { name: 'Lateef', value: '"Lateef", serif', category: 'IndoPak' },
+];
+
+export const defaultSettings: Settings = {
+  translationId: 20,
+  translationIds: [20],
+  tafsirIds: [169],
+  arabicFontSize: 28,
+  translationFontSize: 16,
+  tafsirFontSize: 16,
+  arabicFontFace: ARABIC_FONTS[0].value,
+  wordLang: 'en',
+  wordTranslationId: 85,
+  showByWords: false,
+  tajweed: false,
+};
+
+const SETTINGS_KEY = 'quranAppSettings';
+const SELECTED_TRANSLATIONS_KEY = 'selected-translations';
+
+export const loadSettings = (defaults: Settings = defaultSettings): Settings => {
+  if (typeof window === 'undefined') return defaults;
+
+  const savedSettings = localStorage.getItem(SETTINGS_KEY);
+  const savedTranslations = localStorage.getItem(SELECTED_TRANSLATIONS_KEY);
+  if (!savedSettings) return defaults;
+
+  try {
+    const parsed = JSON.parse(savedSettings);
+
+    if (parsed.tafsirId && !parsed.tafsirIds) {
+      parsed.tafsirIds = [parsed.tafsirId];
+      delete parsed.tafsirId;
+    }
+
+    if (!parsed.translationIds && savedTranslations) {
+      try {
+        const translationIds = JSON.parse(savedTranslations);
+        if (Array.isArray(translationIds) && translationIds.length > 0) {
+          parsed.translationIds = translationIds;
+          parsed.translationId = translationIds[0];
+        }
+      } catch (e) {
+        console.warn('Failed to parse selected-translations:', e);
+      }
+    }
+
+    if (!parsed.translationIds) {
+      parsed.translationIds = parsed.translationId
+        ? [parsed.translationId]
+        : [defaults.translationId];
+    }
+
+    return { ...defaults, ...parsed } as Settings;
+  } catch (error) {
+    console.error('Error parsing settings from localStorage:', error);
+    return defaults;
+  }
+};
+
+export const saveSettings = (settings: Settings) => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+};


### PR DESCRIPTION
## Summary
- centralize settings persistence and defaults in `settingsStorage`
- use a reducer-based `SettingsContext` that relies on `loadSettings`/`saveSettings`
- document new Arabic font configuration location

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689ec31d72c0832f9d82588bba741036