### PR TITLE
fix: use semantic accent color in 404 link

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,7 +7,10 @@ export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
       <h1 className="text-2xl font-semibold mb-4">{t('page_not_found')}</h1>
-      <Link href="/" className="text-teal-600 hover:underline">
+      <Link
+        href="/"
+        className="text-accent hover:text-accent-hover focus:text-accent-hover hover:underline"
+      >
         {t('home')}
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- replace hardcoded teal styling on not-found link with semantic accent token
- add hover and focus accent-hover tokens for accessible state colors

## Testing
- `npm install`
- `npm run format -- app/not-found.tsx`
- `npm run lint -- --file app/not-found.tsx`
- `npm run check` *(fails: IndexPage.test.tsx)*
- `npm test` *(fails: IndexPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a35627be80832fae6882864c89a412