### PR TITLE
feat: add settings sidebar to bookmark folders

### DIFF
--- a/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
+++ b/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
@@ -2,6 +2,11 @@
 
 import React, { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { LANGUAGE_CODES, LanguageCode } from '@/lib/text/languageCodes';
+import { useTranslationOptions } from '@/app/(features)/surah/hooks/useTranslationOptions';
+import { useSettings } from '@/app/providers/SettingsContext';
+import { SettingsSidebar } from '@/app/(features)/surah/[surahId]/components/SettingsSidebar';
 import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { BookmarkVerseSidebar } from '../components/BookmarkVerseSidebar';
 import { BookmarkListView } from '../components/BookmarkListView';
@@ -13,9 +18,14 @@ interface BookmarkFolderClientProps {
 
 export default function BookmarkFolderClient({ folderId }: BookmarkFolderClientProps) {
   const router = useRouter();
+  const { t } = useTranslation();
   const { isHidden } = useHeaderVisibility();
   const { folders } = useBookmarks();
+  const { translationOptions, wordLanguageOptions } = useTranslationOptions();
+  const { settings } = useSettings();
   const [activeVerseId, setActiveVerseId] = useState<string | undefined>(undefined);
+  const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);
+  const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
 
   // Find the current folder and its bookmarks
   const folder = useMemo(() => folders.find((f) => f.id === folderId), [folders, folderId]);
@@ -26,6 +36,22 @@ export default function BookmarkFolderClient({ folderId }: BookmarkFolderClientP
     if (activeVerseId) return bookmarks.filter((b) => b.verseId === activeVerseId);
     return bookmarks;
   }, [bookmarks, activeVerseId]);
+
+  const selectedTranslationName = useMemo(
+    () =>
+      translationOptions.find((o) => o.id === settings.translationId)?.name ||
+      t('select_translation'),
+    [settings.translationId, translationOptions, t]
+  );
+  const selectedWordLanguageName = useMemo(
+    () =>
+      wordLanguageOptions.find(
+        (o) =>
+          (LANGUAGE_CODES as Record<string, LanguageCode>)[o.name.toLowerCase()] ===
+          settings.wordLang
+      )?.name || t('select_word_translation'),
+    [settings.wordLang, wordLanguageOptions, t]
+  );
 
   if (!folder) {
     return (
@@ -41,33 +67,49 @@ export default function BookmarkFolderClient({ folderId }: BookmarkFolderClientP
   }
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] mt-16 bg-background text-foreground overflow-hidden">
-      {/* Left Sidebar - Bookmarked verses list (matches app sidebar sizing) */}
-      <aside className="w-80 lg:w-[20.7rem] h-full bg-surface border-r border-border flex-shrink-0">
-        <BookmarkVerseSidebar
-          bookmarks={bookmarks}
-          folder={folder}
-          activeVerseId={activeVerseId}
-          onVerseSelect={setActiveVerseId}
-          onBack={() => router.push('/bookmarks')}
-        />
-      </aside>
+    <>
+      <div className="flex h-[calc(100vh-4rem)] mt-16 bg-background text-foreground overflow-hidden">
+        {/* Left Sidebar - Bookmarked verses list (matches app sidebar sizing) */}
+        <aside className="w-80 lg:w-[20.7rem] h-full bg-surface border-r border-border flex-shrink-0">
+          <BookmarkVerseSidebar
+            bookmarks={bookmarks}
+            folder={folder}
+            activeVerseId={activeVerseId}
+            onVerseSelect={setActiveVerseId}
+            onBack={() => router.push('/bookmarks')}
+          />
+        </aside>
 
-      {/* Main Content - Verse display (reuse verse page styling) */}
-      <main className="flex-1 h-full overflow-hidden">
-        <div
-          className={`h-full overflow-y-auto px-4 sm:px-6 lg:px-8 pb-6 transition-all duration-300 ${
-            isHidden
-              ? 'pt-0'
-              : 'pt-[calc(3.5rem+env(safe-area-inset-top))] sm:pt-[calc(4rem+env(safe-area-inset-top))]'
-          }`}
-        >
-          <div className="max-w-4xl mx-auto">
-            <BookmarkListView bookmarks={displayBookmarks} folder={folder} showAsVerseList={true} />
+        {/* Main Content - Verse display (reuse verse page styling) */}
+        <main className="flex-1 h-full overflow-hidden lg:mr-[20.7rem]">
+          <div
+            className={`h-full overflow-y-auto px-4 sm:px-6 lg:px-8 pb-6 transition-all duration-300 ${
+              isHidden
+                ? 'pt-0'
+                : 'pt-[calc(3.5rem+env(safe-area-inset-top))] sm:pt-[calc(4rem+env(safe-area-inset-top))]'
+            }`}
+          >
+            <div className="max-w-4xl mx-auto">
+              <BookmarkListView
+                bookmarks={displayBookmarks}
+                folder={folder}
+                showAsVerseList={true}
+              />
+            </div>
           </div>
-        </div>
-      </main>
-    </div>
+        </main>
+      </div>
+      <SettingsSidebar
+        onTranslationPanelOpen={() => setIsTranslationPanelOpen(true)}
+        onWordLanguagePanelOpen={() => setIsWordPanelOpen(true)}
+        onReadingPanelOpen={() => {}}
+        selectedTranslationName={selectedTranslationName}
+        selectedWordLanguageName={selectedWordLanguageName}
+        isTranslationPanelOpen={isTranslationPanelOpen}
+        onTranslationPanelClose={() => setIsTranslationPanelOpen(false)}
+        isWordLanguagePanelOpen={isWordPanelOpen}
+        onWordLanguagePanelClose={() => setIsWordPanelOpen(false)}
+      />
+    </>
   );
 }
-

--- a/app/(features)/bookmarks/hooks/useBookmarkVerse.ts
+++ b/app/(features)/bookmarks/hooks/useBookmarkVerse.ts
@@ -32,7 +32,9 @@ export function useBookmarkVerse(verseId: string, createdAt: number): UseBookmar
 
         const isCompositeKey = /:/.test(verseId) || /[^0-9]/.test(verseId);
         const [verse, chapters] = await Promise.all([
-          isCompositeKey ? getVerseByKey(verseId, translationId) : getVerseById(verseId, translationId),
+          isCompositeKey
+            ? getVerseByKey(verseId, translationId)
+            : getVerseById(verseId, translationId),
           getChapters(),
         ]);
 

--- a/lib/api/verses.ts
+++ b/lib/api/verses.ts
@@ -172,10 +172,7 @@ export async function getVerseById(
 /**
  * Fetch a single verse by its composite key (e.g., "2:255").
  */
-export async function getVerseByKey(
-  verseKey: string,
-  translationId: number
-): Promise<Verse> {
+export async function getVerseByKey(verseKey: string, translationId: number): Promise<Verse> {
   const data = await apiFetch<{ verse: ApiVerse }>(
     `verses/by_key/${encodeURIComponent(verseKey)}`,
     { translations: translationId.toString(), fields: 'text_uthmani' },


### PR DESCRIPTION
## Summary
- integrate settings sidebar into bookmark folder view
- show selected translation and word language in settings
- offset main content to accommodate settings sidebar

## Testing
- `npm run lint`
- `npm run test` *(fails: ResponsiveVerseActions, responsive hooks, TafsirVerseCard, VerseOfDay, mobile-performance)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68a9d2c66b14832f8dcacc3af286989f