### PR TITLE
refactor: replace CSS variable colors with token utilities

### DIFF
--- a/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
@@ -66,13 +66,9 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
       data-testid="arabic-font-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
+      } bg-surface text-primary`}
     >
-      <header
-        className={`flex items-center p-4 border-b ${
-          theme === 'dark' ? 'border-[var(--border-color)]' : 'border-slate-200'
-        }`}
-      >
+      <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
           className={`p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 ${
@@ -90,11 +86,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <h2
-          className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-primary' : 'text-slate-800'
-          }`}
-        >
+        <h2 className="text-lg font-bold text-center flex-grow text-primary">
           Arabic Font Selection
         </h2>
         <button
@@ -143,10 +135,8 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
               {/* Font Type Toggle - Uthmani/Indopak */}
               <div
                 className={`sticky top-0 z-10 py-4 border-b ${
-                  theme === 'dark'
-                    ? 'bg-surface border-[var(--border-color)]'
-                    : 'bg-surface/95 backdrop-blur-sm border-slate-200'
-                }`}
+                  theme === 'dark' ? 'bg-surface' : 'bg-surface/95 backdrop-blur-sm'
+                } border-border`}
               >
                 <div className="px-4">
                   <div

--- a/app/(features)/surah/[surahId]/components/CollapsibleSection.tsx
+++ b/app/(features)/surah/[surahId]/components/CollapsibleSection.tsx
@@ -20,7 +20,7 @@ export const CollapsibleSection = ({
   onToggle,
 }: CollapsibleSectionProps) => {
   return (
-    <div className={isLast ? '' : 'border-b border-[var(--border-color)]'}>
+    <div className={isLast ? '' : 'border-b border-border'}>
       {' '}
       {/* Apply border only if not the last section */}
       <button onClick={onToggle} className="w-full flex items-center justify-between p-4 text-left">

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -166,7 +166,7 @@ export const SettingsSidebar = ({
           scrollbarWidth: 'none',
         }}
       >
-        <header className="flex items-center justify-between p-4 border-b border-[var(--border-color)]">
+        <header className="flex items-center justify-between p-4 border-b border-border">
           <button
             aria-label="Back"
             onClick={() => setSettingsOpen(false)}

--- a/app/(features)/surah/[surahId]/components/SidebarContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SidebarContent.tsx
@@ -63,7 +63,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
         } lg:translate-x-0 ${isOpen ? 'flex' : 'hidden'} lg:flex scrollbar-hide`}
         style={{ position: 'relative' }}
       >
-        <header className="flex items-center justify-between p-4 border-b border-[var(--border-color)]">
+        <header className="flex items-center justify-between p-4 border-b border-border">
           <button
             aria-label="Back"
             onClick={onClose}

--- a/app/(features)/surah/[surahId]/components/Verse.tsx
+++ b/app/(features)/surah/[surahId]/components/Verse.tsx
@@ -69,7 +69,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
   }, [addBookmark, removeBookmark, findBookmark, verse.id]);
 
   return (
-    <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-[var(--border-color)]">
+    <div className="flex items-start gap-x-6 mb-12 pb-8 border-b border-border">
       <VerseActions
         verseKey={verse.verse_key}
         isPlaying={isPlaying}

--- a/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
+++ b/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
@@ -144,13 +144,9 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
       data-testid="word-language-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
+      } bg-surface text-primary`}
     >
-      <header
-        className={`flex items-center p-4 border-b ${
-          theme === 'dark' ? 'border-[var(--border-color)]' : 'border-slate-200'
-        }`}
-      >
+      <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
           className={`p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 ${
@@ -168,11 +164,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <h2
-          className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-primary' : 'text-slate-800'
-          }`}
-        >
+        <h2 className="text-lg font-bold text-center flex-grow text-primary">
           {t('word_by_word_panel_title')}
         </h2>
       </header>

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -85,15 +85,11 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
       data-testid="tafsir-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
+      } bg-surface text-primary`}
     >
       <TafsirLimitWarning show={showLimitWarning} theme={theme} />
 
-      <header
-        className={`flex items-center p-4 border-b ${
-          theme === 'dark' ? 'border-[var(--border-color)]' : 'border-slate-200'
-        }`}
-      >
+      <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
           className={`p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 ${
@@ -111,13 +107,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <h2
-          className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-primary' : 'text-slate-800'
-          }`}
-        >
-          Manage Tafsirs
-        </h2>
+        <h2 className="text-lg font-bold text-center flex-grow text-primary">Manage Tafsirs</h2>
         <button
           onClick={handleReset}
           className={`p-2 rounded-full focus-visible:outline-none transition-colors ${
@@ -179,10 +169,8 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
               {/* Sticky Tabs - Will stick to top when scrolled to */}
               <div
                 className={`sticky top-0 z-10 py-2 border-b ${
-                  theme === 'dark'
-                    ? 'bg-surface border-[var(--border-color)]'
-                    : 'bg-surface/95 backdrop-blur-sm border-slate-200'
-                }`}
+                  theme === 'dark' ? 'bg-surface' : 'bg-surface/95 backdrop-blur-sm'
+                } border-border`}
               >
                 <div className="px-4">
                   <ResourceTabs

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
@@ -103,13 +103,9 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
       data-testid="translation-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
+      } bg-surface text-primary`}
     >
-      <header
-        className={`flex items-center p-4 border-b ${
-          theme === 'dark' ? 'border-[var(--border-color)]' : 'border-slate-200'
-        }`}
-      >
+      <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
           className={`p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 ${
@@ -127,11 +123,7 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <h2
-          className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-primary' : 'text-slate-800'
-          }`}
-        >
+        <h2 className="text-lg font-bold text-center flex-grow text-primary">
           Manage Translations
         </h2>
         <button
@@ -199,10 +191,8 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
               {/* Sticky Tabs - Will stick to top when scrolled to */}
               <div
                 className={`sticky top-0 z-10 py-2 border-b ${
-                  theme === 'dark'
-                    ? 'bg-surface border-[var(--border-color)]'
-                    : 'bg-surface/95 backdrop-blur-sm border-slate-200'
-                }`}
+                  theme === 'dark' ? 'bg-surface' : 'bg-surface/95 backdrop-blur-sm'
+                } border-border`}
               >
                 <div className="px-4">
                   <ResourceTabs

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
@@ -19,7 +19,7 @@ export const TafsirPanels = ({ verseKey, tafsirIds }: TafsirPanelsProps) => {
       {tafsirIds.map((id) => {
         const open = !!openPanels[id];
         return (
-          <div key={id} className="border-b border-[var(--border-color)] last:border-none">
+          <div key={id} className="border-b border-border last:border-none">
             <button
               onClick={() => togglePanel(id)}
               className="w-full flex items-center justify-between py-3 text-left"

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
@@ -25,7 +25,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
   return (
     <div className="space-y-6">
            {' '}
-      <div className="flex items-start gap-x-6 pb-8 border-b border-[var(--border-color)]">
+      <div className="flex items-start gap-x-6 pb-8 border-b border-border">
                {' '}
         <VerseActions
           verseKey={verse.verse_key}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 export default function NotFound() {
   const { t } = useTranslation();
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background)] text-[var(--foreground)] p-6">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
       <h1 className="text-2xl font-semibold mb-4">{t('page_not_found')}</h1>
       <Link href="/" className="text-teal-600 hover:underline">
         {t('home')}

--- a/app/shared/Header.tsx
+++ b/app/shared/Header.tsx
@@ -7,7 +7,6 @@ import { useSidebar } from '@/app/providers/SidebarContext';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { FaCog } from 'react-icons/fa';
-import { useTheme } from '@/app/providers/ThemeContext';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
 
 const Header = () => {
@@ -15,7 +14,6 @@ const Header = () => {
   const { setSurahListOpen, setSettingsOpen } = useSidebar();
   const router = useRouter();
   const [query, setQuery] = useState('');
-  const { theme } = useTheme(); // Use the theme context to determine colors
   const { isHidden } = useHeaderVisibility();
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -24,8 +22,7 @@ const Header = () => {
     }
   };
 
-  // Use a stable header background based on the current theme
-  const headerBgClass = theme === 'light' ? 'bg-white' : 'bg-[var(--background)]';
+  const headerBgClass = 'bg-background';
 
   return (
     <header

--- a/app/shared/IconSidebar.tsx
+++ b/app/shared/IconSidebar.tsx
@@ -15,7 +15,7 @@ const IconSidebar = () => {
   return (
     // CHANGE: Removed the border-r class for a cleaner look and centered content vertically
     // Added h-full to make the sidebar take full height for vertical centering
-    <aside className="w-20 bg-[var(--background)] text-[var(--foreground)] flex flex-col justify-center py-4 h-full overflow-x-hidden">
+    <aside className="w-20 bg-background text-foreground flex flex-col justify-center py-4 h-full overflow-x-hidden">
       <nav className="flex flex-col items-center space-y-2">
         {navItems.map((item) => (
           <Link
@@ -23,7 +23,7 @@ const IconSidebar = () => {
             href={item.href}
             title={item.label}
             aria-label={item.label}
-            className="p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-[var(--foreground)] hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 border-0"
+            className="p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-foreground hover:text-teal-600 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 border-0"
           >
             <item.icon className="h-6 w-6" />
           </Link>

--- a/app/shared/SelectionBox.tsx
+++ b/app/shared/SelectionBox.tsx
@@ -18,7 +18,7 @@ const SelectionBox = ({ label, value, onClick }: SelectionBoxProps) => {
 
   return (
     <div>
-      <label className="block mb-2 text-sm font-medium text-[var(--foreground)]">{label}</label>
+      <label className="block mb-2 text-sm font-medium text-foreground">{label}</label>
       <button
         onClick={onClick}
         className={`w-full flex justify-between items-center ${boxClasses} rounded-lg p-2.5 text-sm text-left focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600`}

--- a/app/shared/SurahListSidebar.tsx
+++ b/app/shared/SurahListSidebar.tsx
@@ -104,11 +104,11 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     <>
       {/* This is the main sidebar container. */}
       <aside
-        className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[20.7rem] bg-white dark:bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-40 md:z-10 md:h-full transform transition-transform duration-300 ${
+        className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[20.7rem] bg-background text-foreground flex flex-col shadow-lg z-40 md:z-10 md:h-full transform transition-transform duration-300 ${
           isSurahListOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
       >
-        <div className="p-4 border-b border-[var(--border-color)]">
+        <div className="p-4 border-b border-border">
           <SidebarTabs
             tabs={TABS}
             activeTab={activeTab}
@@ -117,7 +117,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
             theme={theme}
           />
         </div>
-        <div className="p-4 border-b border-[var(--border-color)]">
+        <div className="p-4 border-b border-border">
           <SearchInput
             value={searchTerm}
             onChange={setSearchTerm}

--- a/app/shared/VerseArabic.tsx
+++ b/app/shared/VerseArabic.tsx
@@ -17,7 +17,7 @@ const VerseArabic = ({ verse }: VerseArabicProps) => {
   return (
     <p
       dir="rtl"
-      className="text-right leading-loose text-[var(--foreground)]"
+      className="text-right leading-loose text-foreground"
       style={{
         fontFamily: settings.arabicFontFace,
         fontSize: `${settings.arabicFontSize}px`,

--- a/app/shared/resource-panel/ResourceItem.tsx
+++ b/app/shared/resource-panel/ResourceItem.tsx
@@ -54,13 +54,7 @@ export const ResourceItem = <T extends Resource>({
       <div className="flex-1 min-w-0 pr-3">
         <p
           className={`font-medium text-sm leading-tight truncate ${
-            isSelected
-              ? theme === 'dark'
-                ? 'text-blue-200'
-                : 'text-blue-800'
-              : theme === 'dark'
-                ? 'text-[var(--foreground)]'
-                : 'text-slate-800'
+            isSelected ? (theme === 'dark' ? 'text-blue-200' : 'text-blue-800') : 'text-primary'
           }`}
           title={item.name}
         >

--- a/app/shared/surah-sidebar/Juz.tsx
+++ b/app/shared/surah-sidebar/Juz.tsx
@@ -68,15 +68,7 @@ const Juz = ({
               {juz.number}
             </div>
             <div>
-              <p
-                className={`font-semibold ${
-                  isActive
-                    ? 'text-white'
-                    : theme === 'light'
-                      ? 'text-slate-700'
-                      : 'text-[var(--foreground)]'
-                }`}
-              >
+              <p className={`font-semibold ${isActive ? 'text-white' : 'text-primary'}`}>
                 Juz {juz.number}
               </p>
               <p

--- a/app/shared/surah-sidebar/Page.tsx
+++ b/app/shared/surah-sidebar/Page.tsx
@@ -60,17 +60,7 @@ const Page = ({
             >
               {p}
             </div>
-            <p
-              className={`font-semibold ${
-                isActive
-                  ? 'text-white'
-                  : theme === 'light'
-                    ? 'text-slate-700'
-                    : 'text-[var(--foreground)]'
-              }`}
-            >
-              Page {p}
-            </p>
+            <p className={`font-semibold ${isActive ? 'text-white' : 'text-primary'}`}>Page {p}</p>
           </Link>
         </li>
       );

--- a/app/shared/surah-sidebar/Surah.tsx
+++ b/app/shared/surah-sidebar/Surah.tsx
@@ -61,15 +61,7 @@ const Surah = ({
               {chapter.id}
             </div>
             <div className="flex-grow">
-              <p
-                className={`font-bold ${
-                  isActive
-                    ? 'text-white'
-                    : theme === 'light'
-                      ? 'text-slate-700'
-                      : 'text-[var(--foreground)]'
-                }`}
-              >
+              <p className={`font-bold ${isActive ? 'text-white' : 'text-primary'}`}>
                 {chapter.name_simple}
               </p>
               <p className={`text-xs ${isActive ? 'text-white/80' : 'text-gray-500'}`}>


### PR DESCRIPTION
## Summary
- swap hardcoded CSS variable classes for semantic token utilities like `bg-background` and `border-border`
- drop `dark:` overrides made redundant by token-based theming

## Testing
- `npm run lint` *(fails: warnings about unused vars)*
- `npm run check` *(fails: 2 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_b_68a270979cc4832fa712aa09a996b2b6