### PR TITLE
refactor: use design tokens in SelectionBox

### DIFF
--- a/app/shared/SelectionBox.tsx
+++ b/app/shared/SelectionBox.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ChevronDownIcon } from './icons';
-import { useTheme } from '@/app/providers/ThemeContext';
 
 interface SelectionBoxProps {
   label: string;
@@ -9,22 +8,15 @@ interface SelectionBoxProps {
 }
 
 const SelectionBox = ({ label, value, onClick }: SelectionBoxProps) => {
-  const { theme } = useTheme();
-
-  const boxClasses =
-    theme === 'light'
-      ? 'bg-white border border-gray-200 text-gray-700'
-      : 'bg-gray-800 border border-gray-600 text-gray-200';
-
   return (
     <div>
       <label className="block mb-2 text-sm font-medium text-foreground">{label}</label>
       <button
         onClick={onClick}
-        className={`w-full flex justify-between items-center ${boxClasses} rounded-lg p-2.5 text-sm text-left focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600`}
+        className="w-full flex justify-between items-center bg-surface text-primary border border-border rounded-lg p-2.5 text-sm text-left focus:outline-none focus:ring-1 focus:ring-accent transition-all duration-300 hover:bg-accent/10"
       >
         <span className="truncate">{value}</span>
-        <ChevronDownIcon className="text-gray-500" />
+        <ChevronDownIcon className="text-muted" />
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove theme hook and conditional styling from SelectionBox
- use semantic color tokens for background, text, border, hover, and focus states

## Testing
- `npm install`
- `npm run format`
- `npm run lint` *(warnings remain)*
- `npm run check` *(fails: 2 test suites)*

------
https://chatgpt.com/codex/tasks/task_b_68a27712e218832f82bf93b6b1aec9a1