### PR TITLE
refactor: replace teal utilities with tokens

### DIFF
--- a/app/(features)/bookmarks/components/CreateFolderModal.tsx
+++ b/app/(features)/bookmarks/components/CreateFolderModal.tsx
@@ -59,7 +59,7 @@ export const CreateFolderModal = ({ isOpen, onClose }: CreateFolderModalProps) =
                 <button
                   type="submit"
                   disabled={!folderName.trim()}
-                  className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-on-accent hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Create Folder
                 </button>

--- a/app/(features)/bookmarks/page.tsx
+++ b/app/(features)/bookmarks/page.tsx
@@ -76,7 +76,7 @@ const ContentHeader = ({ onNewFolderClick }: { onNewFolderClick: () => void }) =
     <div className="flex items-center space-x-2">
       <button
         onClick={onNewFolderClick}
-        className="flex items-center space-x-2 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover"
+        className="flex items-center space-x-2 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent hover:bg-accent-hover"
       >
         <PlusIcon size={16} />
         <span>New Folder</span>

--- a/app/(features)/home/components/SurahTab.tsx
+++ b/app/(features)/home/components/SurahTab.tsx
@@ -30,7 +30,7 @@ export default function SurahTab({ searchQuery }: SurahTabProps) {
   if (allSurahs.length === 0) {
     return (
       <div className="flex justify-center py-10 col-span-full">
-        <Spinner className="h-6 w-6 text-emerald-600" />
+        <Spinner className="h-6 w-6 text-accent" />
       </div>
     );
   }

--- a/app/(features)/home/components/VerseOfDay.tsx
+++ b/app/(features)/home/components/VerseOfDay.tsx
@@ -86,7 +86,7 @@ export default function VerseOfDay() {
   if (loading) {
     content = (
       <div className="flex justify-center py-8">
-        <Spinner className="h-6 w-6 text-emerald-600" />
+        <Spinner className="h-6 w-6 text-accent" />
       </div>
     );
   } else if (error) {
@@ -113,7 +113,7 @@ export default function VerseOfDay() {
                   w.uthmani
                 )}
                 {w.en && (
-                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1 py-0.5 rounded bg-surface text-white text-xs whitespace-nowrap opacity-0 group-hover:opacity-100">
+                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1 py-0.5 rounded bg-surface text-primary text-xs whitespace-nowrap opacity-0 group-hover:opacity-100">
                     {w.en}
                   </span>
                 )}

--- a/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
+++ b/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
@@ -28,7 +28,7 @@ export function JuzVerseList({
         <Verse key={v.id} verse={v} />
       ))}
       <div ref={loadMoreRef} className="py-4 text-center">
-        {isValidating && <span className="text-teal-600">{t('loading')}</span>}
+        {isValidating && <span className="text-accent">{t('loading')}</span>}
         {isReachingEnd && <span className="text-muted">{t('end_of_juz')}</span>}
       </div>
     </>

--- a/app/(features)/juz/[juzId]/page.tsx
+++ b/app/(features)/juz/[juzId]/page.tsx
@@ -85,7 +85,7 @@ export default function JuzPage({ params }: { params: Promise<{ juzId: string }>
         <div className="w-full relative">
           {juzId ? (
             isLoading ? (
-              <div className="text-center py-20 text-teal-600">{t('loading')}</div>
+              <div className="text-center py-20 text-accent">{t('loading')}</div>
             ) : error ? (
               <div className="text-center py-20 text-red-600 bg-red-50 p-4 rounded-lg">{error}</div>
             ) : juzError ? (
@@ -104,7 +104,7 @@ export default function JuzPage({ params }: { params: Promise<{ juzId: string }>
               </>
             )
           ) : (
-            <div className="text-center py-20 text-teal-600">{t('loading')}</div>
+            <div className="text-center py-20 text-accent">{t('loading')}</div>
           )}
         </div>
       </main>

--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -86,7 +86,7 @@ export default function PagePage({ params }: PagePageProps) {
         <div className="w-full relative">
           {isLoading ? (
             <div className="flex justify-center py-20">
-              <Spinner className="h-8 w-8 text-teal-600" />
+              <Spinner className="h-8 w-8 text-accent" />
             </div>
           ) : error ? (
             <div className="text-center py-20 text-red-600 bg-red-50 p-4 rounded-lg">{error}</div>
@@ -98,7 +98,7 @@ export default function PagePage({ params }: PagePageProps) {
                 </React.Fragment>
               ))}
               <div ref={loadMoreRef} className="py-4 text-center space-x-2">
-                {isValidating && <Spinner className="inline h-5 w-5 text-teal-600" />}
+                {isValidating && <Spinner className="inline h-5 w-5 text-accent" />}
                 {isReachingEnd && <span className="text-muted">{t('end_of_page')}</span>}
               </div>
             </>

--- a/app/(features)/search/page.tsx
+++ b/app/(features)/search/page.tsx
@@ -30,7 +30,7 @@ function SearchContent() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {query && <h1 className="text-2xl font-bold mb-6">Search results for: {query}</h1>}
-      {loading && <p className="text-teal-600">Loading...</p>}
+      {loading && <p className="text-accent">Loading...</p>}
       {error && <p className="text-red-600 mb-4">{error}</p>}
       {!loading && verses.length === 0 && !error && query && (
         <p className="text-muted">No verses found.</p>

--- a/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
@@ -69,7 +69,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
       <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
-          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 hover:bg-hover"
+          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-hover"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/app/(features)/surah/[surahId]/components/FontSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/FontSettings.tsx
@@ -30,7 +30,7 @@ export const FontSettings = ({
   return (
     <CollapsibleSection
       title={t('font_setting')}
-      icon={<FontSettingIcon size={20} className="text-teal-700" />}
+      icon={<FontSettingIcon size={20} className="text-accent" />}
       isLast
       isOpen={isOpen}
       onToggle={onToggle || (() => {})}
@@ -39,7 +39,7 @@ export const FontSettings = ({
         <div>
           <div className="flex justify-between mb-1 text-sm">
             <label className="text-primary">{t('arabic_font_size')}</label>
-            <span className="font-semibold text-teal-700">{settings.arabicFontSize}</span>
+            <span className="font-semibold text-accent">{settings.arabicFontSize}</span>
           </div>
           <input
             type="range"
@@ -53,7 +53,7 @@ export const FontSettings = ({
         <div>
           <div className="flex justify-between mb-1 text-sm">
             <label className="text-primary">{t('translation_font_size')}</label>
-            <span className="font-semibold text-teal-700">{settings.translationFontSize}</span>
+            <span className="font-semibold text-accent">{settings.translationFontSize}</span>
           </div>
           <input
             type="range"

--- a/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
@@ -16,7 +16,7 @@ export const ReadingSettings = ({ isOpen = false, onToggle }: ReadingSettingsPro
   return (
     <CollapsibleSection
       title="Mushaf Settings"
-      icon={<BookReaderIcon size={20} className="text-teal-700" />}
+      icon={<BookReaderIcon size={20} className="text-accent" />}
       isLast={false}
       isOpen={isOpen}
       onToggle={onToggle || (() => {})}

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -170,7 +170,7 @@ export const SettingsSidebar = ({
           <button
             aria-label="Back"
             onClick={() => setSettingsOpen(false)}
-            className="p-2 rounded-full hover:bg-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 lg:hidden"
+            className="p-2 rounded-full hover:bg-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
           >
             <ArrowLeftIcon size={18} />
           </button>

--- a/app/(features)/surah/[surahId]/components/SidebarContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SidebarContent.tsx
@@ -67,7 +67,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
           <button
             aria-label="Back"
             onClick={onClose}
-            className="p-2 rounded-full hover:bg-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 lg:hidden"
+            className="p-2 rounded-full hover:bg-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
           >
             <ArrowLeftIcon size={18} />
           </button>

--- a/app/(features)/surah/[surahId]/components/SurahVerseList.tsx
+++ b/app/(features)/surah/[surahId]/components/SurahVerseList.tsx
@@ -29,7 +29,7 @@ export const SurahVerseList = ({
     <div className="w-full relative">
       {isLoading ? (
         <div className="flex justify-center py-20">
-          <Spinner className="h-8 w-8 text-teal-600" />
+          <Spinner className="h-8 w-8 text-accent" />
         </div>
       ) : error ? (
         <div className="text-center py-20 text-red-600 bg-red-50 p-4 rounded-lg">{error}</div>
@@ -41,7 +41,7 @@ export const SurahVerseList = ({
             </React.Fragment>
           ))}
           <div ref={loadMoreRef} className="py-4 text-center space-x-2">
-            {isValidating && <Spinner className="inline h-5 w-5 text-teal-600" />}
+            {isValidating && <Spinner className="inline h-5 w-5 text-accent" />}
             {isReachingEnd && <span className="text-muted">{t('end_of_surah')}</span>}
           </div>
         </>

--- a/app/(features)/surah/[surahId]/components/TafsirSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TafsirSettings.tsx
@@ -32,7 +32,7 @@ export const TafsirSettings = ({
       {showTafsirSetting && (
         <CollapsibleSection
           title={t('tafsir_setting')}
-          icon={<BookReaderIcon size={20} className="text-teal-700" />}
+          icon={<BookReaderIcon size={20} className="text-accent" />}
           isLast={true}
           isOpen={isOpen}
           onToggle={onToggle || (() => {})}
@@ -46,7 +46,7 @@ export const TafsirSettings = ({
             <div>
               <div className="flex justify-between mb-1 text-sm">
                 <label className="text-primary">{t('tafsir_font_size')}</label>
-                <span className="font-semibold text-teal-700">{settings.tafsirFontSize}</span>
+                <span className="font-semibold text-accent">{settings.tafsirFontSize}</span>
               </div>
               <input
                 type="range"

--- a/app/(features)/surah/[surahId]/components/arabic-font-panel/ArabicFontSearch.tsx
+++ b/app/(features)/surah/[surahId]/components/arabic-font-panel/ArabicFontSearch.tsx
@@ -21,7 +21,7 @@ export const ArabicFontSearch: React.FC<ArabicFontSearchProps> = ({
         placeholder="Search for a font..."
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
-        className="w-full pl-10 pr-4 py-3 rounded-lg border text-sm placeholder-muted focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors bg-surface border-border text-foreground"
+        className="w-full pl-10 pr-4 py-3 rounded-lg border text-sm placeholder-muted focus:outline-none focus:ring-2 focus:ring-accent transition-colors bg-surface border-border text-foreground"
       />
     </div>
   </div>

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/AyahNavigation.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/AyahNavigation.tsx
@@ -21,17 +21,17 @@ export const AyahNavigation = ({
   currentSurah,
   ayahId,
 }: AyahNavigationProps) => (
-  <div className="flex items-center justify-between rounded-full bg-teal-600 text-white p-2">
+  <div className="flex items-center justify-between rounded-full bg-accent text-on-accent p-2">
     <button
       aria-label="Previous"
       disabled={!prev}
       onClick={() => navigate(prev)}
-      className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
+      className="flex items-center px-4 py-2 rounded-full bg-accent text-on-accent disabled:opacity-50 font-bold"
     >
       <div className="flex items-center justify-center w-8 h-8 rounded-full bg-surface mr-2">
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className="h-5 w-5 text-teal-600"
+          className="h-5 w-5 text-accent"
           viewBox="0 0 20 20"
           fill="currentColor"
         >
@@ -43,7 +43,7 @@ export const AyahNavigation = ({
         </svg>
       </div>
     </button>
-    <div className="text-white font-bold">
+    <div className="text-on-accent font-bold">
       {currentSurah ? (
         <>
           <span className="font-bold">{currentSurah.name}</span> : {ayahId}
@@ -56,12 +56,12 @@ export const AyahNavigation = ({
       aria-label="Next"
       disabled={!next}
       onClick={() => navigate(next)}
-      className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
+      className="flex items-center px-4 py-2 rounded-full bg-accent text-on-accent disabled:opacity-50 font-bold"
     >
       <div className="flex items-center justify-center w-8 h-8 rounded-full bg-surface ml-2">
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className="h-5 w-5 text-teal-600"
+          className="h-5 w-5 text-accent"
           viewBox="0 0 20 20"
           fill="currentColor"
         >

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
@@ -34,10 +34,10 @@ export const TafsirPanels = ({ verseKey, tafsirIds }: TafsirPanelsProps) => {
               className={`grid transition-all duration-300 ease-in-out ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
             >
               <div className="overflow-hidden">
-                <div className="bg-teal-50  rounded-md p-4 max-h-64 overflow-y-auto">
+                <div className="bg-accent/10  rounded-md p-4 max-h-64 overflow-y-auto">
                   {loading[id] ? (
                     <div className="flex justify-center py-4">
-                      <Spinner className="h-5 w-5 text-teal-600" />
+                      <Spinner className="h-5 w-5 text-accent" />
                     </div>
                   ) : (
                     <div

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
@@ -86,7 +86,7 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
         <h2 className="mb-8 text-center text-xl font-bold text-primary">{activeTab?.name}</h2>
         {loading[activeId] ? (
           <div className="flex justify-center py-4">
-            <Spinner className="h-5 w-5 text-emerald-600" />
+            <Spinner className="h-5 w-5 text-accent" />
           </div>
         ) : (
           <div

--- a/app/shared/HeaderSearch.tsx
+++ b/app/shared/HeaderSearch.tsx
@@ -18,7 +18,7 @@ const HeaderSearch = ({ query, setQuery, placeholder, onKeyDown }: Props) => {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={onKeyDown}
-        className="w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 bg-surface text-primary border border-border placeholder:text-muted"
+        className="w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-accent transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-accent bg-surface text-primary border border-border placeholder:text-muted"
       />
     </div>
   );

--- a/app/shared/components/SearchInput.tsx
+++ b/app/shared/components/SearchInput.tsx
@@ -28,7 +28,7 @@ export const SearchInput = ({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         onKeyDown={onKeyDown}
-        className={`w-full pl-9 pr-3 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-teal-500 transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-teal-600 ${searchBarClasses}`}
+        className={`w-full pl-9 pr-3 py-2 rounded-lg focus:outline-none focus:ring-1 focus:ring-accent transition-all duration-300 hover:shadow-lg hover:ring-1 hover:ring-accent ${searchBarClasses}`}
       />
     </div>
   );

--- a/app/shared/player/components/PlaybackOptionsModal.tsx
+++ b/app/shared/player/components/PlaybackOptionsModal.tsx
@@ -107,7 +107,7 @@ export default function PlaybackOptionsModal({ open, onClose, activeTab, setActi
               Cancel
             </button>
             <button
-              className="px-4 py-2 rounded-xl bg-accent text-white hover:opacity-90"
+              className="px-4 py-2 rounded-xl bg-accent text-on-accent hover:opacity-90"
               onClick={commit}
             >
               Apply

--- a/app/shared/player/components/PlayerOptions.tsx
+++ b/app/shared/player/components/PlayerOptions.tsx
@@ -5,9 +5,7 @@ import SpeedControl from './SpeedControl';
 import VolumeControl from './VolumeControl';
 import IconBtn from './IconBtn';
 
-interface Props {}
-
-export default function PlayerOptions({}: Props) {
+export default function PlayerOptions() {
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'reciter' | 'repeat'>('reciter');
   return (

--- a/app/shared/player/components/RepeatPanel.tsx
+++ b/app/shared/player/components/RepeatPanel.tsx
@@ -25,7 +25,7 @@ export default function RepeatPanel({
               onClick={() => setLocalRepeat({ ...localRepeat, mode: m })}
               className={`px-3 py-2 rounded-xl text-sm capitalize ${
                 localRepeat.mode === m
-                  ? 'bg-accent text-white'
+                  ? 'bg-accent text-on-accent'
                   : 'bg-interactive hover:bg-interactive'
               }`}
             >

--- a/app/shared/player/components/SpeedControl.tsx
+++ b/app/shared/player/components/SpeedControl.tsx
@@ -2,9 +2,7 @@ import React, { useRef, useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
 import { useAudio } from '@/app/shared/player/context/AudioContext';
 
-interface Props {}
-
-export default function SpeedControl({}: Props) {
+export default function SpeedControl() {
   const { playbackRate, setPlaybackRate } = useAudio();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -49,7 +47,7 @@ export default function SpeedControl({}: Props) {
               close();
             }}
             className={`w-full text-center text-sm p-1.5 rounded-md ${
-              playbackRate === speed ? 'bg-accent text-white' : 'hover:bg-interactive'
+              playbackRate === speed ? 'bg-accent text-on-accent' : 'hover:bg-interactive'
             }`}
           >
             {speed}x

--- a/app/shared/player/components/Timeline.tsx
+++ b/app/shared/player/components/Timeline.tsx
@@ -46,7 +46,7 @@ export default function Timeline({
               <Tooltip.Portal>
                 <Tooltip.Content
                   sideOffset={8}
-                  className="rounded-md text-white text-xs px-2 py-1 shadow bg-surface"
+                  className="rounded-md text-primary text-xs px-2 py-1 shadow bg-surface"
                 >
                   {elapsed}
                   <Tooltip.Arrow className="fill-surface" />

--- a/app/shared/player/components/TransportControls.tsx
+++ b/app/shared/player/components/TransportControls.tsx
@@ -26,10 +26,10 @@ export default function TransportControls({
         aria-label={isPlaying ? 'Pause' : 'Play'}
         onClick={togglePlay}
         disabled={!interactable}
-        className={`h-10 w-10 grid place-items-center rounded-full text-white hover:opacity-90 active:scale-95 transition ${
+        className={`h-10 w-10 grid place-items-center rounded-full hover:opacity-90 active:scale-95 transition ${
           interactable
-            ? 'bg-accent hover:bg-accent-hover'
-            : 'bg-disabled cursor-not-allowed opacity-60'
+            ? 'bg-accent text-on-accent hover:bg-accent-hover'
+            : 'bg-disabled cursor-not-allowed opacity-60 text-primary'
         }`}
       >
         {isPlaying ? <Pause /> : <Play />}

--- a/app/shared/player/components/VolumeControl.tsx
+++ b/app/shared/player/components/VolumeControl.tsx
@@ -3,9 +3,7 @@ import * as Slider from '@radix-ui/react-slider';
 import { Volume2, VolumeX } from 'lucide-react';
 import { useAudio } from '@/app/shared/player/context/AudioContext';
 
-interface Props {}
-
-export default function VolumeControl({}: Props) {
+export default function VolumeControl() {
   const { volume, setVolume } = useAudio();
   return (
     <div className="hidden lg:flex items-center gap-2 w-28">

--- a/app/shared/surah-sidebar/Juz.tsx
+++ b/app/shared/surah-sidebar/Juz.tsx
@@ -46,7 +46,7 @@ const Juz = ({
             }}
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
-                ? 'bg-accent text-white shadow-lg shadow-accent/30'
+                ? 'bg-accent text-on-accent shadow-lg shadow-accent/30'
                 : 'bg-surface text-primary hover:bg-accent/10 shadow'
             }`}
           >
@@ -60,10 +60,10 @@ const Juz = ({
               {juz.number}
             </div>
             <div>
-              <p className={`font-semibold ${isActive ? 'text-white' : 'text-primary'}`}>
+              <p className={`font-semibold ${isActive ? 'text-on-accent' : 'text-primary'}`}>
                 Juz {juz.number}
               </p>
-              <p className={`text-xs ${isActive ? 'text-white/90' : 'text-muted'}`}>
+              <p className={`text-xs ${isActive ? 'text-on-accent/90' : 'text-muted'}`}>
                 {juz.surahRange}
               </p>
             </div>

--- a/app/shared/surah-sidebar/Page.tsx
+++ b/app/shared/surah-sidebar/Page.tsx
@@ -39,7 +39,7 @@ const Page = ({
             }}
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
-                ? 'bg-accent text-white shadow-lg shadow-accent/30'
+                ? 'bg-accent text-on-accent shadow-lg shadow-accent/30'
                 : 'bg-surface text-primary hover:bg-accent/10 shadow'
             }`}
           >
@@ -52,7 +52,9 @@ const Page = ({
             >
               {p}
             </div>
-            <p className={`font-semibold ${isActive ? 'text-white' : 'text-primary'}`}>Page {p}</p>
+            <p className={`font-semibold ${isActive ? 'text-on-accent' : 'text-primary'}`}>
+              Page {p}
+            </p>
           </Link>
         </li>
       );

--- a/app/shared/surah-sidebar/Surah.tsx
+++ b/app/shared/surah-sidebar/Surah.tsx
@@ -39,7 +39,7 @@ const Surah = ({
             }}
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
-                ? 'bg-accent text-white shadow-lg shadow-accent/30'
+                ? 'bg-accent text-on-accent shadow-lg shadow-accent/30'
                 : 'bg-surface text-primary hover:bg-accent/10 shadow'
             }`}
           >
@@ -53,16 +53,16 @@ const Surah = ({
               {chapter.id}
             </div>
             <div className="flex-grow">
-              <p className={`font-bold ${isActive ? 'text-white' : 'text-primary'}`}>
+              <p className={`font-bold ${isActive ? 'text-on-accent' : 'text-primary'}`}>
                 {chapter.name_simple}
               </p>
-              <p className={`text-xs ${isActive ? 'text-white/80' : 'text-muted'}`}>
+              <p className={`text-xs ${isActive ? 'text-on-accent/80' : 'text-muted'}`}>
                 {chapter.revelation_place} • {chapter.verses_count} verses
               </p>
             </div>
             <p
               className={`font-amiri text-xl font-bold transition-colors ${
-                isActive ? 'text-white' : 'text-muted group-hover:text-accent'
+                isActive ? 'text-on-accent' : 'text-muted group-hover:text-accent'
               }`}
             >
               {chapter.name_arabic}

--- a/app/theme.css
+++ b/app/theme.css
@@ -4,6 +4,7 @@
   --color-text-muted: 107 114 128;
   --color-accent: 13 148 136;
   --color-accent-hover: 15 118 110;
+  --color-on-accent: 255 255 255;
   --color-border: 229 231 235;
 
   /* Interactive states */
@@ -41,6 +42,7 @@
   --color-text-muted: 156 163 175;
   --color-accent: 13 148 136;
   --color-accent-hover: 15 118 110;
+  --color-on-accent: 255 255 255;
   --color-border: 75 85 99;
 
   /* Interactive states */

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -15,6 +15,7 @@ const config = {
         border: 'rgb(var(--color-border) / <alpha-value>)',
         accent: 'rgb(var(--color-accent) / <alpha-value>)',
         'accent-hover': 'rgb(var(--color-accent-hover) / <alpha-value>)',
+        'on-accent': 'rgb(var(--color-on-accent) / <alpha-value>)',
         brand: '#009688',
 
         // Interactive states


### PR DESCRIPTION
## Summary
- replace teal and white utility classes with semantic accent tokens
- add `on-accent` semantic color and map to Tailwind
- ensure accent components use tokenized colors for better theming

## Testing
- `npm install`
- `npm run check` *(fails: Avoid theme conditionals in className. Use semantic tokens instead.)*

------
https://chatgpt.com/codex/tasks/task_b_68a336e68854832fa29ff56bbe03d24a