### PR TITLE
feat: add storybook theme switcher and stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/nextjs';
 
 const config: StorybookConfig = {
   stories: ['../app/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-essentials'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-themes'],
   framework: {
     name: '@storybook/nextjs',
     options: {},

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,10 +1,22 @@
 import type { Preview } from '@storybook/react';
 import '../app/globals.css';
+import '../app/theme.css';
+
+import { withThemeByClassName } from '@storybook/addon-themes';
 
 const preview: Preview = {
   parameters: {
     layout: 'centered',
   },
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: '',
+        dark: 'dark',
+      },
+      defaultTheme: 'light',
+    }),
+  ],
 };
 
 export default preview;

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Run Storybook to iterate on UI components in isolation:
 npm run storybook
 ```
 
-This launches an interactive component workbench useful for AI-assisted design sessions.
+This launches an interactive component workbench with a light/dark theme toggle driven by semantic tokens. Use it for quick AI-assisted design validation.
 
 The CI workflow uploads this report as an artifact.
 

--- a/app/(features)/home/components/SurahCard.stories.tsx
+++ b/app/(features)/home/components/SurahCard.stories.tsx
@@ -20,6 +20,11 @@ const sampleSurah: Surah = {
 };
 
 export const Default: Story = {
+  render: (args) => (
+    <div className="p-4 bg-surface">
+      <SurahCard {...args} />
+    </div>
+  ),
   args: {
     surah: sampleSurah,
   },

--- a/app/shared/player/components/ReciterPanel.stories.tsx
+++ b/app/shared/player/components/ReciterPanel.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import ReciterPanel from './ReciterPanel';
+
+const meta: Meta<typeof ReciterPanel> = {
+  title: 'Player/ReciterPanel',
+  component: ReciterPanel,
+};
+export default meta;
+
+type Story = StoryObj<typeof ReciterPanel>;
+
+function ReciterPanelStory() {
+  const [reciter, setReciter] = useState('1');
+  return (
+    <div className="p-4 bg-surface">
+      <ReciterPanel localReciter={reciter} setLocalReciter={setReciter} />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ReciterPanelStory />,
+};

--- a/app/shared/player/components/RepeatPanel.stories.tsx
+++ b/app/shared/player/components/RepeatPanel.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import RepeatPanel from './RepeatPanel';
+import type { RepeatOptions } from '../types';
+
+const meta: Meta<typeof RepeatPanel> = {
+  title: 'Player/RepeatPanel',
+  component: RepeatPanel,
+};
+export default meta;
+
+type Story = StoryObj<typeof RepeatPanel>;
+
+function RepeatPanelStory() {
+  const [repeat, setRepeat] = useState<RepeatOptions>({ mode: 'off' });
+  const [warning, setWarning] = useState<string | null>(null);
+  return (
+    <div className="p-4 bg-surface">
+      <RepeatPanel
+        localRepeat={repeat}
+        setLocalRepeat={setRepeat}
+        rangeWarning={warning}
+        setRangeWarning={setWarning}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <RepeatPanelStory />,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@storybook/addon-essentials": "^8.4.3",
+        "@storybook/addon-themes": "^8.4.3",
         "@storybook/nextjs": "^8.4.3",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.6.4",
@@ -5117,6 +5118,23 @@
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-8.6.14.tgz",
+      "integrity": "sha512-/HJCgskA3OFGectuoLEBQ3JX1nQhE7lnpSv5gH13CWyyaMEk/mP8JYF1uO25YQqwGuSgL2gaEox+aK7UmglAmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "ts-dedent": "^2.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "whatwg-fetch": "^3.6.20",
     "@storybook/nextjs": "^8.4.3",
     "@storybook/addon-essentials": "^8.4.3",
+    "@storybook/addon-themes": "^8.4.3",
     "storybook": "^8.4.3"
   }
 }


### PR DESCRIPTION
## Summary
- configure Storybook to toggle light and dark themes
- add SurahCard, ReciterPanel, and RepeatPanel stories using semantic tokens
- document Storybook theme toggle for quick design validation

## Testing
- `npm run lint`
- `npm run check` *(fails: IndexPage.test.tsx unable to find Al-Fatihah)*

------
https://chatgpt.com/codex/tasks/task_b_68a34739ac34832f949541f940e0862d