### PR TITLE
fix: use CSS variables for base colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,8 @@
 
 @layer base {
   body {
-    @apply bg-[var(--background)] text-[var(--foreground)];
+    background: var(--background);
+    color: var(--foreground);
     font-family: Inter, sans-serif;
     margin: 0;
     -webkit-font-smoothing: antialiased;
@@ -35,7 +36,8 @@
   }
 
   .card {
-    @apply rounded-lg bg-surface p-4 shadow-sm;
+    @apply rounded-lg p-4 shadow-sm;
+    background: var(--background);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace Tailwind token utilities in `app/globals.css` with CSS variable declarations for body and card backgrounds
- ensure build succeeds after using explicit CSS variables

## Testing
- `npm run format -- app/globals.css`
- `npm run lint`
- `npm run build`
- `npm run check` *(fails: IndexPage tests cannot find expected links)*
- `npm test` *(fails: IndexPage tests cannot find expected links)*

------
https://chatgpt.com/codex/tasks/task_b_68a26d4e57f8832fb52d3e8e162d331b