### PR TITLE
feat(bookmarks): specify verse page type for settings sidebar

### DIFF
--- a/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
+++ b/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
@@ -109,6 +109,7 @@ export default function BookmarkFolderClient({ folderId }: BookmarkFolderClientP
         onTranslationPanelClose={() => setIsTranslationPanelOpen(false)}
         isWordLanguagePanelOpen={isWordPanelOpen}
         onWordLanguagePanelClose={() => setIsWordPanelOpen(false)}
+        pageType="verse"
       />
     </>
   );


### PR DESCRIPTION
## Summary
- pass pageType="verse" to BookmarkFolderClient SettingsSidebar

## Testing
- `npm test` *(fails: Unable to find button 'play' in ResponsiveVerseActions, useBreakpoint SSR mismatch, etc.)*
- `npx eslint app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68a9d42a448c832f959b57f6adc8db59