### PR TITLE
refactor: replace secondary tokens

### DIFF
--- a/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
+++ b/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
@@ -137,7 +137,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="h-6 w-6 text-secondary"
+            className="h-6 w-6 text-muted"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -96,7 +96,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="h-6 w-6 text-secondary"
+            className="h-6 w-6 text-muted"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -108,7 +108,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
         <h2 className="text-lg font-bold text-center flex-grow text-primary">Manage Tafsirs</h2>
         <button
           onClick={handleReset}
-          className="p-2 rounded-full focus-visible:outline-none transition-colors text-secondary hover:bg-hover hover:text-primary"
+          className="p-2 rounded-full focus-visible:outline-none transition-colors text-muted hover:bg-hover hover:text-primary"
           title="Reset to Default"
         >
           <RotateCcw size={20} />
@@ -118,7 +118,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
       <div className="flex-1 flex flex-col min-h-0">
         {loading && (
           <div className="flex items-center justify-center p-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-secondary" />
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-border" />
           </div>
         )}
 

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirSearch.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirSearch.tsx
@@ -10,7 +10,7 @@ interface TafsirSearchProps {
 
 export const TafsirSearch: React.FC<TafsirSearchProps> = ({ searchTerm, setSearchTerm }) => (
   <div className="relative">
-    <Search className="h-5 w-5 absolute left-3 top-1/2 -translate-y-1/2 text-secondary" />
+    <Search className="h-5 w-5 absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
     <input
       type="text"
       placeholder="Search tafsirs (exact match)..."

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationSearch.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationSearch.tsx
@@ -13,13 +13,13 @@ export const TranslationSearch: React.FC<TranslationSearchProps> = ({
   setSearchTerm,
 }) => (
   <div className="relative">
-    <Search className="h-4 w-4 absolute left-3.5 top-1/2 -translate-y-1/2 text-secondary" />
+    <Search className="h-4 w-4 absolute left-3.5 top-1/2 -translate-y-1/2 text-muted" />
     <input
       type="text"
       placeholder="Search by name or style..."
       value={searchTerm}
       onChange={(e) => setSearchTerm(e.target.value)}
-      className="w-full pl-10 pr-4 py-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent transition border bg-interactive border-border text-primary placeholder-secondary"
+      className="w-full pl-10 pr-4 py-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent transition border bg-interactive border-border text-primary placeholder-muted"
     />
   </div>
 );

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
@@ -73,9 +73,7 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
             key={t.id}
             onClick={() => setActiveId(t.id)}
             className={`flex-1 text-center py-3 px-5 rounded-full text-sm font-semibold transition-colors whitespace-nowrap ${
-              activeId === t.id
-                ? 'bg-surface shadow text-primary'
-                : 'text-secondary hover:text-primary'
+              activeId === t.id ? 'bg-surface shadow text-primary' : 'text-muted hover:text-primary'
             }`}
           >
             {t.name}

--- a/app/shared/resource-panel/ResourceTabs.tsx
+++ b/app/shared/resource-panel/ResourceTabs.tsx
@@ -32,7 +32,7 @@ export const ResourceTabs: React.FC<ResourceTabsProps> = ({
       disabled={!canScrollLeft}
       className={`p-1 rounded-full mr-2 transition-colors ${
         canScrollLeft
-          ? 'text-secondary hover:text-primary hover:bg-hover'
+          ? 'text-muted hover:text-primary hover:bg-hover'
           : 'text-muted cursor-not-allowed'
       }`}
     >
@@ -46,7 +46,7 @@ export const ResourceTabs: React.FC<ResourceTabsProps> = ({
           className={`flex-shrink-0 px-3 py-1 text-sm font-semibold border-b-2 transition-colors flex items-center justify-center ${
             activeFilter === lang
               ? 'border-accent text-accent'
-              : 'border-transparent text-secondary hover:text-primary hover:border-border'
+              : 'border-transparent text-muted hover:text-primary hover:border-border'
           }`}
         >
           {lang}
@@ -58,7 +58,7 @@ export const ResourceTabs: React.FC<ResourceTabsProps> = ({
       disabled={!canScrollRight}
       className={`p-1 rounded-full ml-2 transition-colors ${
         canScrollRight
-          ? 'text-secondary hover:text-primary hover:bg-hover'
+          ? 'text-muted hover:text-primary hover:bg-hover'
           : 'text-muted cursor-not-allowed'
       }`}
     >


### PR DESCRIPTION
## Summary
- replace `text-secondary` with `text-muted`
- replace `border-secondary` with `border-border`
- update placeholders to drop secondary token usage

## Testing
- `npm install`
- `npm run format`
- `npm run lint` *(fails: Avoid theme conditionals in className, @typescript-eslint/no-empty-object-type)*
- `npm run check` *(fails: Avoid theme conditionals in className, @typescript-eslint/no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_b_68a33697465c832fa30dbb39d1596991