### PR TITLE
fix: tidy Verse JSX spacing

### DIFF
--- a/app/(features)/surah/[surahId]/components/Verse.tsx
+++ b/app/(features)/surah/[surahId]/components/Verse.tsx
@@ -69,38 +69,29 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
   }, [addBookmark, removeBookmark, findBookmark, verse.id]);
 
   return (
-    <>
-           {' '}
-      <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
-               {' '}
-        <VerseActions
-          verseKey={verse.verse_key}
-          isPlaying={isPlaying}
-          isLoadingAudio={isLoadingAudio}
-          isBookmarked={isVerseBookmarked}
-          onPlayPause={handlePlayPause}
-          onBookmark={handleBookmark}
-          className="w-16 pt-1"
-        />
-               {' '}
-        <div className="flex-grow space-y-6">
-                    <VerseArabic verse={verse} />          {/* TRANSLATIONS */}         {' '}
-          {verse.translations?.map((t: Translation) => (
-            <div key={t.resource_id}>
-                           {' '}
-              <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
-                style={{ fontSize: `${settings.translationFontSize}px` }}
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
-              />
-                         {' '}
-            </div>
-          ))}
-                 {' '}
-        </div>
-             {' '}
+    <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
+      <VerseActions
+        verseKey={verse.verse_key}
+        isPlaying={isPlaying}
+        isLoadingAudio={isLoadingAudio}
+        isBookmarked={isVerseBookmarked}
+        onPlayPause={handlePlayPause}
+        onBookmark={handleBookmark}
+        className="w-16 pt-1"
+      />
+      <div className="flex-grow space-y-6">
+        <VerseArabic verse={verse} />
+        {/* TRANSLATIONS */}
+        {verse.translations?.map((t: Translation) => (
+          <div key={t.resource_id}>
+            <p
+              className="text-left leading-relaxed text-[var(--foreground)]"
+              style={{ fontSize: `${settings.translationFontSize}px` }}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
+            />
+          </div>
+        ))}
       </div>
-         {' '}
-    </>
+    </div>
   );
 });


### PR DESCRIPTION
## Summary
- remove redundant JSX spacing in Verse component

## Testing
- `npm test -- "app/\(features\)/surah/__tests__/Verse.test.tsx"`
- `npm run check` *(fails: The autoFocus prop should not be used, as it can reduce usability and accessibility for users.)*

------
https://chatgpt.com/codex/tasks/task_b_68a1981311b4832fbadded773217f87d