### PR TITLE
docs: document API helpers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,35 @@
+# API Helpers
+
+This document lists the main helpers in `lib/api/` and outlines how Quran.com API data flows into the UI.
+
+## HTTP Client
+
+- `apiFetch(path, params, errorPrefix)` – wraps `fetch` against the base URL `https://api.quran.com/api/v4`.
+
+## Functions and Endpoints
+
+| Function                               | Endpoint                                                         | Description                              |
+| -------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------- |
+| `getChapters()`                        | `/chapters?language=en`                                          | Fetch list of chapters.                  |
+| `getSurahCoverUrl(surahNumber)`        | `https://api.wikimedia.org/core/v1/commons/file/File:{filename}` | Fetch Surah cover image from Wikimedia.  |
+| `getTranslations()`                    | `/resources/translations`                                        | List available translations.             |
+| `getWordTranslations()`                | `/resources/translations?resource_type=word_by_word`             | List word-by-word translation resources. |
+| `getVersesByChapter(id, ...)`          | `/verses/by_chapter/:id`                                         | Fetch verses for a chapter.              |
+| `getVersesByJuz(id, ...)`              | `/verses/by_juz/:id`                                             | Fetch verses for a juz.                  |
+| `getVersesByPage(id, ...)`             | `/verses/by_page/:id`                                            | Fetch verses for a page.                 |
+| `searchVerses(query)`                  | `/search`                                                        | Search verses.                           |
+| `getJuz(id)`                           | `/juzs/:id`                                                      | Fetch metadata for a juz.                |
+| `getRandomVerse(translationId)`        | `/verses/random`                                                 | Retrieve a random verse.                 |
+| `getVerseById(id, translationId)`      | `/verses/:id`                                                    | Fetch a single verse by id.              |
+| `getTafsirResources()`                 | `/resources/tafsirs`                                             | List tafsir resources.                   |
+| `getTafsirByVerse(verseKey, tafsirId)` | `/tafsirs/:id/by_ayah/:verseKey`                                 | Retrieve tafsir text for a verse.        |
+
+## Data Flow from API to UI
+
+### Chapters
+
+`SurahListSidebar` uses SWR to load chapters via `getChapters`. The sidebar relies on `SidebarContext` for selection and scroll state and renders Surah, Juz, or page lists from the fetched data.
+
+### Verses
+
+`useVerseListing` accepts a lookup function such as `getVersesByChapter` or `getVersesByJuz` and uses `useSWRInfinite` for paginated loading. It consults `SettingsContext` for translation and word language preferences and `AudioContext` to manage the active verse for playback. Pages like `app/(features)/surah/[surahId]/page.tsx` invoke this hook to render verses in the UI.


### PR DESCRIPTION
## Summary
- document available API helpers and their endpoints
- outline how chapters and verses flow from API through hooks and contexts to the UI

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Type '{ activeFilter: string; languages: string[]; groupedResources: Record<string, Tafsir[]>; selectedIds: Set<number>; onToggle: (id: number) => void; theme: Theme; }' is not assignable to type 'ResourceListProps<Resource>'.)*

------
https://chatgpt.com/codex/tasks/task_b_689ed125a408832fb64b69195488c16a