### PR TITLE
fix: replace destructive token with error tokens

### DIFF
--- a/STYLING.md
+++ b/STYLING.md
@@ -58,7 +58,7 @@ colors: {
 - `muted` - Secondary text and subdued elements
 - `border` - Border colors
 - `interactive` - Interactive element backgrounds
-- `destructive` - Error/danger states
+- `error` - Error/danger states
 
 ### Usage Examples
 

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
@@ -141,9 +141,9 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
         )}
 
         {error && (
-          <div className="mx-4 mt-4 p-4 rounded-lg border bg-destructive/10 border-destructive/20 text-destructive">
+          <div className="mx-4 mt-4 p-4 rounded-lg border bg-error/10 border-error/20 text-error">
             <div className="flex items-center space-x-2">
-              <AlertCircle className="h-5 w-5 text-destructive" />
+              <AlertCircle className="h-5 w-5 text-error" />
               <span className="text-sm">{error}</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- replace `destructive` classes in translation panel with semantic `error` tokens
- document `error` token for error/danger states in styling guide

## Testing
- `npm run format`
- `npm run lint`
- `npm run audit-styles`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68a336c2e9ac832f86c2ca80ea1c67e6