### PR TITLE
fix: update interactive hover colors

### DIFF
--- a/app/(features)/home/components/HomeSearch.tsx
+++ b/app/(features)/home/components/HomeSearch.tsx
@@ -33,7 +33,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
         {shortcutSurahs.map((name) => (
           <button
             key={name}
-            className="px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 bg-surface border border-border text-foreground hover:bg-hover hover:shadow-md"
+            className="px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 bg-surface border border-border text-foreground hover:bg-interactive-hover hover:shadow-md"
           >
             {name}
           </button>

--- a/app/(features)/home/components/HomeTabs.tsx
+++ b/app/(features)/home/components/HomeTabs.tsx
@@ -15,7 +15,7 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
     <section id="surahs" className="py-20 max-w-screen-2xl mx-auto w-full">
       <div className="flex justify-between items-center mb-8 content-visibility-auto animate-fade-in-up animation-delay-600">
         <h2 className="text-3xl font-bold text-foreground ">All Surahs</h2>
-        <div className="flex items-center p-1 sm:p-2 rounded-full bg-hover">
+        <div className="flex items-center p-1 sm:p-2 rounded-full bg-interactive">
           <button
             onClick={() => setActiveTab('Surah')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${

--- a/app/(features)/home/components/PageTab.tsx
+++ b/app/(features)/home/components/PageTab.tsx
@@ -13,7 +13,7 @@ export default function PageTab() {
           className="group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up bg-surface/60"
         >
           <div className="flex items-center space-x-4">
-            <div className="flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors bg-hover text-accent group-hover:bg-accent/10">
+            <div className="flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors bg-interactive text-accent group-hover:bg-accent/10">
               {page}
             </div>
             <h3 className="font-semibold text-lg text-foreground">Page {page}</h3>

--- a/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
@@ -69,7 +69,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
       <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
-          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-hover"
+          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-interactive-hover"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -87,7 +87,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
         </h2>
         <button
           onClick={handleReset}
-          className="p-2 rounded-full focus-visible:outline-none transition-colors text-foreground hover:bg-hover"
+          className="p-2 rounded-full focus-visible:outline-none transition-colors text-foreground hover:bg-interactive-hover"
           title="Reset to Default"
         >
           <RotateCcw size={20} />
@@ -117,7 +117,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
               {/* Font Type Toggle - Uthmani/Indopak */}
               <div className="sticky top-0 z-10 py-4 border-b bg-surface/95 backdrop-blur-sm border-border">
                 <div className="px-4">
-                  <div className="flex items-center p-1 rounded-full bg-hover">
+                  <div className="flex items-center p-1 rounded-full bg-interactive">
                     <button
                       onClick={() => setActiveFilter('Uthmani')}
                       className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${

--- a/app/(features)/surah/[surahId]/components/SidebarContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SidebarContent.tsx
@@ -75,7 +75,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
           <div className="w-8" />
         </header>
         <div className="flex-grow p-4 space-y-4">
-          <div className="flex items-center p-1 rounded-full mb-4 bg-hover">
+          <div className="flex items-center p-1 rounded-full mb-4 bg-interactive">
             <button
               onClick={() => onTabClick('translation')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
@@ -131,7 +131,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
           )}
         </div>
         <div className="p-4">
-          <div className="flex items-center p-1 rounded-full bg-hover">
+          <div className="flex items-center p-1 rounded-full bg-interactive">
             <button
               onClick={() => setTheme('light')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${

--- a/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
+++ b/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
@@ -96,7 +96,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
       <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
-          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-hover"
+          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-interactive-hover"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -92,7 +92,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
       <header className="flex items-center p-4 border-b border-border">
         <button
           onClick={onClose}
-          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-hover"
+          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent hover:bg-interactive-hover"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -108,7 +108,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
         <h2 className="text-lg font-bold text-center flex-grow text-foreground">Manage Tafsirs</h2>
         <button
           onClick={handleReset}
-          className="p-2 rounded-full focus-visible:outline-none transition-colors text-muted hover:bg-hover hover:text-foreground"
+          className="p-2 rounded-full focus-visible:outline-none transition-colors text-muted hover:bg-interactive-hover hover:text-foreground"
           title="Reset to Default"
         >
           <RotateCcw size={20} />

--- a/app/shared/resource-panel/ResourceTabs.tsx
+++ b/app/shared/resource-panel/ResourceTabs.tsx
@@ -32,7 +32,7 @@ export const ResourceTabs: React.FC<ResourceTabsProps> = ({
       disabled={!canScrollLeft}
       className={`p-1 rounded-full mr-2 transition-colors ${
         canScrollLeft
-          ? 'text-muted hover:text-foreground hover:bg-hover'
+          ? 'text-muted hover:text-foreground hover:bg-interactive-hover'
           : 'text-muted cursor-not-allowed'
       }`}
     >
@@ -58,7 +58,7 @@ export const ResourceTabs: React.FC<ResourceTabsProps> = ({
       disabled={!canScrollRight}
       className={`p-1 rounded-full ml-2 transition-colors ${
         canScrollRight
-          ? 'text-muted hover:text-foreground hover:bg-hover'
+          ? 'text-muted hover:text-foreground hover:bg-interactive-hover'
           : 'text-muted cursor-not-allowed'
       }`}
     >


### PR DESCRIPTION
## Summary
- use `hover:bg-interactive-hover` on resource tabs navigation
- apply `bg-interactive` to home and surah settings tabs
- swap shortcut button hover colors with interactive tokens

## Testing
- `npm run check` *(fails: IndexPage.test.tsx, IndexPage.test.tsx (tafsir))*

------
https://chatgpt.com/codex/tasks/task_b_68a353514de4832f85417feb12fb1d70