### PR TITLE
fix: add tafsir tabs fallback while loading

### DIFF
--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
@@ -20,21 +20,19 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
   // Compute tabs only when data or tafsirIds change
   const tabs = useMemo(() => {
     const resources = data || [];
-    return tafsirIds
-      .map((id) => resources.find((r) => r.id === id))
-      .filter(Boolean)
-      .slice(0, 3) as { id: number; name: string }[];
+    return tafsirIds.slice(0, 3).map((id) => {
+      const resource = resources.find((r) => r.id === id);
+      return resource ? { id: resource.id, name: resource.name } : { id, name: `Tafsir ${id}` };
+    });
   }, [tafsirIds, data]);
 
-  // -- Fix 1: activeId needs to track the tabs --
-  const [activeId, setActiveId] = useState<number | undefined>(undefined);
+  const [activeId, setActiveId] = useState<number | undefined>(tafsirIds[0]);
 
   useEffect(() => {
-    // If tabs exist and activeId is not in them, set to first tab
-    if (tabs.length && !tabs.find((t) => t.id === activeId)) {
-      setActiveId(tabs[0].id);
+    if (!activeId || !tafsirIds.includes(activeId)) {
+      setActiveId(tafsirIds[0]);
     }
-  }, [tabs, activeId]);
+  }, [tafsirIds, activeId]);
 
   // -- Caching and loading state --
   const [contents, setContents] = useState<Record<number, string>>({});
@@ -51,7 +49,13 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
   }, [activeId, verseKey, contents]);
 
   const { theme } = useTheme();
-  if (!tabs.length || !activeId) return null;
+  if (!tabs.length || !activeId) {
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner className="h-5 w-5 text-emerald-600" />
+      </div>
+    );
+  }
 
   const activeTab = tabs.find((t) => t.id === activeId);
 

--- a/app/(features)/tafsir/__tests__/TafsirTabs.test.tsx
+++ b/app/(features)/tafsir/__tests__/TafsirTabs.test.tsx
@@ -57,3 +57,16 @@ it('shows tabs and switches content on click', async () => {
   expect(await screen.findByText('Text 2')).toBeInTheDocument();
   expect(mockGetTafsirCached).toHaveBeenCalledWith('1:1', 2);
 });
+
+it('renders placeholder tabs before metadata loads', async () => {
+  mockUseSWR.mockReturnValue({ data: undefined });
+  render(
+    <SettingsProvider>
+      <ThemeProvider>
+        <TafsirTabs verseKey="1:1" tafsirIds={[1]} />
+      </ThemeProvider>
+    </SettingsProvider>
+  );
+  expect(screen.getByRole('button', { name: 'Tafsir 1' })).toBeInTheDocument();
+  expect(await screen.findByText('Text 1')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- ensure TafsirTabs builds fallback tabs from `tafsirIds` and defaults to the first tab
- show loading indicator instead of returning null when tabs are unavailable
- add tests covering placeholder tabs before metadata resolves

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_689fc7aac900832fb1d81650c13a282a