### PR TITLE
feat: add surface and interactive tokens

### DIFF
--- a/app/theme.css
+++ b/app/theme.css
@@ -1,17 +1,27 @@
 :root {
   --color-background: 247 249 249;
+  --color-surface: 255 255 255;
   --color-foreground: 55 65 81;
+  --color-muted: 107 114 128;
   --color-accent: 13 148 136;
   --color-accent-hover: 15 118 110;
+  --color-interactive: 243 244 246;
+  --color-interactive-hover: 229 231 235;
   --color-border: 229 231 235;
+  --color-error: 220 38 38;
   --color-on-accent: 255 255 255;
 }
 
 .dark {
   --color-background: 26 32 44;
+  --color-surface: 45 55 72;
   --color-foreground: 209 213 219;
+  --color-muted: 156 163 175;
   --color-accent: 13 148 136;
   --color-accent-hover: 15 118 110;
+  --color-interactive: 55 65 81;
+  --color-interactive-hover: 75 85 99;
   --color-border: 75 85 99;
+  --color-error: 248 113 113;
   --color-on-accent: 255 255 255;
 }

--- a/design-system.json
+++ b/design-system.json
@@ -1,14 +1,24 @@
 {
   "colors": {
     "background": "#F7F9F9",
+    "surface": "#FFFFFF",
     "foreground": "#374151",
+    "muted": "#6B7280",
     "accent": "#0d9488",
     "accentHover": "#0f766e",
+    "interactive": "#F3F4F6",
+    "interactiveHover": "#E5E7EB",
     "border": "#e5e7eb",
+    "error": "#DC2626",
     "onAccent": "#ffffff",
     "backgroundDark": "#1a202c",
+    "surfaceDark": "#2d3748",
     "foregroundDark": "#d1d5db",
+    "mutedDark": "#9ca3af",
+    "interactiveDark": "#374151",
+    "interactiveHoverDark": "#4b5563",
     "borderDark": "#4b5563",
+    "errorDark": "#F87171",
     "onAccentDark": "#ffffff"
   },
   "spacing": {


### PR DESCRIPTION
## Summary
- add missing design tokens (surface, muted, interactive, error and variants)
- regenerate theme.css from design tokens

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: SurahListSidebar, Tafsir IndexPage, Surah IndexPage)*

------
https://chatgpt.com/codex/tasks/task_b_68a34737e9f4832f97aade3e13ab4936