### PR TITLE
refactor: drop theme props in surah sidebar

### DIFF
--- a/app/shared/SurahListSidebar.tsx
+++ b/app/shared/SurahListSidebar.tsx
@@ -6,7 +6,6 @@ import { Chapter } from '@/types';
 import { getChapters } from '@/lib/api';
 import useSWR from 'swr';
 import { useSidebar } from '@/app/providers/SidebarContext';
-import { useTheme } from '@/app/providers/ThemeContext';
 import juzData from '@/data/juz.json';
 import useSidebarScroll from './surah-sidebar/useSidebarScroll';
 import Surah from './surah-sidebar/Surah';
@@ -51,7 +50,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
     return 'Surah';
   });
 
-  const { theme } = useTheme();
   const isTafsirPath = pathname?.includes('/tafsir');
 
   const {
@@ -114,7 +112,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
             activeTab={activeTab}
             setActiveTab={setActiveTab}
             prepareForTabSwitch={prepareForTabSwitch}
-            theme={theme}
           />
         </div>
         <div className="p-4 border-b border-border">
@@ -128,7 +125,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
           {activeTab === 'Surah' && (
             <Surah
               chapters={filteredChapters}
-              theme={theme}
               selectedSurahId={selectedSurahId}
               setSelectedSurahId={setSelectedSurahId}
               setSelectedPageId={setSelectedPageId}
@@ -142,7 +138,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
             <Juz
               juzs={filteredJuzs}
               chapters={chapters}
-              theme={theme}
               selectedJuzId={selectedJuzId}
               setSelectedJuzId={setSelectedJuzId}
               setSelectedPageId={setSelectedPageId}
@@ -155,7 +150,6 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
             <Page
               pages={filteredPages}
               chapters={chapters}
-              theme={theme}
               selectedPageId={selectedPageId}
               setSelectedPageId={setSelectedPageId}
               setSelectedJuzId={setSelectedJuzId}

--- a/app/shared/surah-sidebar/Juz.tsx
+++ b/app/shared/surah-sidebar/Juz.tsx
@@ -11,7 +11,6 @@ interface JuzSummary {
 interface Props {
   juzs: JuzSummary[];
   chapters: Chapter[];
-  theme: string;
   selectedJuzId: string | null;
   setSelectedJuzId: (id: string) => void;
   setSelectedPageId: (id: string) => void;
@@ -22,7 +21,6 @@ interface Props {
 const Juz = ({
   juzs,
   chapters,
-  theme,
   selectedJuzId,
   setSelectedJuzId,
   setSelectedPageId,
@@ -48,21 +46,15 @@ const Juz = ({
             }}
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
-                ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
-                : theme === 'light'
-                  ? 'bg-white shadow hover:bg-slate-50'
-                  : 'bg-slate-800 shadow hover:bg-slate-700'
+                ? 'bg-accent text-white shadow-lg shadow-accent/30'
+                : 'bg-surface text-primary hover:bg-accent/10 shadow'
             }`}
           >
             <div
               className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg shadow transition-colors ${
                 isActive
-                  ? theme === 'light'
-                    ? 'bg-gray-100 text-teal-600'
-                    : 'bg-slate-700 text-teal-400'
-                  : theme === 'light'
-                    ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                    : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                  ? 'bg-surface text-accent'
+                  : 'bg-surface text-accent group-hover:bg-accent/10'
               }`}
             >
               {juz.number}
@@ -71,15 +63,7 @@ const Juz = ({
               <p className={`font-semibold ${isActive ? 'text-white' : 'text-primary'}`}>
                 Juz {juz.number}
               </p>
-              <p
-                className={`text-xs ${
-                  isActive
-                    ? 'text-white/90'
-                    : theme === 'light'
-                      ? 'text-slate-600'
-                      : 'text-slate-400'
-                }`}
-              >
+              <p className={`text-xs ${isActive ? 'text-white/90' : 'text-muted'}`}>
                 {juz.surahRange}
               </p>
             </div>

--- a/app/shared/surah-sidebar/Page.tsx
+++ b/app/shared/surah-sidebar/Page.tsx
@@ -5,7 +5,6 @@ import { getJuzByPage, getSurahByPage } from '@/lib/utils/surah-navigation';
 interface Props {
   pages: number[];
   chapters: Chapter[];
-  theme: string;
   selectedPageId: string | null;
   setSelectedPageId: (id: string) => void;
   setSelectedJuzId: (id: string) => void;
@@ -16,7 +15,6 @@ interface Props {
 const Page = ({
   pages,
   chapters,
-  theme,
   selectedPageId,
   setSelectedPageId,
   setSelectedJuzId,
@@ -41,21 +39,15 @@ const Page = ({
             }}
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
-                ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
-                : theme === 'light'
-                  ? 'bg-white shadow hover:bg-slate-50'
-                  : 'bg-slate-800 shadow hover:bg-slate-700'
+                ? 'bg-accent text-white shadow-lg shadow-accent/30'
+                : 'bg-surface text-primary hover:bg-accent/10 shadow'
             }`}
           >
             <div
               className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg shadow transition-colors ${
                 isActive
-                  ? theme === 'light'
-                    ? 'bg-gray-100 text-teal-600'
-                    : 'bg-slate-700 text-teal-400'
-                  : theme === 'light'
-                    ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                    : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                  ? 'bg-surface text-accent'
+                  : 'bg-surface text-accent group-hover:bg-accent/10'
               }`}
             >
               {p}

--- a/app/shared/surah-sidebar/Surah.tsx
+++ b/app/shared/surah-sidebar/Surah.tsx
@@ -4,7 +4,6 @@ import { getJuzByPage } from '@/lib/utils/surah-navigation';
 
 interface Props {
   chapters: Chapter[];
-  theme: string;
   selectedSurahId: string | null;
   setSelectedSurahId: (id: string) => void;
   setSelectedPageId: (id: string) => void;
@@ -15,7 +14,6 @@ interface Props {
 
 const Surah = ({
   chapters,
-  theme,
   selectedSurahId,
   setSelectedSurahId,
   setSelectedPageId,
@@ -41,21 +39,15 @@ const Surah = ({
             }}
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
-                ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
-                : theme === 'light'
-                  ? 'bg-white shadow hover:bg-slate-50'
-                  : 'bg-slate-800 shadow hover:bg-slate-700'
+                ? 'bg-accent text-white shadow-lg shadow-accent/30'
+                : 'bg-surface text-primary hover:bg-accent/10 shadow'
             }`}
           >
             <div
               className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg shadow transition-colors ${
                 isActive
-                  ? theme === 'light'
-                    ? 'bg-gray-100 text-teal-600'
-                    : 'bg-slate-700 text-teal-400'
-                  : theme === 'light'
-                    ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                    : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                  ? 'bg-surface text-accent'
+                  : 'bg-surface text-accent group-hover:bg-accent/10'
               }`}
             >
               {chapter.id}
@@ -70,11 +62,7 @@ const Surah = ({
             </div>
             <p
               className={`font-amiri text-xl font-bold transition-colors ${
-                isActive
-                  ? 'text-white'
-                  : theme === 'light'
-                    ? 'text-muted group-hover:text-teal-600'
-                    : 'text-muted group-hover:text-teal-400'
+                isActive ? 'text-white' : 'text-muted group-hover:text-accent'
               }`}
             >
               {chapter.name_arabic}

--- a/app/shared/surah-sidebar/components/SidebarTabs.tsx
+++ b/app/shared/surah-sidebar/components/SidebarTabs.tsx
@@ -10,15 +10,10 @@ interface Props {
   activeTab: 'Surah' | 'Juz' | 'Page';
   setActiveTab: (tab: 'Surah' | 'Juz' | 'Page') => void;
   prepareForTabSwitch: (tab: 'Surah' | 'Juz' | 'Page') => void;
-  theme: string;
 }
 
-const SidebarTabs = ({ tabs, activeTab, setActiveTab, prepareForTabSwitch, theme }: Props) => (
-  <div
-    className={`flex items-center p-1 rounded-full ${
-      theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'
-    }`}
-  >
+const SidebarTabs = ({ tabs, activeTab, setActiveTab, prepareForTabSwitch }: Props) => (
+  <div className="flex items-center p-1 rounded-full bg-surface">
     {tabs.map(({ key, label }) => (
       <button
         key={key}
@@ -27,13 +22,7 @@ const SidebarTabs = ({ tabs, activeTab, setActiveTab, prepareForTabSwitch, theme
           setActiveTab(key);
         }}
         className={`w-1/3 px-4 py-2 text-sm font-semibold rounded-full transition-colors ${
-          activeTab === key
-            ? theme === 'light'
-              ? 'bg-white text-slate-900 shadow'
-              : 'bg-slate-700 text-white shadow'
-            : theme === 'light'
-              ? 'text-slate-400 hover:text-slate-700'
-              : 'text-slate-400 hover:text-white'
+          activeTab === key ? 'bg-surface text-primary shadow' : 'text-muted hover:bg-accent/10'
         }`}
       >
         {label}


### PR DESCRIPTION
## Summary
- remove ThemeContext usage from Surah sidebar components
- switch sidebar tabs and lists to semantic color tokens

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`
- toggled `.dark` class in JSDOM to verify token colors


------
https://chatgpt.com/codex/tasks/task_b_68a2ef2eca64832fa62d82d804dc4e7b