### PR TITLE
feat: cache verse metadata in bookmarks

### DIFF
--- a/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
@@ -86,12 +86,9 @@ interface VerseItemProps {
 }
 
 const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) => {
-  const { bookmarkWithVerse, isLoading, error } = useBookmarkVerse(
-    bookmark.verseId,
-    bookmark.createdAt
-  );
+  const { bookmark: enrichedBookmark, isLoading, error } = useBookmarkVerse(bookmark);
 
-  if (isLoading || error || !bookmarkWithVerse.verse) {
+  if (isLoading || error || !enrichedBookmark.verseKey || !enrichedBookmark.surahName) {
     return (
       <li className="flex items-center justify-between py-2 px-2 rounded-lg animate-pulse">
         <div className="h-4 bg-interactive rounded w-24" />
@@ -100,8 +97,8 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) =
     );
   }
 
-  const verse = bookmarkWithVerse.verse;
-  const verseDisplayName = `${verse.surahNameEnglish}: ${verse.ayahNumber}`;
+  const ayahNumber = enrichedBookmark.verseKey.split(':')[1];
+  const verseDisplayName = `${enrichedBookmark.surahName}: ${ayahNumber}`;
 
   return (
     <li className="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-interactive-hover">

--- a/app/(features)/bookmarks/components/BookmarkVerseSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkVerseSidebar.tsx
@@ -19,12 +19,9 @@ interface VerseItemProps {
 }
 
 const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) => {
-  const { bookmarkWithVerse, isLoading, error } = useBookmarkVerse(
-    bookmark.verseId,
-    bookmark.createdAt
-  );
+  const { bookmark: enrichedBookmark, isLoading, error } = useBookmarkVerse(bookmark);
 
-  if (isLoading || error || !bookmarkWithVerse.verse) {
+  if (isLoading || error || !enrichedBookmark.verseKey || !enrichedBookmark.surahName) {
     return (
       <div className="p-3 border-b border-border">
         <div className="animate-pulse">
@@ -34,8 +31,7 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) =
       </div>
     );
   }
-
-  const verse = bookmarkWithVerse.verse;
+  const ayahNumber = enrichedBookmark.verseKey.split(':')[1];
 
   return (
     <button
@@ -46,13 +42,13 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) =
     >
       <div className="space-y-1">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-accent">{verse.verse_key}</span>
+          <span className="text-sm font-medium text-accent">{enrichedBookmark.verseKey}</span>
           <span className="text-xs text-muted">
             {new Date(bookmark.createdAt).toLocaleDateString()}
           </span>
         </div>
-        <p className="text-sm font-medium text-foreground truncate">{verse.surahNameEnglish}</p>
-        <p className="text-xs text-muted truncate">Ayah {verse.ayahNumber}</p>
+        <p className="text-sm font-medium text-foreground truncate">{enrichedBookmark.surahName}</p>
+        <p className="text-xs text-muted truncate">Ayah {ayahNumber}</p>
       </div>
     </button>
   );

--- a/app/(features)/bookmarks/hooks/useBookmarkVerse.ts
+++ b/app/(features)/bookmarks/hooks/useBookmarkVerse.ts
@@ -2,67 +2,45 @@ import { useState, useEffect } from 'react';
 import { getVerseById, getVerseByKey } from '@/lib/api/verses';
 import { getChapters } from '@/lib/api/chapters';
 import { useSettings } from '@/app/providers/SettingsContext';
-import { BookmarkWithVerse } from '@/types';
+import { useBookmarks } from '@/app/providers/BookmarkContext';
+import { Bookmark } from '@/types';
 
 interface UseBookmarkVerseReturn {
-  bookmarkWithVerse: BookmarkWithVerse;
+  bookmark: Bookmark;
   isLoading: boolean;
   error: string | null;
 }
 
-export function useBookmarkVerse(verseId: string, createdAt: number): UseBookmarkVerseReturn {
+export function useBookmarkVerse(bookmark: Bookmark): UseBookmarkVerseReturn {
   const { settings } = useSettings();
-  const [bookmarkWithVerse, setBookmarkWithVerse] = useState<BookmarkWithVerse>({
-    verseId,
-    createdAt,
-  });
+  const { updateBookmark } = useBookmarks();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchVerseData = async () => {
-      if (bookmarkWithVerse.verse) return; // Already have verse data
-
+      if (bookmark.verseText && bookmark.surahName && bookmark.translation && bookmark.verseKey) {
+        return;
+      }
       setIsLoading(true);
       setError(null);
 
       try {
-        // Get the default translation from settings
-        const translationId = settings.translationIds[0] || settings.translationId || 20; // Default to English
-
-        const isCompositeKey = /:/.test(verseId) || /[^0-9]/.test(verseId);
+        const translationId = settings.translationIds[0] || settings.translationId || 20;
+        const isCompositeKey = /:/.test(bookmark.verseId) || /[^0-9]/.test(bookmark.verseId);
         const [verse, chapters] = await Promise.all([
           isCompositeKey
-            ? getVerseByKey(verseId, translationId)
-            : getVerseById(verseId, translationId),
+            ? getVerseByKey(bookmark.verseId, translationId)
+            : getVerseById(bookmark.verseId, translationId),
           getChapters(),
         ]);
-
-        // Parse verse key to get surah info
         const [surahIdStr] = verse.verse_key.split(':');
-        const surahId = parseInt(surahIdStr);
-        const ayahNumber = parseInt(verse.verse_key.split(':')[1]);
-
-        // Find surah info
-        const surahInfo = chapters.find((chapter) => chapter.id === surahId);
-
-        setBookmarkWithVerse({
-          verseId,
-          createdAt,
-          verse: {
-            id: verse.id,
-            verse_key: verse.verse_key,
-            text_uthmani: verse.text_uthmani,
-            surahId,
-            ayahNumber,
-            surahNameEnglish: surahInfo?.name_simple || `Surah ${surahId}`,
-            surahNameArabic: surahInfo?.name_arabic || '',
-            translations: verse.translations?.map((t) => ({
-              id: t.id || t.resource_id,
-              resource_id: t.resource_id,
-              text: t.text,
-            })),
-          },
+        const surahInfo = chapters.find((chapter) => chapter.id === parseInt(surahIdStr));
+        updateBookmark(bookmark.verseId, {
+          verseKey: verse.verse_key,
+          verseText: verse.text_uthmani,
+          surahName: surahInfo?.name_simple || `Surah ${surahIdStr}`,
+          translation: verse.translations?.[0]?.text,
         });
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch verse');
@@ -72,13 +50,7 @@ export function useBookmarkVerse(verseId: string, createdAt: number): UseBookmar
     };
 
     fetchVerseData();
-  }, [
-    verseId,
-    settings.translationIds,
-    settings.translationId,
-    bookmarkWithVerse.verse,
-    createdAt,
-  ]);
+  }, [bookmark, settings.translationIds, settings.translationId, updateBookmark]);
 
-  return { bookmarkWithVerse, isLoading, error };
+  return { bookmark, isLoading, error };
 }

--- a/types/bookmark.ts
+++ b/types/bookmark.ts
@@ -1,31 +1,35 @@
+/**
+ * A saved verse reference with optional cached metadata for quick display.
+ */
 export interface Bookmark {
+  /** Numeric verse identifier. */
   verseId: string;
+  /** Timestamp when the bookmark was created. */
   createdAt: number; // Store as timestamp
+  /** Surah and ayah representation (e.g., `1:1`). */
+  verseKey?: string;
+  /** Arabic text of the verse. */
+  verseText?: string;
+  /** English name of the surah. */
+  surahName?: string;
+  /** Translation text for the verse. */
+  translation?: string;
 }
 
+/**
+ * A collection of bookmarks grouped under a user-defined folder.
+ */
 export interface Folder {
+  /** Unique identifier. */
   id: string; // Store as timestamp string or UUID
+  /** Display name for the folder. */
   name: string;
+  /** Bookmarks contained in the folder. */
   bookmarks: Bookmark[];
+  /** Creation timestamp. */
   createdAt: number;
+  /** Optional folder color. */
   color?: string; // Folder color customization
+  /** Optional folder icon. */
   icon?: string; // Folder icon customization
-}
-
-// Enhanced bookmark with verse content for display
-export interface BookmarkWithVerse extends Bookmark {
-  verse?: {
-    id: number;
-    verse_key: string;
-    text_uthmani: string;
-    surahId: number;
-    ayahNumber: number;
-    surahNameEnglish: string;
-    surahNameArabic: string;
-    translations?: Array<{
-      id: number;
-      resource_id: number;
-      text: string;
-    }>;
-  };
 }


### PR DESCRIPTION
## Summary
- extend bookmark type with verse metadata
- cache verse details when adding bookmarks
- render bookmarks using stored metadata

## Testing
- `npm run format`
- `npm run lint` *(fails: 'rerender' unused in lib/__tests__/focus.test.ts)*
- `npm run type-check`
- `npm run test` *(fails: multiple test suites failing, settings provider missing)*

------
https://chatgpt.com/codex/tasks/task_b_68a9fdd97888832f8a315b23b8bf716b