### PR TITLE
style: replace legacy color tokens

### DIFF
--- a/app/(features)/tafsir/tafsir.css
+++ b/app/(features)/tafsir/tafsir.css
@@ -2,7 +2,7 @@
 .tafsir-content {
   font-family: var(--font-noto-sans-bengali), 'Noto Sans Bengali', sans-serif;
   line-height: 2.3;
-  color: var(--foreground);
+  color: rgb(var(--color-foreground));
   text-align: justify;
   word-spacing: normal;
   letter-spacing: 0.015em;
@@ -34,7 +34,7 @@
 .tafsir-content [lang='ar'] {
   font-size: 1.1em;
   font-weight: 500;
-  color: var(--accent);
+  color: rgb(var(--color-accent));
   background: rgba(13, 148, 136, 0.08);
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
@@ -59,7 +59,7 @@
 .tafsir-content i {
   font-style: normal;
   font-weight: 500;
-  color: var(--accent);
+  color: rgb(var(--color-accent));
   position: relative;
 }
 
@@ -72,7 +72,7 @@
 .tafsir-content strong,
 .tafsir-content b {
   font-weight: 700;
-  color: var(--foreground);
+  color: rgb(var(--color-foreground));
   font-family: var(--font-libre-baskerville), serif;
 }
 
@@ -84,16 +84,16 @@
   margin: 0.1em 0.1em 0 0;
   font-family: var(--font-libre-baskerville), serif;
   font-weight: 700;
-  color: var(--accent);
+  color: rgb(var(--color-accent));
 }
 
 /* Improved quote styling */
 .tafsir-content blockquote {
-  border-left: 4px solid var(--accent);
+  border-left: 4px solid rgb(var(--color-accent));
   padding-left: 1.5rem;
   margin: 2rem 0;
   font-style: italic;
-  color: var(--foreground);
+  color: rgb(var(--color-foreground));
   opacity: 0.9;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,8 +4,8 @@
 
 @layer base {
   body {
-    background: var(--background);
-    color: var(--foreground);
+    background: rgb(var(--color-background));
+    color: rgb(var(--color-foreground));
     font-family: Inter, sans-serif;
     margin: 0;
     -webkit-font-smoothing: antialiased;
@@ -37,7 +37,7 @@
 
   .card {
     @apply rounded-lg p-4 shadow-sm;
-    background: var(--background);
+    background: rgb(var(--color-background));
   }
 }
 
@@ -51,8 +51,8 @@ input[type='range'] {
   outline: none;
   background: linear-gradient(
     to right,
-    var(--accent) var(--value-percent, 0%),
-    var(--subtle-grey) var(--value-percent, 0%)
+    rgb(var(--color-accent)) var(--value-percent, 0%),
+    rgb(var(--color-border)) var(--value-percent, 0%)
   );
 }
 
@@ -61,8 +61,8 @@ input[type='range']::-webkit-slider-thumb {
   appearance: none;
   width: 16px;
   height: 16px;
-  background: var(--background);
-  border: 2px solid var(--border-color);
+  background: rgb(var(--color-background));
+  border: 2px solid rgb(var(--color-border));
   border-radius: 50%;
   cursor: pointer;
   margin-top: -5px;
@@ -72,8 +72,8 @@ input[type='range']::-webkit-slider-thumb {
 }
 
 input[type='range']::-webkit-slider-thumb:hover {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: rgb(var(--color-accent));
+  border-color: rgb(var(--color-accent));
 }
 
 /* ===== Custom Scrollbar Styles ===== */


### PR DESCRIPTION
## Summary
- use rgb(var(--color-*))) tokens in global styles
- update tafsir styles to new color token scheme

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: IndexPage tests for tafsir and surah)*

------
https://chatgpt.com/codex/tasks/task_b_68a3473811a8832f95ec22080d3d709f