### PR TITLE
refactor: modularize surah page panels and player

### DIFF
--- a/app/(features)/surah/[surahId]/components/SurahAudioPlayer.tsx
+++ b/app/(features)/surah/[surahId]/components/SurahAudioPlayer.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { QuranAudioPlayer } from '@/app/shared/player';
+import { buildAudioUrl } from '@/lib/audio/reciters';
+import { getSurahCoverUrl } from '@/lib/api';
+import type { Verse } from '@/types';
+import type { Reciter } from '@/app/shared/player/types';
+
+interface SurahAudioPlayerProps {
+  activeVerse: Verse | null;
+  reciter: Reciter;
+  isVisible: boolean;
+  onNext: () => boolean;
+  onPrev: () => boolean;
+}
+
+export const SurahAudioPlayer = ({
+  activeVerse,
+  reciter,
+  isVisible,
+  onNext,
+  onPrev,
+}: SurahAudioPlayerProps) => {
+  const [coverUrl, setCoverUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (activeVerse) {
+      const surahNumber = parseInt(activeVerse.verse_key.split(':')[0], 10);
+      getSurahCoverUrl(surahNumber).then(setCoverUrl);
+    }
+  }, [activeVerse]);
+
+  if (!activeVerse || !isVisible) return null;
+
+  const track = {
+    id: activeVerse.id.toString(),
+    title: `Verse ${activeVerse.verse_key}`,
+    artist: reciter.name,
+    coverUrl: coverUrl || '',
+    durationSec: 0,
+    src: buildAudioUrl(activeVerse.verse_key, reciter.path),
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
+      <QuranAudioPlayer track={track} onNext={onNext} onPrev={onPrev} />
+    </div>
+  );
+};
+
+export default SurahAudioPlayer;

--- a/app/(features)/surah/[surahId]/components/SurahVerseList.tsx
+++ b/app/(features)/surah/[surahId]/components/SurahVerseList.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Spinner from '@/app/shared/Spinner';
+import { Verse as VerseComponent } from './Verse';
+import type { Verse as VerseType } from '@/types';
+
+interface SurahVerseListProps {
+  verses: VerseType[];
+  isLoading: boolean;
+  error: string | null;
+  loadMoreRef: React.RefObject<HTMLDivElement | null>;
+  isValidating: boolean;
+  isReachingEnd: boolean;
+}
+
+export const SurahVerseList = ({
+  verses,
+  isLoading,
+  error,
+  loadMoreRef,
+  isValidating,
+  isReachingEnd,
+}: SurahVerseListProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="w-full relative">
+      {isLoading ? (
+        <div className="flex justify-center py-20">
+          <Spinner className="h-8 w-8 text-teal-600" />
+        </div>
+      ) : error ? (
+        <div className="text-center py-20 text-red-600 bg-red-50 p-4 rounded-lg">{error}</div>
+      ) : verses.length > 0 ? (
+        <>
+          {verses.map((v) => (
+            <React.Fragment key={v.id}>
+              <VerseComponent verse={v} />
+            </React.Fragment>
+          ))}
+          <div ref={loadMoreRef} className="py-4 text-center space-x-2">
+            {isValidating && <Spinner className="inline h-5 w-5 text-teal-600" />}
+            {isReachingEnd && <span className="text-gray-500">{t('end_of_surah')}</span>}
+          </div>
+        </>
+      ) : (
+        <div className="text-center py-20 text-gray-500">{t('no_verses_found')}</div>
+      )}
+    </div>
+  );
+};
+
+export default SurahVerseList;

--- a/app/(features)/surah/__tests__/SurahPage.test.tsx
+++ b/app/(features)/surah/__tests__/SurahPage.test.tsx
@@ -53,6 +53,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   (api.getTranslations as jest.Mock).mockResolvedValue([]);
   (api.getWordTranslations as jest.Mock).mockResolvedValue([]);
+  (api.getSurahCoverUrl as jest.Mock).mockResolvedValue('');
   (useSWRInfinite as jest.Mock).mockImplementation(jest.requireActual('swr/infinite').default);
 });
 

--- a/app/(features)/surah/hooks/useSurahPanels.ts
+++ b/app/(features)/surah/hooks/useSurahPanels.ts
@@ -1,0 +1,52 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LANGUAGE_CODES } from '@/lib/text/languageCodes';
+import type { LanguageCode } from '@/lib/text/languageCodes';
+import type { Settings } from '@/types';
+
+interface Option {
+  id: number;
+  name: string;
+}
+
+export default function useSurahPanels({
+  translationOptions,
+  wordLanguageOptions,
+  settings,
+}: {
+  translationOptions: Option[];
+  wordLanguageOptions: Option[];
+  settings: Settings;
+}) {
+  const { t } = useTranslation();
+  const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
+  const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
+
+  const selectedTranslationName = useMemo(
+    () =>
+      translationOptions.find((o) => o.id === settings.translationId)?.name ||
+      t('select_translation'),
+    [settings.translationId, translationOptions, t]
+  );
+
+  const selectedWordLanguageName = useMemo(
+    () =>
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
+    [settings.wordLang, wordLanguageOptions, t]
+  );
+
+  return {
+    isTranslationPanelOpen,
+    openTranslationPanel: () => setIsTranslationPanelOpen(true),
+    closeTranslationPanel: () => setIsTranslationPanelOpen(false),
+    isWordLanguagePanelOpen: isWordPanelOpen,
+    openWordLanguagePanel: () => setIsWordPanelOpen(true),
+    closeWordLanguagePanel: () => setIsWordPanelOpen(false),
+    selectedTranslationName,
+    selectedWordLanguageName,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- extract translation and word language panel state into `useSurahPanels`
- move audio player setup to `SurahAudioPlayer` component
- render verses via new `SurahVerseList` component
- update Surah page test to mock cover URL fetch

## Testing
- `npm run format`
- `npm run lint` (fails: jsx-a11y/no-autofocus etc. in unrelated files)
- `npm run lint -- --file app/(features)/surah/[surahId]/page.tsx --file app/(features)/surah/hooks/useSurahPanels.ts --file app/(features)/surah/[surahId]/components/SurahAudioPlayer.tsx --file app/(features)/surah/[surahId]/components/SurahVerseList.tsx --file app/(features)/surah/__tests__/SurahPage.test.tsx`
- `npm run type-check` (fails: missing properties in BookmarkContextType, etc.)
- `npm test -- app/\(features\)/surah/__tests__/SurahPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a19824e768832f91ac9b07ae192c85