### PR TITLE
fix: use surface background for selection list

### DIFF
--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationSelectionList.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationSelectionList.tsx
@@ -37,7 +37,7 @@ export const TranslationSelectionList: React.FC<TranslationSelectionListProps> =
         </span>
       )}
     </h2>
-    <div className="space-y-2 min-h-[60px] rounded-lg p-3 bg-interactive border border-border">
+    <div className="space-y-2 min-h-[60px] rounded-lg p-3 bg-surface border border-border">
       {orderedSelection.length === 0 ? (
         <p className="text-center text-sm py-4 text-muted font-medium">No translations selected</p>
       ) : (


### PR DESCRIPTION
## Summary
- use surface background for translation selections

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: IndexPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a362ef6250832fa7cde96185534e2a