### PR TITLE
fix: improve player mobile layout

### DIFF
--- a/app/shared/player/__tests__/PlayerComponentsMobile.test.tsx
+++ b/app/shared/player/__tests__/PlayerComponentsMobile.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import PlayerOptions from '../components/PlayerOptions';
+import Timeline from '../components/Timeline';
+import { AudioProvider } from '../context/AudioContext';
+
+describe('Player components mobile layout', () => {
+  beforeAll(() => {
+    // Mock ResizeObserver used by Radix UI components
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    window.ResizeObserver = ResizeObserverMock as any;
+  });
+
+  test('renders options icon and progress bar on small viewports', async () => {
+    window.innerWidth = 375;
+    window.dispatchEvent(new Event('resize'));
+    await act(async () => {
+      render(
+        <AudioProvider>
+          <div>
+            <PlayerOptions />
+            <Timeline
+              current={0}
+              duration={10}
+              setSeek={() => {}}
+              interactable
+              elapsed="0:00"
+              total="0:10"
+            />
+          </div>
+        </AudioProvider>
+      );
+    });
+    expect(screen.getByLabelText('Options')).toBeInTheDocument();
+    expect(screen.getByLabelText('Seek')).toBeInTheDocument();
+  });
+});

--- a/app/shared/player/components/PlayerOptions.tsx
+++ b/app/shared/player/components/PlayerOptions.tsx
@@ -9,10 +9,11 @@ export default function PlayerOptions() {
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'reciter' | 'repeat'>('reciter');
   return (
-    <>
+    <div className="flex items-center gap-1 sm:gap-2">
       <SpeedControl />
       <VolumeControl />
       <IconBtn
+        className="shrink-0"
         aria-label="Options"
         onClick={() => {
           setActiveTab('reciter');
@@ -27,6 +28,6 @@ export default function PlayerOptions() {
         activeTab={activeTab}
         setActiveTab={setActiveTab}
       />
-    </>
+    </div>
   );
 }

--- a/app/shared/player/components/Timeline.tsx
+++ b/app/shared/player/components/Timeline.tsx
@@ -56,7 +56,7 @@ export default function Timeline({
           </Slider.Root>
         </Tooltip.Provider>
       </div>
-      <div className="hidden md:flex min-w-[88px] justify-between text-[11px] tabular-nums text-muted">
+      <div className="flex min-w-[72px] justify-between text-[10px] tabular-nums text-muted md:min-w-[88px] md:text-[11px]">
         <span aria-label="elapsed">{elapsed}</span>
         <span aria-label="duration">{total}</span>
       </div>


### PR DESCRIPTION
## Summary
- ensure player option buttons and icon stay visible on narrow screens
- show timeline timestamps on mobile with smaller typography
- add mobile viewport test for options icon and progress bar

## Testing
- `npm run check` *(fails: SettingsSidebar.test.tsx, TafsirVerseCard.test.tsx, SurahPage.test.tsx, JuzPage.test.tsx, IndexPage.test.tsx)*
- `npm test app/shared/player/__tests__/PlayerComponentsMobile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a824dedaf8832fa9f03e0060ae987b