### PR TITLE
feat: calculate resource list height dynamically

### DIFF
--- a/app/shared/resource-panel/ResourceList.tsx
+++ b/app/shared/resource-panel/ResourceList.tsx
@@ -16,7 +16,7 @@ interface ResourceListProps<T extends Resource> {
   selectedIds: Set<number>;
   onToggle: (id: number) => void;
   theme: string;
-  height?: number;
+  height: number;
 }
 
 export const ResourceList = <T extends Resource>({
@@ -25,7 +25,7 @@ export const ResourceList = <T extends Resource>({
   selectedIds,
   onToggle,
   theme,
-  height = 400,
+  height,
 }: ResourceListProps<T>) => {
   const itemCount = resources.length;
 


### PR DESCRIPTION
## Summary
- require explicit height for ResourceList
- dynamically size resource lists in translation and tafsir panels using ResizeObserver fallback

## Testing
- `npm run format`
- `npm run lint -- --file app/shared/resource-panel/ResourceList.tsx --file "app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx" --file "app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx"`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689edd5ec7d0832f812a20821126b3f2