### PR TITLE
fix: display selected tafsir content

### DIFF
--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx
@@ -22,18 +22,18 @@ export const TafsirViewer = ({ verse, tafsirResource, tafsirHtml }: TafsirViewer
       {settings.tafsirIds.length > 1 ? (
         <TafsirTabs verseKey={verse.verse_key} tafsirIds={settings.tafsirIds} />
       ) : (
-        tafsirResource && (
-          <div key={verse.verse_key} className="p-4">
+        <div key={verse.verse_key} className="p-4">
+          {tafsirResource && (
             <h2 className="mb-4 text-center text-xl font-bold text-[var(--foreground)]">
               {tafsirResource.name}
             </h2>
-            <div
-              className="prose max-w-none whitespace-pre-wrap"
-              style={{ fontSize: `${settings.tafsirFontSize}px` }}
-              dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
-            />
-          </div>
-        )
+          )}
+          <div
+            className="prose max-w-none whitespace-pre-wrap"
+            style={{ fontSize: `${settings.tafsirFontSize}px` }}
+            dangerouslySetInnerHTML={{ __html: tafsirHtml || '' }}
+          />
+        </div>
       )}
     </div>
   );

--- a/app/(features)/tafsir/hooks/useTafsirVerseData.ts
+++ b/app/(features)/tafsir/hooks/useTafsirVerseData.ts
@@ -15,6 +15,7 @@ export const useTafsirVerseData = (surahId: string, ayahId: string) => {
   const { wordLanguageOptions, wordLanguageMap, selectedWordLanguageName, resetWordSettings } =
     useWordTranslations();
   const { prev, next, navigate, currentSurah } = useVerseNavigation(surahId, ayahId);
+  const primaryTafsirId = settings.tafsirIds[0];
 
   const { data: verseData } = useSWR(
     surahId && ayahId
@@ -26,7 +27,7 @@ export const useTafsirVerseData = (surahId: string, ayahId: string) => {
   const verse: VerseType | undefined = verseData;
 
   const { data: tafsirHtml } = useSWR(
-    verse && tafsirResource ? ['tafsir', verse.verse_key, tafsirResource.id] : null,
+    verse && primaryTafsirId ? ['tafsir', verse.verse_key, primaryTafsirId] : null,
     ([, key, id]) => getTafsirByVerse(key as string, id as number)
   );
 


### PR DESCRIPTION
## Summary
- load tafsir content using the first selected tafsir id so tafsir pages populate immediately
- render tafsir text even when resource metadata is missing

## Testing
- `npx next lint --file "app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx" --file "app/(features)/tafsir/hooks/useTafsirVerseData.ts"`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689f97a69394832fbd337f471a169dbf