### PR TITLE
feat: add design token validator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,13 @@ feat: add audio player
 Before submitting a pull request, run `npm run check` to lint, type-check and
 test your changes. See [AGENTS.md](AGENTS.md) for the full workflow.
 
+Validate that all `bg-*`, `text-*`, and `border-*` classes map to tokens in
+`design-system.json`:
+
+```bash
+npm run validate:tokens
+```
+
 ## Feature Scaffolding
 
 Use the generator to create a new feature folder with a page component and test:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check": "npm run format -- --check && npm run lint && npm run type-check && npm test",
     "generate:tokens": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/generate-tokens.ts",
     "generate-feature": "ts-node scripts/generateFeature.ts",
+    "validate:tokens": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validate-tokens.ts",
     "audit-styles": "npm run audit:theme && npm run audit:colors && npm run audit:classes",
     "audit:theme": "grep -r \"theme ===\" app/ && exit 1 || echo \"✅ No theme conditionals found\"",
     "audit:colors": "grep -r \"#[0-9a-fA-F]\" app/ --include=\"*.tsx\" --include=\"*.ts\" && exit 1 || echo \"✅ No hardcoded colors found\"",

--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -1,0 +1,122 @@
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+
+function kebabCase(str: string): string {
+  return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+const designPath = path.resolve(__dirname, '..', 'design-system.json');
+const design = JSON.parse(readFileSync(designPath, 'utf8'));
+const allowedTokens = new Set(
+  Object.keys(design.colors)
+    .filter((key) => !key.endsWith('Dark'))
+    .map(kebabCase)
+);
+
+const ignore: Record<string, Set<string>> = {
+  text: new Set([
+    'center',
+    'left',
+    'right',
+    'justify',
+    'start',
+    'end',
+    'xs',
+    'sm',
+    'base',
+    'lg',
+    'xl',
+    '2xl',
+    '3xl',
+    '4xl',
+    '5xl',
+    '6xl',
+    '7xl',
+    '8xl',
+    '9xl',
+  ]),
+  bg: new Set([
+    'cover',
+    'contain',
+    'center',
+    'fixed',
+    'local',
+    'no-repeat',
+    'repeat',
+    'repeat-x',
+    'repeat-y',
+    'auto',
+    'bottom',
+    'top',
+    'left',
+    'right',
+  ]),
+  border: new Set([
+    '0',
+    '2',
+    '4',
+    '8',
+    't',
+    'b',
+    'l',
+    'r',
+    'x',
+    'y',
+    'solid',
+    'dashed',
+    'double',
+    'collapse',
+    'separate',
+  ]),
+};
+
+const tokenRegex = /(bg|text|border)-([a-zA-Z0-9-]+)/g;
+
+function getFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', '.git', '.next', 'public'].includes(entry.name)) {
+        continue;
+      }
+      files.push(...getFiles(fullPath));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const rootDir = path.resolve(__dirname, '..');
+const files = getFiles(rootDir);
+const undefinedTokens: Record<string, Set<string>> = {};
+
+for (const file of files) {
+  const content = readFileSync(file, 'utf8');
+  let match: RegExpExecArray | null;
+  while ((match = tokenRegex.exec(content))) {
+    const prefix = match[1];
+    const token = match[2];
+    if (ignore[prefix]?.has(token)) continue;
+    if (!allowedTokens.has(token)) {
+      const key = `${prefix}-${token}`;
+      undefinedTokens[key] ||= new Set();
+      undefinedTokens[key].add(path.relative(rootDir, file));
+    }
+  }
+}
+
+if (Object.keys(undefinedTokens).length > 0) {
+  console.error('Undefined design tokens found:');
+  for (const [token, files] of Object.entries(undefinedTokens)) {
+    console.error(`  ${token}`);
+    for (const f of files) {
+      console.error(`    - ${f}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log('All token classes are defined in design-system.json');


### PR DESCRIPTION
## Summary
- add script to ensure bg-/text-/border- classes map to design tokens
- expose validator via npm script
- document token validation workflow

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: renders list of surah links, renders list of tafsir links)*
- `npm run validate:tokens` *(fails: undefined tokens like bg-surface, text-muted)*

------
https://chatgpt.com/codex/tasks/task_b_68a34738c8d0832faab8e2b463929303