### PR TITLE
refactor: simplify tafsir panel filter handling

### DIFF
--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -33,15 +33,16 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
     draggedId,
     showLimitWarning,
     activeFilter,
-    handleTabClick,
+    setActiveFilter,
     canScrollLeft,
     canScrollRight,
     scrollTabsLeft,
     scrollTabsRight,
-    stickyHeaderRef,
     tabsContainerRef,
     handleReset,
   } = useTafsirPanel(isOpen);
+
+  const resourcesToRender = activeFilter === 'All' ? tafsirs : groupedTafsirs[activeFilter] || [];
 
   return (
     <div
@@ -138,7 +139,6 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
             </div>
 
             <div
-              ref={stickyHeaderRef}
               className={`sticky top-0 z-10 backdrop-blur-sm pt-2 pb-0 border-b ${
                 theme === 'dark'
                   ? 'bg-slate-900/95 border-slate-700'
@@ -149,7 +149,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
                 <ResourceTabs
                   languages={languages}
                   activeFilter={activeFilter}
-                  onTabClick={handleTabClick}
+                  onTabClick={setActiveFilter}
                   tabsContainerRef={tabsContainerRef}
                   canScrollLeft={canScrollLeft}
                   canScrollRight={canScrollRight}
@@ -164,9 +164,8 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
             <div className="px-4 pb-4">
               <div className="mt-4">
                 <ResourceList
-                  activeFilter={activeFilter}
-                  languages={languages}
-                  groupedResources={groupedTafsirs}
+                  resources={resourcesToRender}
+                  rowHeight={60}
                   selectedIds={selectedIds}
                   onToggle={handleSelectionToggle}
                   theme={theme}

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/useTafsirPanel.ts
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/useTafsirPanel.ts
@@ -18,7 +18,6 @@ export const useTafsirPanel = (isOpen: boolean) => {
   const [error, setError] = useState<string | null>(null);
   const [showLimitWarning, setShowLimitWarning] = useState(false);
 
-  const stickyHeaderRef = useRef<HTMLDivElement>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -117,22 +116,6 @@ export const useTafsirPanel = (isOpen: boolean) => {
     }
   }, [isOpen, tafsirs.length, settings.tafsirIds, setSelections]);
 
-  const handleTabClick = (lang: string) => {
-    setActiveFilter(lang);
-    if (lang === 'All') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    } else {
-      const header = document.querySelector(`.lang-header[data-lang="${lang}"]`);
-      if (header && stickyHeaderRef.current) {
-        const headerTop =
-          header.getBoundingClientRect().top +
-          window.pageYOffset -
-          stickyHeaderRef.current.offsetHeight;
-        window.scrollTo({ top: headerTop, behavior: 'smooth' });
-      }
-    }
-  };
-
   const checkScrollState = useCallback(() => {
     if (tabsContainerRef.current) {
       const { scrollLeft, scrollWidth, clientWidth } = tabsContainerRef.current;
@@ -193,8 +176,7 @@ export const useTafsirPanel = (isOpen: boolean) => {
     draggedId,
     showLimitWarning,
     activeFilter,
-    handleTabClick,
-    stickyHeaderRef,
+    setActiveFilter,
     tabsContainerRef,
     canScrollLeft,
     canScrollRight,


### PR DESCRIPTION
## Summary
- drop sticky header refs and DOM queries in useTafsirPanel
- call setActiveFilter directly from TafsirPanel tabs

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689edd5b66d0832fabe1d068e87e9102