### PR TITLE
chore: clean up console logs

### DIFF
--- a/app/(features)/layout/context/HeaderVisibilityContext.tsx
+++ b/app/(features)/layout/context/HeaderVisibilityContext.tsx
@@ -33,23 +33,11 @@ export const HeaderVisibilityProvider = ({ children }: { children: React.ReactNo
       // For short content, require larger scroll delta to prevent shaking
       const minScrollDelta = maxScrollableHeight < 150 ? 20 : 5;
 
-      // Debug logs (remove after testing)
-      console.log({
-        currentY,
-        lastScrollY: lastScrollY.current,
-        maxScrollableHeight,
-        scrollDelta,
-        minScrollDelta,
-        scrollingDown: currentY > lastScrollY.current,
-      });
-
       if (scrollDelta > minScrollDelta) {
         // Hide header when scrolling down past threshold
         if (currentY > lastScrollY.current && currentY > 50) {
-          console.log('Setting header hidden to true');
           setIsHidden(true);
         } else if (currentY < lastScrollY.current) {
-          console.log('Setting header hidden to false');
           setIsHidden(false);
         }
       }

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -76,14 +76,18 @@ export const SettingsSidebar = ({
 
   // Function to handle section toggle with max 2 open rule and localStorage persistence
   const handleSectionToggle = (sectionId: string) => {
-    console.log('Toggling section:', sectionId, 'Current open:', openSections);
+    if (process.env.NODE_ENV === 'development') {
+      console.log('Toggling section:', sectionId, 'Current open:', openSections);
+    }
     setOpenSections((prev) => {
       let newState: string[];
 
       if (prev.includes(sectionId)) {
         // If section is open, close it
         newState = prev.filter((id) => id !== sectionId);
-        console.log('Closing section, new state:', newState);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Closing section, new state:', newState);
+        }
       } else {
         // If section is closed, open it
         if (prev.length >= 2) {
@@ -93,7 +97,9 @@ export const SettingsSidebar = ({
           // If less than 2 sections open, just add the new one
           newState = [...prev, sectionId];
         }
-        console.log('Opening section, new state:', newState);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Opening section, new state:', newState);
+        }
       }
 
       // Save to localStorage


### PR DESCRIPTION
## Summary
- guard section toggle logs behind development checks
- remove leftover debug logs from header visibility context

## Testing
- `npm run check` *(fails: token-rules/no-raw-color-classes in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68a33cdc0864832fbe919d4c6f8c74b2