### PR TITLE
fix: initialize settings reducer

### DIFF
--- a/app/providers/SettingsContext.tsx
+++ b/app/providers/SettingsContext.tsx
@@ -40,7 +40,7 @@ const SettingsContext = createContext<SettingsContextType | undefined>(undefined
  * the {@link useSettings} hook to read or update them.
  */
 export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
-  const [settings, dispatch] = useReducer(reducer, defaultSettings, loadSettings);
+  const [settings, dispatch] = useReducer(reducer, defaultSettings);
 
   const settingsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestSettings = useRef(settings);


### PR DESCRIPTION
## Summary
- initialize settings reducer with default settings
- load persisted settings after mount

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689fc7aa1ddc832f9d4d27ba2cf9c175