### PR TITLE
feat: enforce token color usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - run: npm ci
       - name: Audit dependencies
         run: npm audit --omit=dev --audit-level=high
+      - run: npm run lint
       - run: npm run check
       - run: npm run test:coverage
       - name: Install Playwright

--- a/app/shared/HeaderSearch.tsx
+++ b/app/shared/HeaderSearch.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { SearchSolidIcon } from './icons';
-import { useTheme } from '@/app/providers/ThemeContext';
 
 interface Props {
   query: string;
@@ -10,26 +9,16 @@ interface Props {
 }
 
 const HeaderSearch = ({ query, setQuery, placeholder, onKeyDown }: Props) => {
-  const { theme } = useTheme();
-
-  const searchBarClasses =
-    theme === 'light'
-      ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
-
   return (
     <div className="relative">
-      <SearchSolidIcon
-        size={18}
-        className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"
-      />
+      <SearchSolidIcon size={18} className="absolute left-4 top-1/2 -translate-y-1/2 text-muted" />
       <input
         type="text"
         placeholder={placeholder}
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={onKeyDown}
-        className={`w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 ${searchBarClasses}`}
+        className="w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 bg-surface text-primary border border-border placeholder:text-muted"
       />
     </div>
   );

--- a/app/shared/VerseArabic.tsx
+++ b/app/shared/VerseArabic.tsx
@@ -37,14 +37,14 @@ const VerseArabic = ({ verse }: VerseArabicProps) => {
                   }}
                 />
                 {!showByWords && (
-                  <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
+                  <span className="absolute left-1/2 -translate-x-1/2 -top-7 hidden group-hover:block bg-surface text-primary text-xs px-2 py-1 rounded shadow z-10 whitespace-nowrap">
                     {word[wordLang as LanguageCode] as string}
                   </span>
                 )}
               </span>
               {showByWords && (
                 <span
-                  className="mt-0.5 block text-gray-500 mx-1"
+                  className="mt-0.5 block text-muted mx-1"
                   style={{ fontSize: `${settings.arabicFontSize * 0.5}px` }}
                 >
                   {word[wordLang as LanguageCode] as string}

--- a/app/shared/components/SearchInput.tsx
+++ b/app/shared/components/SearchInput.tsx
@@ -1,7 +1,6 @@
 'use client';
 import React from 'react';
 import { SearchSolidIcon } from '../icons';
-import { useTheme } from '@/app/providers/ThemeContext';
 
 interface SearchInputProps {
   value: string;
@@ -18,18 +17,11 @@ export const SearchInput = ({
   onKeyDown,
   className = '',
 }: SearchInputProps) => {
-  const { theme } = useTheme();
-  const searchBarClasses =
-    theme === 'light'
-      ? 'bg-white text-gray-700 border border-gray-200 placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border border-gray-600 placeholder-gray-400';
+  const searchBarClasses = 'bg-surface text-primary border border-border placeholder:text-muted';
 
   return (
     <div className={`relative ${className}`}>
-      <SearchSolidIcon
-        size={18}
-        className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-      />
+      <SearchSolidIcon size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
       <input
         type="text"
         value={value}

--- a/app/shared/surah-sidebar/Surah.tsx
+++ b/app/shared/surah-sidebar/Surah.tsx
@@ -64,7 +64,7 @@ const Surah = ({
               <p className={`font-bold ${isActive ? 'text-white' : 'text-primary'}`}>
                 {chapter.name_simple}
               </p>
-              <p className={`text-xs ${isActive ? 'text-white/80' : 'text-gray-500'}`}>
+              <p className={`text-xs ${isActive ? 'text-white/80' : 'text-muted'}`}>
                 {chapter.revelation_place} • {chapter.verses_count} verses
               </p>
             </div>
@@ -73,8 +73,8 @@ const Surah = ({
                 isActive
                   ? 'text-white'
                   : theme === 'light'
-                    ? 'text-gray-500 group-hover:text-teal-600'
-                    : 'text-gray-500 group-hover:text-teal-400'
+                    ? 'text-muted group-hover:text-teal-600'
+                    : 'text-muted group-hover:text-teal-400'
               }`}
             >
               {chapter.name_arabic}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { FlatCompat } from '@eslint/eslintrc';
+import noRawColorClasses from './scripts/eslint/no-raw-color-classes.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -9,6 +10,12 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+const tokenRules = {
+  rules: {
+    'no-raw-color-classes': noRawColorClasses,
+  },
+};
+
 const eslintConfig = [
   ...compat.extends(
     'next/core-web-vitals',
@@ -16,6 +23,15 @@ const eslintConfig = [
     'plugin:jsx-a11y/recommended',
     'plugin:prettier/recommended'
   ),
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: {
+      'token-rules': tokenRules,
+    },
+    rules: {
+      'token-rules/no-raw-color-classes': 'error',
+    },
+  },
   {
     files: ['**/__tests__/**'],
     rules: {

--- a/scripts/eslint/no-raw-color-classes.mjs
+++ b/scripts/eslint/no-raw-color-classes.mjs
@@ -1,0 +1,50 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow raw Tailwind color utilities',
+    },
+    schema: [],
+    messages: {
+      noRaw: 'Avoid using raw color utility "{{utility}}". Use design tokens instead.',
+    },
+  },
+  create(context) {
+    const regex = /(text-gray-\d+|dark:[^\s"']+)/g;
+
+    function report(node, value) {
+      let match;
+      while ((match = regex.exec(value)) !== null) {
+        context.report({ node, messageId: 'noRaw', data: { utility: match[0] } });
+      }
+    }
+
+    function check(node) {
+      if (!node) return;
+      if (node.type === 'Literal' && typeof node.value === 'string') {
+        report(node, node.value);
+      } else if (node.type === 'TemplateLiteral') {
+        node.quasis.forEach((q) => report(q, q.value.raw));
+      }
+    }
+
+    return {
+      JSXAttribute(node) {
+        if (!node.name || (node.name.name !== 'className' && node.name.name !== 'class')) return;
+        const value = node.value;
+        if (!value) return;
+        if (value.type === 'Literal' && typeof value.value === 'string') {
+          report(value, value.value);
+        } else if (value.type === 'JSXExpressionContainer') {
+          const expr = value.expression;
+          if (expr.type === 'ConditionalExpression') {
+            check(expr.consequent);
+            check(expr.alternate);
+          } else {
+            check(expr);
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- add custom ESLint rule to forbid `text-gray-*` and `dark:` utilities
- replace raw color utilities with design tokens
- run lint separately in CI to ensure token usage

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68a2e99ef66c832f913386f63fb04c93