### PR TITLE
fix: remove stray space tokens

### DIFF
--- a/app/(features)/home/components/VerseOfDay.tsx
+++ b/app/(features)/home/components/VerseOfDay.tsx
@@ -135,8 +135,7 @@ export default function VerseOfDay() {
           <p
             className={`mt-4 text-left text-sm ${theme === 'light' ? 'text-slate-800' : 'text-slate-400'}`}
           >
-            &quot;{stripHtml(verse.translations[0].text)}&quot; - [Surah {surahName ?? surahNum},{' '}
-            {verse.verse_key}]
+            {`"${stripHtml(verse.translations[0].text)}" - [Surah ${surahName ?? surahNum}, ${verse.verse_key}]`}
           </p>
         )}
       </>

--- a/app/(features)/surah/[surahId]/components/CollapsibleSection.tsx
+++ b/app/(features)/surah/[surahId]/components/CollapsibleSection.tsx
@@ -21,7 +21,6 @@ export const CollapsibleSection = ({
 }: CollapsibleSectionProps) => {
   return (
     <div className={isLast ? '' : 'border-b border-[var(--border-color)]'}>
-      {' '}
       {/* Apply border only if not the last section */}
       <button onClick={onToggle} className="w-full flex items-center justify-between p-4 text-left">
         <div className="flex items-center space-x-3">

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
@@ -24,9 +24,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
 
   return (
     <div className="space-y-6">
-           {' '}
       <div className="flex items-start gap-x-6 pb-8 border-b border-[var(--border-color)]">
-               {' '}
         <VerseActions
           verseKey={verse.verse_key}
           isPlaying={isPlaying}
@@ -38,25 +36,20 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
           onBookmark={() => toggleBookmark(String(verse.id))}
           className="w-16 pt-1"
         />
-               {' '}
         <div className="flex-grow space-y-6">
-                    <VerseArabic verse={verse} />         {' '}
+          <VerseArabic verse={verse} />
           {verse.translations?.map((t: Translation) => (
             <div key={t.resource_id}>
-                           {' '}
               <p
                 className="text-left leading-relaxed text-[var(--foreground)]"
                 style={{ fontSize: `${settings.translationFontSize}px` }}
                 dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
               />
-                         {' '}
             </div>
           ))}
-                 {' '}
         </div>
-             {' '}
       </div>
-            <TafsirPanels verseKey={verse.verse_key} tafsirIds={tafsirIds} />   {' '}
+      <TafsirPanels verseKey={verse.verse_key} tafsirIds={tafsirIds} />
     </div>
   );
 };

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
@@ -77,23 +77,18 @@ export default function VerseCard({ verse }: VerseCardProps) {
         onBookmark={handleBookmark}
         className="mr-4 w-14 pt-2 text-gray-500"
       />
-           {' '}
       <div className="flex-grow space-y-6">
-                <VerseArabic verse={verse} />       {' '}
+        <VerseArabic verse={verse} />
         {verse.translations?.map((t: Translation) => (
           <div key={t.resource_id}>
-                       {' '}
             <p
               className="text-left leading-relaxed"
               style={{ fontSize: `${settings.translationFontSize}px` }}
               dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
             />
-                     {' '}
           </div>
         ))}
-             {' '}
       </div>
-         {' '}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- clean up stray space tokens in VerseOfDay
- remove invisible characters in tafsir verse components
- tidy CollapsibleSection layout

## Testing
- `npm run format`
- `npm run lint` *(fails: The autoFocus prop should not be used, as it can reduce usability and accessibility for users. jsx-a11y/no-autofocus)*
- `npm test` *(fails: IndexPage.test.tsx cannot find expected links)*
- `npm run type-check` *(fails: Property 'bookmarkedVerses' does not exist on type 'BookmarkContextType')*


------
https://chatgpt.com/codex/tasks/task_b_68a1c344db0c832fa2f6ca1c441d1086