### PR TITLE
feat: improve bookmark accessibility

### DIFF
--- a/app/(features)/bookmarks/components/BookmarkCard.tsx
+++ b/app/(features)/bookmarks/components/BookmarkCard.tsx
@@ -166,6 +166,8 @@ export const BookmarkCard = memo(function BookmarkCard({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       className="rounded-xl bg-surface border border-border p-6 mb-6 hover:border-accent/30 transition-colors"
+      role="article"
+      aria-label={`Bookmark for verse ${enrichedBookmark.verseKey} from ${enrichedBookmark.surahName}`}
     >
       {/* Header with surah info and timestamp */}
       <div className="flex items-center justify-between mb-4">

--- a/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
@@ -74,9 +74,10 @@ interface VerseItemProps {
   bookmark: Bookmark;
   isActive: boolean;
   onSelect: () => void;
+  onRemove: () => void;
 }
 
-const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) => {
+const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect, onRemove }) => {
   const { bookmark: enrichedBookmark, isLoading, error } = useBookmarkVerse(bookmark);
 
   if (isLoading || error || !enrichedBookmark.verseKey || !enrichedBookmark.surahName) {
@@ -101,7 +102,13 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, isActive, onSelect }) =
       >
         {verseDisplayName}
       </button>
-      <TrashIcon />
+      <button
+        onClick={onRemove}
+        className="p-1 rounded-full hover:bg-interactive-hover"
+        aria-label={`Remove bookmark ${verseDisplayName}`}
+      >
+        <TrashIcon />
+      </button>
     </li>
   );
 };
@@ -113,7 +120,7 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
   onVerseSelect,
   onBack,
 }) => {
-  const { folders } = useBookmarks();
+  const { folders, removeBookmark } = useBookmarks();
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedFolderId, setExpandedFolderId] = useState<string | null>(folder.id);
 
@@ -157,6 +164,7 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full py-3 pl-11 pr-4 text-foreground bg-surface border border-border rounded-full focus:outline-none focus:ring-2 focus:ring-accent transition-shadow"
+            aria-label="Search bookmark folders"
           />
         </div>
 
@@ -187,6 +195,11 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
                     }}
                     role="button"
                     tabIndex={0}
+                    aria-label={
+                      isCurrentFolder
+                        ? `Toggle folder ${folderItem.name}`
+                        : `Open folder ${folderItem.name}`
+                    }
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
@@ -231,6 +244,7 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
                               bookmark={bookmark}
                               isActive={activeVerseId === bookmark.verseId}
                               onSelect={() => onVerseSelect?.(bookmark.verseId)}
+                              onRemove={() => removeBookmark(String(bookmark.verseId), folder.id)}
                             />
                           ))}
                         </ul>

--- a/app/(features)/bookmarks/components/FolderCard.tsx
+++ b/app/(features)/bookmarks/components/FolderCard.tsx
@@ -46,9 +46,11 @@ export const FolderCard: React.FC<FolderCardProps> = React.memo(function FolderC
       <div className="flex items-center space-x-3">
         <div className="flex-shrink-0">
           {folder.icon ? (
-            <span className={cn('text-2xl', folder.color)}>{folder.icon}</span>
+            <span className={cn('text-2xl', folder.color)} aria-hidden="true">
+              {folder.icon}
+            </span>
           ) : (
-            <FolderIcon size={24} className={folder.color || 'text-accent'} />
+            <FolderIcon size={24} className={folder.color || 'text-accent'} aria-hidden="true" />
           )}
         </div>
         <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- label bookmark cards as articles for screen readers
- mark folder icons as decorative to prevent redundant narration
- add accessible controls in bookmark sidebar, including search field labeling and removable verse buttons

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check` (fails: Types of property 'verseId' are incompatible)
- `npm run test` (fails: Responsive System and ResponsiveVerseActions tests)


------
https://chatgpt.com/codex/tasks/task_b_68aa102d56fc832fb6ca88da3d9fab1d