### PR TITLE
style: refine interactive backgrounds

### DIFF
--- a/STYLING.md
+++ b/STYLING.md
@@ -130,6 +130,10 @@ Primary Button
   Secondary Button
 </button>
 
+Use `bg-surface` for the default state of neutral interactive elements. Apply
+`hover:bg-interactive-hover` or `active:bg-interactive` to provide visual
+feedback on hover or active states.
+
 Form Inputs
 <input className="bg-background border border-border text-foreground placeholder:text-foreground/50 focus:ring-2 focus:ring-accent/20" />
 

--- a/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
@@ -117,7 +117,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
               {/* Font Type Toggle - Uthmani/Indopak */}
               <div className="sticky top-0 z-10 py-4 border-b bg-surface/95 backdrop-blur-sm border-border">
                 <div className="px-4">
-                  <div className="flex items-center p-1 rounded-full bg-interactive">
+                  <div className="flex items-center p-1 rounded-full bg-surface">
                     <button
                       onClick={() => setActiveFilter('Uthmani')}
                       className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -176,7 +176,7 @@ export const SettingsSidebar = ({
           <button
             aria-label="Back"
             onClick={() => setSettingsOpen(false)}
-            className="p-2 rounded-full hover:bg-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
+            className="p-2 rounded-full hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
           >
             <ArrowLeftIcon size={18} />
           </button>
@@ -184,7 +184,7 @@ export const SettingsSidebar = ({
           <div className="w-8" />
         </header>
         <div className="flex-grow p-4 space-y-4">
-          <div className="flex items-center p-1 rounded-full mb-4 bg-interactive">
+          <div className="flex items-center p-1 rounded-full mb-4 bg-surface">
             <button
               onClick={() => handleTabClick('translation')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
@@ -240,7 +240,7 @@ export const SettingsSidebar = ({
           )}
         </div>
         <div className="p-4">
-          <div className="flex items-center p-1 rounded-full bg-interactive">
+          <div className="flex items-center p-1 rounded-full bg-surface">
             <button
               onClick={() => setTheme('light')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${

--- a/app/(features)/surah/[surahId]/components/SidebarContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SidebarContent.tsx
@@ -67,7 +67,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
           <button
             aria-label="Back"
             onClick={onClose}
-            className="p-2 rounded-full hover:bg-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
+            className="p-2 rounded-full hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
           >
             <ArrowLeftIcon size={18} />
           </button>
@@ -75,7 +75,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
           <div className="w-8" />
         </header>
         <div className="flex-grow p-4 space-y-4">
-          <div className="flex items-center p-1 rounded-full mb-4 bg-interactive">
+          <div className="flex items-center p-1 rounded-full mb-4 bg-surface">
             <button
               onClick={() => onTabClick('translation')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
@@ -131,7 +131,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
           )}
         </div>
         <div className="p-4">
-          <div className="flex items-center p-1 rounded-full bg-interactive">
+          <div className="flex items-center p-1 rounded-full bg-surface">
             <button
               onClick={() => setTheme('light')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${

--- a/app/shared/player/components/IconBtn.tsx
+++ b/app/shared/player/components/IconBtn.tsx
@@ -13,7 +13,7 @@ export default function IconBtn({
       className={`h-9 w-9 grid place-items-center rounded-full transition focus:outline-none focus:ring-2 ${
         disabled
           ? 'opacity-40 cursor-not-allowed'
-          : 'hover:-translate-y-px active:scale-95 active:bg-surface/10 text-foreground focus:ring-accent/35 hover:text-accent hover:bg-interactive'
+          : 'hover:-translate-y-px active:scale-95 active:bg-surface/10 text-foreground focus:ring-accent/35 hover:text-accent hover:bg-interactive-hover'
       } ${className}`}
     >
       <span className="[&>*]:h-[18px] [&>*]:w-[18px] [&>*]:stroke-[1.75]">{children}</span>

--- a/app/shared/player/components/PlaybackOptionsModal.tsx
+++ b/app/shared/player/components/PlaybackOptionsModal.tsx
@@ -62,7 +62,9 @@ export default function PlaybackOptionsModal({ open, onClose, activeTab, setActi
           <button
             onClick={() => setActiveTab('reciter')}
             className={`px-3 py-1.5 rounded-full text-sm ${
-              activeTab === 'reciter' ? 'bg-accent/10 text-accent' : 'hover:bg-interactive'
+              activeTab === 'reciter'
+                ? 'bg-accent/10 text-accent'
+                : 'bg-surface hover:bg-interactive-hover'
             }`}
           >
             <span className="inline-flex items-center gap-2">
@@ -73,7 +75,9 @@ export default function PlaybackOptionsModal({ open, onClose, activeTab, setActi
           <button
             onClick={() => setActiveTab('repeat')}
             className={`px-3 py-1.5 rounded-full text-sm ${
-              activeTab === 'repeat' ? 'bg-accent/10 text-accent' : 'hover:bg-interactive'
+              activeTab === 'repeat'
+                ? 'bg-accent/10 text-accent'
+                : 'bg-surface hover:bg-interactive-hover'
             }`}
           >
             <span className="inline-flex items-center gap-2">
@@ -101,7 +105,7 @@ export default function PlaybackOptionsModal({ open, onClose, activeTab, setActi
           <div className="text-muted">Tips: Space • ←/→ seek • ↑/↓ volume</div>
           <div className="flex gap-2">
             <button
-              className="px-4 py-2 rounded-xl bg-interactive hover:bg-interactive text-foreground"
+              className="px-4 py-2 rounded-xl bg-surface hover:bg-interactive-hover text-foreground"
               onClick={onClose}
             >
               Cancel

--- a/app/shared/player/components/RepeatPanel.tsx
+++ b/app/shared/player/components/RepeatPanel.tsx
@@ -26,7 +26,7 @@ export default function RepeatPanel({
               className={`px-3 py-2 rounded-xl text-sm capitalize ${
                 localRepeat.mode === m
                   ? 'bg-accent text-on-accent'
-                  : 'bg-interactive hover:bg-interactive'
+                  : 'bg-surface hover:bg-interactive-hover'
               }`}
             >
               {m}

--- a/app/shared/player/components/SpeedControl.tsx
+++ b/app/shared/player/components/SpeedControl.tsx
@@ -24,7 +24,7 @@ export default function SpeedControl() {
               setOpen(false);
             }
           }}
-          className="h-9 w-14 grid place-items-center rounded-full text-xs font-bold transition focus:outline-none focus:ring-2 text-foreground focus:ring-accent/35 hover:bg-interactive"
+          className="h-9 w-14 grid place-items-center rounded-full text-xs font-bold transition focus:outline-none focus:ring-2 text-foreground focus:ring-accent/35 hover:bg-interactive-hover"
         >
           {playbackRate}x
         </button>
@@ -47,7 +47,7 @@ export default function SpeedControl() {
               close();
             }}
             className={`w-full text-center text-sm p-1.5 rounded-md ${
-              playbackRate === speed ? 'bg-accent text-on-accent' : 'hover:bg-interactive'
+              playbackRate === speed ? 'bg-accent text-on-accent' : 'hover:bg-interactive-hover'
             }`}
           >
             {speed}x

--- a/app/shared/player/components/Timeline.tsx
+++ b/app/shared/player/components/Timeline.tsx
@@ -33,7 +33,7 @@ export default function Timeline({
             onValueChange={([v]) => setSeek(v)}
             aria-label="Seek"
           >
-            <Slider.Track className="h-0.5 rounded-full relative w-full grow bg-interactive">
+            <Slider.Track className="h-0.5 rounded-full relative w-full grow bg-surface group-hover:bg-interactive-hover">
               <Slider.Range className="h-full rounded-full absolute bg-accent" />
             </Slider.Track>
             <Tooltip.Root>

--- a/app/shared/player/components/VolumeControl.tsx
+++ b/app/shared/player/components/VolumeControl.tsx
@@ -22,7 +22,7 @@ export default function VolumeControl() {
         }}
         aria-label="Volume"
       >
-        <Slider.Track className="h-0.5 rounded-full relative w-full grow bg-interactive">
+        <Slider.Track className="h-0.5 rounded-full relative w-full grow bg-surface group-hover:bg-interactive-hover">
           <Slider.Range className="h-full rounded-full absolute bg-accent" />
         </Slider.Track>
         <Slider.Thumb className="block h-3 w-3 rounded-full focus:outline-none ring-2 bg-background ring-accent" />


### PR DESCRIPTION
## Summary
- use surface background by default for player sliders, repeat mode buttons, and playback modal controls
- clean up surah settings containers to use `bg-surface` and interactive hover styles
- document interactive surface pattern in styling guide

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: renders list of tafsir links, renders list of surah links)*

------
https://chatgpt.com/codex/tasks/task_b_68a36300f2e4832f8d6cbefef9ab3708