### PR TITLE
feat: add pinned and last-read verse tracking

### DIFF
--- a/app/(features)/bookmarks/pinned/page.tsx
+++ b/app/(features)/bookmarks/pinned/page.tsx
@@ -5,11 +5,14 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { BookmarksSidebar } from '../components/BookmarksSidebar';
 import { useRouter } from 'next/navigation';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
+import { useBookmarks } from '@/app/providers/BookmarkContext';
+import { BookmarkCard } from '../components/BookmarkCard';
 
 export default function PinnedAyahPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const router = useRouter();
   const { isHidden } = useHeaderVisibility();
+  const { pinnedVerses } = useBookmarks();
 
   React.useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -55,27 +58,35 @@ export default function PinnedAyahPage() {
                 <p className="text-muted">Your saved verses for quick reference</p>
               </div>
 
-              <div className="text-center py-16">
-                <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg
-                    className="w-8 h-8 text-muted"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-                    />
-                  </svg>
+              {pinnedVerses.length === 0 ? (
+                <div className="text-center py-16">
+                  <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-4">
+                    <svg
+                      className="w-8 h-8 text-muted"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+                      />
+                    </svg>
+                  </div>
+                  <h3 className="text-lg font-semibold text-foreground mb-2">No Pinned Verses</h3>
+                  <p className="text-muted max-w-md mx-auto">
+                    Pin your favorite verses while reading to access them quickly from here.
+                  </p>
                 </div>
-                <h3 className="text-lg font-semibold text-foreground mb-2">No Pinned Verses</h3>
-                <p className="text-muted max-w-md mx-auto">
-                  Pin your favorite verses while reading to access them quickly from here.
-                </p>
-              </div>
+              ) : (
+                <div>
+                  {pinnedVerses.map((bookmark) => (
+                    <BookmarkCard key={bookmark.verseId} bookmark={bookmark} folderId="pinned" />
+                  ))}
+                </div>
+              )}
             </motion.div>
           </div>
         </main>


### PR DESCRIPTION
## Summary
- track pinned verses and last-read progress in `BookmarkContext`
- render pinned bookmarks via `BookmarkCard`
- show reading progress for last read verses

## Testing
- `npm run lint`
- `npx jest app/providers/__tests__/BookmarkContext.test.tsx`
- `npm test` *(fails: ResponsiveVerseActions, SettingsSidebar, responsive hooks, and other suites)*

------
https://chatgpt.com/codex/tasks/task_b_68aa045b8788832fa1b23995ae85991e