### PR TITLE
fix: add docs for fetch helpers and tafsir list

### DIFF
--- a/app/(features)/bookmarks/components/BookmarkedVersesList.tsx
+++ b/app/(features)/bookmarks/components/BookmarkedVersesList.tsx
@@ -20,6 +20,8 @@ const BookmarkedVersesList = () => {
       return;
     }
 
+    // Fetch full verse data for all bookmarks.
+    // Handles network failures by capturing errors and clearing verses.
     const fetchBookmarkedVerses = async () => {
       try {
         const fetched = await Promise.all(

--- a/app/(features)/home/components/VerseOfDay.tsx
+++ b/app/(features)/home/components/VerseOfDay.tsx
@@ -23,6 +23,8 @@ export default function VerseOfDay() {
 
   const abortRef = useRef(false);
 
+  // Preload a random verse and queue it for display.
+  // Aborts gracefully if the component unmounts mid-fetch.
   const prefetchVerse = useCallback(async () => {
     try {
       const v = await getRandomVerse(settings.translationId);

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -43,6 +43,8 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
     handleReset,
   } = useTafsirPanel(isOpen);
 
+  const resourcesToRender = groupedTafsirs[activeFilter] || [];
+
   return (
     <div
       data-testid="tafsir-panel"
@@ -164,9 +166,8 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
             <div className="px-4 pb-4">
               <div className="mt-4">
                 <ResourceList
-                  activeFilter={activeFilter}
-                  languages={languages}
-                  groupedResources={groupedTafsirs}
+                  resources={resourcesToRender}
+                  rowHeight={60}
                   selectedIds={selectedIds}
                   onToggle={handleSelectionToggle}
                   theme={theme}

--- a/lib/api/chapters.ts
+++ b/lib/api/chapters.ts
@@ -11,6 +11,14 @@ export async function getChapters(): Promise<Chapter[]> {
   return data.chapters as Chapter[];
 }
 
+/**
+ * Fetch the Wikimedia cover image URL for a given surah.
+ *
+ * @param surahNumber 1-based surah index.
+ *
+ * Returns `null` when the surah has no mapped image, the request fails, or
+ * Wikimedia responds without a usable URL.
+ */
 export async function getSurahCoverUrl(surahNumber: number): Promise<string | null> {
   const filename = surahImageMap[surahNumber];
   if (!filename) return null;

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,5 +1,15 @@
 const API_BASE_URL = process.env.QURAN_API_BASE_URL ?? 'https://api.quran.com/api/v4';
 
+/**
+ * Perform a GET request against the Quran.com API.
+ *
+ * @param path       Relative endpoint path.
+ * @param params     Query parameters appended to the request.
+ * @param errorPrefix Message prefix used if the request fails.
+ *
+ * Handles leading/trailing slashes, encodes query params, and throws when the
+ * response is not OK.
+ */
 async function apiFetch<T>(
   path: string,
   params: Record<string, string> = {},

--- a/lib/api/verses.ts
+++ b/lib/api/verses.ts
@@ -14,6 +14,15 @@ interface ApiVerse extends Omit<Verse, 'words'> {
   words?: ApiWord[];
 }
 
+/**
+ * Normalize API verse data into the internal `Verse` shape.
+ *
+ * @param raw       Verse object as returned by the API.
+ * @param wordLang  Key used for word-by-word translations.
+ *
+ * Safely maps optional `words` array, falling back to base text when the
+ * Uthmani script or translations are missing.
+ */
 function normalizeVerse(raw: ApiVerse, wordLang: string = 'en'): Verse {
   return {
     ...raw,
@@ -32,6 +41,19 @@ export interface PaginatedVerses {
   totalPages: number;
 }
 
+/**
+ * Fetch verses grouped by chapter, juz or page and return pagination info.
+ *
+ * @param type            Grouping method for the verses.
+ * @param id              Identifier for the grouping (chapter/juz/page).
+ * @param translationIds  One or more translation IDs.
+ * @param page            Page number (1-indexed).
+ * @param perPage         Number of verses per page.
+ * @param wordLang        Language code for word translations.
+ *
+ * Handles single vs array translation IDs and normalizes API pagination
+ * metadata, defaulting to one page when the server omits totals.
+ */
 export async function fetchVerses(
   type: 'by_chapter' | 'by_juz' | 'by_page',
   id: string | number,
@@ -43,7 +65,7 @@ export async function fetchVerses(
   const lang = wordLang as LanguageCode;
   const translationIdsArray = Array.isArray(translationIds) ? translationIds : [translationIds];
   const translationParam = translationIdsArray.join(',');
-  
+
   const data = await apiFetch<{
     verses: ApiVerse[];
     meta?: { total_pages: number };


### PR DESCRIPTION
## Summary
- document API helpers like `normalizeVerse`, `fetchVerses`, and `apiFetch`
- add comments for verse prefetching and bookmark fetching
- fix tafsir panel resource list props

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689ed1242d68832fa3ae8974ddd3f9e9