### PR TITLE
perf: virtualize bookmark lists

### DIFF
--- a/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkFolderSidebar.tsx
@@ -7,6 +7,7 @@ import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useBookmarkVerse } from '../hooks/useBookmarkVerse';
 import { FolderIcon } from '@/app/shared/icons';
 import { cn } from '@/lib/utils/cn';
+import { FixedSizeList as List } from 'react-window';
 
 interface BookmarkFolderSidebarProps {
   bookmarks: Bookmark[];
@@ -90,10 +91,10 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, folderId, isActive, onS
 
   if (isLoading || error || !enrichedBookmark.verseKey || !enrichedBookmark.surahName) {
     return (
-      <li className="flex items-center justify-between py-2 px-2 rounded-lg animate-pulse">
+      <div className="flex items-center justify-between py-2 px-2 rounded-lg animate-pulse">
         <div className="h-4 bg-interactive rounded w-24"></div>
         <div className="w-5 h-5 bg-interactive rounded"></div>
-      </li>
+      </div>
     );
   }
 
@@ -101,7 +102,7 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, folderId, isActive, onS
   const verseDisplayName = `${enrichedBookmark.surahName}: ${ayahNumber}`;
 
   return (
-    <li className="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-interactive-hover">
+    <div className="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-interactive-hover">
       <button
         onClick={onSelect}
         className={`text-foreground hover:text-accent transition-colors ${
@@ -117,7 +118,7 @@ const VerseItem: React.FC<VerseItemProps> = ({ bookmark, folderId, isActive, onS
       >
         <TrashIcon />
       </button>
-    </li>
+    </div>
   );
 };
 
@@ -128,7 +129,7 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
   onVerseSelect,
   onBack,
 }) => {
-  const { folders, removeBookmark } = useBookmarks();
+  const { folders } = useBookmarks();
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedFolderId, setExpandedFolderId] = useState<string | null>(folder.id);
 
@@ -245,17 +246,26 @@ export const BookmarkFolderSidebar: React.FC<BookmarkFolderSidebarProps> = ({
                   <div className="px-4 pb-3">
                     <div className="border-t border-border pt-2">
                       {folderBookmarks.length > 0 ? (
-                        <ul className="space-y-1">
-                          {folderBookmarks.map((bookmark) => (
-                            <VerseItem
-                              key={bookmark.verseId}
-                              bookmark={bookmark}
-                              folderId={folder.id}
-                              isActive={activeVerseId === bookmark.verseId}
-                              onSelect={() => onVerseSelect?.(bookmark.verseId)}
-                            />
-                          ))}
-                        </ul>
+                        <List
+                          height={Math.min(200, folderBookmarks.length * 48)}
+                          width="100%"
+                          itemCount={folderBookmarks.length}
+                          itemSize={48}
+                        >
+                          {({ index, style }) => {
+                            const bookmark = folderBookmarks[index];
+                            return (
+                              <div style={style}>
+                                <VerseItem
+                                  bookmark={bookmark}
+                                  folderId={folder.id}
+                                  isActive={activeVerseId === bookmark.verseId}
+                                  onSelect={() => onVerseSelect?.(bookmark.verseId)}
+                                />
+                              </div>
+                            );
+                          }}
+                        </List>
                       ) : (
                         <p className="py-4 text-sm text-center text-muted">This folder is empty.</p>
                       )}

--- a/app/(features)/bookmarks/components/BookmarkListView.tsx
+++ b/app/(features)/bookmarks/components/BookmarkListView.tsx
@@ -5,6 +5,7 @@ import { Folder, Bookmark } from '@/types';
 import { motion } from 'framer-motion';
 import { ArrowLeftIcon } from '@/app/shared/icons';
 import { BookmarkCard } from './BookmarkCard';
+import { FixedSizeList as List } from 'react-window';
 
 interface BookmarkListViewProps {
   folder: Folder;
@@ -20,6 +21,16 @@ export const BookmarkListView = ({
   showAsVerseList = false,
 }: BookmarkListViewProps) => {
   const [bookmarks, setBookmarks] = useState(externalBookmarks || folder.bookmarks);
+  const [listHeight, setListHeight] = useState(0);
+
+  useEffect(() => {
+    const updateHeight = () => {
+      setListHeight(window.innerHeight - 200);
+    };
+    updateHeight();
+    window.addEventListener('resize', updateHeight);
+    return () => window.removeEventListener('resize', updateHeight);
+  }, []);
 
   // Update local state when external bookmarks change
   useEffect(() => {
@@ -37,42 +48,44 @@ export const BookmarkListView = ({
 
   // If showing as verse list (folder page), display verses like surah page
   if (showAsVerseList) {
-    return (
-      <div className="space-y-6">
-        {bookmarks.length > 0 ? (
-          bookmarks.map((bookmark) => (
-            <BookmarkCard
-              key={bookmark.verseId}
-              bookmark={bookmark}
-              folderId={folder.id}
-              onRemove={() => handleRemoveBookmark(bookmark.verseId)}
-            />
-          ))
-        ) : (
-          <div className="text-center py-16">
-            <div className="max-w-sm mx-auto">
-              <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg
-                  className="w-8 h-8 text-muted"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-                  />
-                </svg>
-              </div>
-              <h3 className="text-lg font-semibold text-foreground mb-2">No Bookmarks</h3>
-              <p className="text-muted mb-4">
-                This folder is empty. Add some bookmarked verses to see them here.
-              </p>
+    return bookmarks.length > 0 ? (
+      <List height={listHeight} width="100%" itemCount={bookmarks.length} itemSize={140}>
+        {({ index, style }) => {
+          const bookmark = bookmarks[index];
+          return (
+            <div style={style} className="px-0">
+              <BookmarkCard
+                bookmark={bookmark}
+                folderId={folder.id}
+                onRemove={() => handleRemoveBookmark(bookmark.verseId)}
+              />
             </div>
+          );
+        }}
+      </List>
+    ) : (
+      <div className="text-center py-16">
+        <div className="max-w-sm mx-auto">
+          <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              className="w-8 h-8 text-muted"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+              />
+            </svg>
           </div>
-        )}
+          <h3 className="text-lg font-semibold text-foreground mb-2">No Bookmarks</h3>
+          <p className="text-muted mb-4">
+            This folder is empty. Add some bookmarked verses to see them here.
+          </p>
+        </div>
       </div>
     );
   }
@@ -106,54 +119,52 @@ export const BookmarkListView = ({
       )}
 
       {/* Bookmark Cards */}
-      <div>
-        {bookmarks.length > 0 ? (
-          <div className="space-y-0">
-            {bookmarks.map((bookmark) => (
-              <BookmarkCard
-                key={bookmark.verseId}
-                bookmark={bookmark}
-                folderId={folder.id}
-                onRemove={() => handleRemoveBookmark(bookmark.verseId)}
-              />
-            ))}
-          </div>
-        ) : (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="text-center py-16"
-          >
-            <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg
-                className="w-8 h-8 text-muted"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+      {bookmarks.length > 0 ? (
+        <List height={listHeight} width="100%" itemCount={bookmarks.length} itemSize={180}>
+          {({ index, style }) => {
+            const bookmark = bookmarks[index];
+            return (
+              <div style={style} className="px-0">
+                <BookmarkCard
+                  bookmark={bookmark}
+                  folderId={folder.id}
+                  onRemove={() => handleRemoveBookmark(bookmark.verseId)}
                 />
-              </svg>
-            </div>
-            <h3 className="text-lg font-semibold text-foreground mb-2">No Bookmarks</h3>
-            <p className="text-muted max-w-md mx-auto mb-4">
-              This folder is empty. Start bookmarking verses while reading to add them here.
-            </p>
-            {onBack && (
-              <button
-                onClick={onBack}
-                className="px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent/90 transition-colors"
-              >
-                Back to Folders
-              </button>
-            )}
-          </motion.div>
-        )}
-      </div>
+              </div>
+            );
+          }}
+        </List>
+      ) : (
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center py-16">
+          <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              className="w-8 h-8 text-muted"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold text-foreground mb-2">No Bookmarks</h3>
+          <p className="text-muted max-w-md mx-auto mb-4">
+            This folder is empty. Start bookmarking verses while reading to add them here.
+          </p>
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent/90 transition-colors"
+            >
+              Back to Folders
+            </button>
+          )}
+        </motion.div>
+      )}
     </motion.div>
   );
 };


### PR DESCRIPTION
## Summary
- virtualize bookmark list view using `react-window`
- add virtualized verse rendering in bookmark sidebar

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Types of property 'verseId' are incompatible, etc.)*
- `npm run test` *(fails: Responsive System › useBreakpoint › should handle SSR correctly, and others)*

------
https://chatgpt.com/codex/tasks/task_b_68aa140d73dc832fa1e415545576116a