### PR TITLE
fix: use interactive token for Juz badge

### DIFF
--- a/app/(features)/home/components/JuzTab.tsx
+++ b/app/(features)/home/components/JuzTab.tsx
@@ -21,7 +21,7 @@ export default function JuzTab() {
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
-              <div className="flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors bg-hover text-accent group-hover:bg-accent/10">
+              <div className="flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors bg-interactive text-accent group-hover:bg-accent/10">
                 {juz.number}
               </div>
               <div>


### PR DESCRIPTION
## Summary
- use interactive token for Juz badge background so it adapts to theme

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: renders list of surah links, renders list of tafsir links)*

------
https://chatgpt.com/codex/tasks/task_b_68a36305eab0832fac36098e34691636