### PR TITLE
fix: format toggle components

### DIFF
--- a/app/shared/surah-sidebar/components/SidebarTabs.tsx
+++ b/app/shared/surah-sidebar/components/SidebarTabs.tsx
@@ -22,7 +22,9 @@ const SidebarTabs = ({ tabs, activeTab, setActiveTab, prepareForTabSwitch }: Pro
           setActiveTab(key);
         }}
         className={`w-1/3 px-4 py-2 text-sm font-semibold rounded-full transition-colors ${
-          activeTab === key ? 'bg-surface text-foreground shadow' : 'text-muted hover:text-foreground hover:bg-surface/30'
+          activeTab === key
+            ? 'bg-surface text-foreground shadow'
+            : 'text-muted hover:text-foreground hover:bg-surface/30'
         }`}
       >
         {label}

--- a/app/shared/ui/TabToggle.tsx
+++ b/app/shared/ui/TabToggle.tsx
@@ -12,7 +12,12 @@ interface TabToggleProps {
 
 export const TabToggle: React.FC<TabToggleProps> = ({ options, value, onChange, className }) => {
   return (
-    <div className={cn('flex items-center p-1 rounded-full bg-interactive border border-border', className)}>
+    <div
+      className={cn(
+        'flex items-center p-1 rounded-full bg-interactive border border-border',
+        className
+      )}
+    >
       {options.map((option) => (
         <button
           key={option.value}

--- a/app/shared/ui/ThemeToggle.tsx
+++ b/app/shared/ui/ThemeToggle.tsx
@@ -32,7 +32,9 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({
   // Tab-style variant
   if (variant === 'tabs') {
     return (
-      <div className={`flex items-center p-1 rounded-full bg-interactive border border-border ${className || ''}`}>
+      <div
+        className={`flex items-center p-1 rounded-full bg-interactive border border-border ${className || ''}`}
+      >
         <button
           onClick={() => handleThemeChange('light')}
           className={`flex items-center justify-center px-3 py-2 rounded-full text-sm font-semibold transition-colors ${


### PR DESCRIPTION
## Summary
- format SidebarTabs conditional classes
- reformat TabToggle className handling
- reformat ThemeToggle tab-style variant

## Testing
- `npm run lint`
- `npm run check` *(fails: Code style issues found in 13 files)*
- `npm test` *(fails: 3 failed, 128 passed, 131 total)*

------
https://chatgpt.com/codex/tasks/task_b_68a479e404bc832f8d575714e9db924e