### PR TITLE
feat: persist folder color in sidebar

### DIFF
--- a/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
+++ b/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
@@ -118,7 +118,7 @@ export default function BookmarkFolderClient({ folderId }: BookmarkFolderClientP
                {' '}
         <BookmarkFolderSidebar
           bookmarks={bookmarks}
-          folder={{ id: folder.id, name: folder.name }}
+          folder={folder}
           activeVerseId={activeVerseId}
           onVerseSelect={(verseId) => {
             setActiveVerseId(verseId);

--- a/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Bookmark } from '@/types';
+import { Bookmark, Folder } from '@/types';
 import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useBookmarkVerse } from '../hooks/useBookmarkVerse';
 import { FolderIcon } from '@/app/shared/icons';
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils/cn';
 
 interface BookmarkFolderSidebarProps {
   bookmarks: Bookmark[];
-  folder: { id: string; name: string };
+  folder: Folder;
   activeVerseId?: string;
   onVerseSelect?: (verseId: string) => void;
   onBack?: () => void;

--- a/app/providers/__tests__/BookmarkContext.test.tsx
+++ b/app/providers/__tests__/BookmarkContext.test.tsx
@@ -33,6 +33,11 @@ const BookmarkTestComponent = () => {
       <button onClick={() => addBookmark('1:1', folders[0]?.id)}>Add Bookmark</button>
       <button onClick={() => removeBookmark('1:1', folders[0]?.id)}>Remove Bookmark</button>
       <button onClick={() => renameFolder(folders[0]?.id, 'New Name')}>Rename Folder</button>
+      <button
+        onClick={() => renameFolder(folders[0]?.id, folders[0]?.name || '', 'text-green-500')}
+      >
+        Set Color
+      </button>
       <button onClick={() => deleteFolder(folders[0]?.id)}>Delete Folder</button>
       <button onClick={() => togglePinned('1:1')}>Toggle Pin</button>
       <button onClick={() => setLastRead('1', 1)}>Set Last Read</button>
@@ -211,6 +216,27 @@ describe('BookmarkContext with Folders', () => {
       expect(localStorage.getItem(OLD_BOOKMARKS_STORAGE_KEY)).toBeNull();
       // Check that the new key has been set
       expect(localStorage.getItem(BOOKMARKS_STORAGE_KEY)).toBeDefined();
+    });
+  });
+
+  it('should persist folder color', async () => {
+    render(
+      <SettingsProvider>
+        <BookmarkProvider>
+          <BookmarkTestComponent />
+        </BookmarkProvider>
+      </SettingsProvider>
+    );
+
+    await userEvent.click(screen.getByText('Create Folder'));
+    await userEvent.click(screen.getByText('Set Color'));
+
+    await waitFor(() => {
+      const folders: Folder[] = JSON.parse(screen.getByTestId('folders').textContent || '[]');
+      expect(folders[0].color).toBe('text-green-500');
+
+      const stored: Folder[] = JSON.parse(localStorage.getItem(BOOKMARKS_STORAGE_KEY) || '[]');
+      expect(stored[0].color).toBe('text-green-500');
     });
   });
 });


### PR DESCRIPTION
## Summary
- use folder model including `color` in BookmarkFolderSidebar
- pass full folder object from BookmarkFolderClient
- test folder color persistence in BookmarkContext

## Testing
- `npm run lint`
- `npm test app/providers/__tests__/BookmarkContext.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68aa0da6c2a4832fa0135bbd51acbf82