### PR TITLE
fix: adjust adaptive header heights

### DIFF
--- a/lib/responsive.ts
+++ b/lib/responsive.ts
@@ -179,8 +179,8 @@ export const layoutPatterns = {
 
   // Header that adapts without breaking
   adaptiveHeader: {
-    mobile: 'fixed top-0 left-0 right-0 h-14 px-3 pt-safe',
-    tablet: 'fixed top-0 left-0 right-0 h-16 px-4 pt-safe',
+    mobile: 'fixed top-0 left-0 right-0 min-h-[calc(3.5rem+env(safe-area-inset-top))] px-3 pt-safe',
+    tablet: 'fixed top-0 left-0 right-0 min-h-[calc(4rem+env(safe-area-inset-top))] px-4 pt-safe',
     desktop: 'static h-20 px-6',
   },
 


### PR DESCRIPTION
## Summary
- account for safe-area inset in adaptive header heights on mobile and tablet

## Testing
- `npm run format lib/responsive.ts`
- `npm run lint`
- `npm run check` *(fails: Unable to find an accessible element with the role "button" and name "Back" in SettingsSidebar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d3e2fd30832fb3aecebbcc0b7dae