### PR TITLE
style: replace colors with tokens

### DIFF
--- a/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
@@ -37,7 +37,7 @@ export const TranslationSettings = ({
     <>
       <CollapsibleSection
         title={t('reading_setting')}
-        icon={<TranslationIcon size={20} className="text-teal-700" />}
+        icon={<TranslationIcon size={20} className="text-accent" />}
         isLast={true}
         isOpen={isOpen}
         onToggle={onToggle || (() => {})}
@@ -47,7 +47,7 @@ export const TranslationSettings = ({
             <span className="text-sm text-primary">{t('show_word_by_word')}</span>
             <button
               onClick={() => setSettings({ ...settings, showByWords: !settings.showByWords })}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.showByWords ? 'bg-teal-600' : 'bg-gray-200'}`}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.showByWords ? 'bg-accent' : 'bg-muted'}`}
             >
               <span
                 className={`inline-block h-4 w-4 transform rounded-full bg-surface transition ${settings.showByWords ? 'translate-x-6' : 'translate-x-1'}`}
@@ -59,7 +59,7 @@ export const TranslationSettings = ({
             <span className="text-sm text-primary">{t('apply_tajweed')}</span>
             <button
               onClick={() => setSettings({ ...settings, tajweed: !settings.tajweed })}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.tajweed ? 'bg-teal-600' : 'bg-gray-200'}`}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.tajweed ? 'bg-accent' : 'bg-muted'}`}
             >
               <span
                 className={`inline-block h-4 w-4 transform rounded-full bg-surface transition ${settings.tajweed ? 'translate-x-6' : 'translate-x-1'}`}


### PR DESCRIPTION
## Summary
- use accent token for translation settings icon and toggles
- swap gray backgrounds for muted token in inactive states

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Unable to find element "Al-Fatihah" in some tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a2788b6204832fa06ee981a6b90ca8