### PR TITLE
refactor: split verse listing hooks

### DIFF
--- a/app/(features)/surah/__tests__/UseVerseListing.test.tsx
+++ b/app/(features)/surah/__tests__/UseVerseListing.test.tsx
@@ -13,18 +13,22 @@ const setActiveVerse = jest.fn((v) => {
 });
 const openPlayer = jest.fn();
 
-jest.mock('swr', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({ data: [] })),
-}));
-
-jest.mock('swr/infinite', () => ({
+jest.mock('@/app/(features)/surah/hooks/useTranslationOptions', () => ({
   __esModule: true,
   default: jest.fn(() => ({
-    data: [{ verses, totalPages: 1 }],
-    size: 1,
-    setSize: jest.fn(),
+    translationOptions: [],
+    wordLanguageOptions: [],
+    wordLanguageMap: {},
+  })),
+}));
+
+jest.mock('@/app/(features)/surah/hooks/useInfiniteVerseLoader', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    verses,
+    isLoading: false,
     isValidating: false,
+    isReachingEnd: false,
   })),
 }));
 
@@ -36,11 +40,6 @@ jest.mock('@/app/shared/player/context/AudioContext', () => ({
     isPlayerVisible: true,
     openPlayer,
   }),
-}));
-
-jest.mock('@/lib/api', () => ({
-  getTranslations: jest.fn().mockResolvedValue([]),
-  getWordTranslations: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('@/app/providers/SettingsContext', () => ({

--- a/app/(features)/surah/hooks/useInfiniteVerseLoader.ts
+++ b/app/(features)/surah/hooks/useInfiniteVerseLoader.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo } from 'react';
+import useSWRInfinite from 'swr/infinite';
+import type { Verse } from '@/types';
+import type { LookupFn } from './useVerseListing';
+
+interface UseInfiniteVerseLoaderParams {
+  id?: string;
+  lookup: LookupFn;
+  stableTranslationIds: string;
+  wordLang: string;
+  loadMoreRef: React.RefObject<HTMLDivElement | null>;
+  error: string | null;
+  setError: (err: string) => void;
+}
+
+export function useInfiniteVerseLoader({
+  id,
+  lookup,
+  stableTranslationIds,
+  wordLang,
+  loadMoreRef,
+  error,
+  setError,
+}: UseInfiniteVerseLoaderParams) {
+  const { data, size, setSize, isValidating } = useSWRInfinite(
+    (index) => (id ? ['verses', id, stableTranslationIds, wordLang, index + 1] : null),
+    ([, pId, translationIdsStr, wl, page]) => {
+      const translationIds = translationIdsStr.split(',').map(Number);
+      return lookup(pId, translationIds, page, 20, wl).catch((err) => {
+        setError(`Failed to load content. ${err.message}`);
+        return { verses: [], totalPages: 1 };
+      });
+    }
+  );
+
+  const verses: Verse[] = useMemo(() => (data ? data.flatMap((d) => d.verses) : []), [data]);
+  const totalPages = useMemo(() => (data ? data[data.length - 1]?.totalPages : 1), [data]);
+  const isLoading = !data && !error;
+  const isReachingEnd = size >= totalPages;
+
+  useEffect(() => {
+    if (!loadMoreRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !isReachingEnd && !isValidating) {
+        setSize(size + 1);
+      }
+    });
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [isReachingEnd, isValidating, size, setSize, loadMoreRef]);
+
+  return { verses, isLoading, isValidating, isReachingEnd } as const;
+}
+
+export default useInfiniteVerseLoader;

--- a/app/(features)/surah/hooks/useTranslationOptions.ts
+++ b/app/(features)/surah/hooks/useTranslationOptions.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { getTranslations, getWordTranslations } from '@/lib/api';
+import { WORD_LANGUAGE_LABELS } from '@/lib/text/wordLanguages';
+import type { TranslationResource } from '@/types';
+
+export interface WordLanguageOption {
+  name: string;
+  id: number;
+}
+
+export function useTranslationOptions() {
+  const { data: translationOptionsData } = useSWR<TranslationResource[]>(
+    'translations',
+    getTranslations
+  );
+  const translationOptions = useMemo(() => translationOptionsData || [], [translationOptionsData]);
+
+  const { data: wordTranslationOptionsData } = useSWR('wordTranslations', getWordTranslations);
+  const wordLanguageMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    (wordTranslationOptionsData || []).forEach((o) => {
+      const name = o.language_name.toLowerCase();
+      if (!map[name]) {
+        map[name] = o.id;
+      }
+    });
+    return map;
+  }, [wordTranslationOptionsData]);
+
+  const wordLanguageOptions: WordLanguageOption[] = useMemo(
+    () =>
+      Object.keys(wordLanguageMap)
+        .filter((name) => WORD_LANGUAGE_LABELS[name])
+        .map((name) => ({ name: WORD_LANGUAGE_LABELS[name], id: wordLanguageMap[name] })),
+    [wordLanguageMap]
+  );
+
+  return { translationOptions, wordLanguageOptions, wordLanguageMap } as const;
+}
+
+export default useTranslationOptions;


### PR DESCRIPTION
## Summary
- extract translation and word language options into `useTranslationOptions`
- move infinite scroll loading to `useInfiniteVerseLoader`
- compose new hooks in `useVerseListing` and update tests

## Testing
- `npm run check` *(fails: The autoFocus prop should not be used, etc.)*
- `npm test` *(fails: SettingsSidebar interactions › opens via header icon, switches font tabs, and closes with back button)*

------
https://chatgpt.com/codex/tasks/task_b_68a198414700832fbde836dc75e3d951