### PR TITLE
fix: ensure resource panel list height

### DIFF
--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -51,7 +51,11 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
     const element = listContainerRef.current;
     if (!element || !isOpen) return;
 
-    const updateHeight = () => setListHeight(element.getBoundingClientRect().height);
+    const updateHeight = () => {
+      const rect = element.getBoundingClientRect();
+      const fallback = window.innerHeight - rect.top;
+      setListHeight(rect.height || fallback);
+    };
 
     updateHeight();
 
@@ -61,7 +65,9 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
     if (ResizeObserverConstructor) {
       const observer = new ResizeObserverConstructor((entries) => {
         for (const entry of entries) {
-          setListHeight(entry.contentRect.height);
+          const rect = entry.target.getBoundingClientRect();
+          const fallback = window.innerHeight - rect.top;
+          setListHeight(entry.contentRect.height || fallback);
         }
       });
       observer.observe(element);

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
@@ -48,7 +48,11 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
     const element = listContainerRef.current;
     if (!element || !isOpen) return;
 
-    const updateHeight = () => setListHeight(element.getBoundingClientRect().height);
+    const updateHeight = () => {
+      const rect = element.getBoundingClientRect();
+      const fallback = window.innerHeight - rect.top;
+      setListHeight(rect.height || fallback);
+    };
 
     updateHeight();
 
@@ -58,7 +62,9 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
     if (ResizeObserverConstructor) {
       const observer = new ResizeObserverConstructor((entries) => {
         for (const entry of entries) {
-          setListHeight(entry.contentRect.height);
+          const rect = entry.target.getBoundingClientRect();
+          const fallback = window.innerHeight - rect.top;
+          setListHeight(entry.contentRect.height || fallback);
         }
       });
       observer.observe(element);


### PR DESCRIPTION
## Summary
- ensure translation and tafsir resource panels calculate list height with viewport fallback

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689f783d285c832f95f420c97f189107