### PR TITLE
fix: use router for bookmark navigation

### DIFF
--- a/app/(features)/bookmarks/components/BookmarkCard.tsx
+++ b/app/(features)/bookmarks/components/BookmarkCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { memo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Bookmark } from '@/types';
 import { useAudio } from '@/app/shared/player/context/AudioContext';
@@ -57,6 +58,8 @@ export const BookmarkCard = memo(function BookmarkCard({
 
   const { bookmark: enrichedBookmark, isLoading, error } = useBookmarkVerse(bookmark);
 
+  const router = useRouter();
+
   const handlePlayPause = useCallback(() => {
     if (playingId === Number(enrichedBookmark.verseId)) {
       audioRef.current?.pause();
@@ -107,8 +110,8 @@ export const BookmarkCard = memo(function BookmarkCard({
   const handleNavigateToVerse = useCallback(() => {
     if (!enrichedBookmark.verseKey) return;
     const [surahId] = enrichedBookmark.verseKey.split(':');
-    window.location.href = `/surah/${surahId}#verse-${enrichedBookmark.verseId}`;
-  }, [enrichedBookmark.verseKey, enrichedBookmark.verseId]);
+    router.push(`/surah/${surahId}#verse-${enrichedBookmark.verseId}`);
+  }, [enrichedBookmark.verseKey, enrichedBookmark.verseId, router]);
 
   // If we don't have verse data yet or it's loading, show a loading state
   if (

--- a/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Bookmark } from '@/types';
 import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useBookmarkVerse } from '../hooks/useBookmarkVerse';
@@ -116,6 +117,8 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedFolderId, setExpandedFolderId] = useState<string | null>(folder.id);
 
+  const router = useRouter();
+
   const filteredFolders = folders.filter((f) =>
     f.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
@@ -126,7 +129,7 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
 
   const handleFolderSelect = (folderId: string) => {
     if (folderId !== folder.id) {
-      window.location.href = `/bookmarks/${folderId}`;
+      router.push(`/bookmarks/${folderId}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- use Next.js router in bookmark card and folder sidebar
- avoid full page reloads when navigating to verses or folders

## Testing
- `npm run lint`
- `npm test` *(fails: Unable to find accessible elements, responsive hook expectations, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68aa09899764832f8aac9cd1b24da356