### PR TITLE
refactor: use string verse IDs for bookmarks

### DIFF
--- a/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
+++ b/app/(features)/bookmarks/[folderId]/BookmarkFolderClient.tsx
@@ -204,7 +204,7 @@ export default function BookmarkFolderClient({ folderId }: BookmarkFolderClientP
                {' '}
         <BookmarkFolderSidebar
           bookmarks={bookmarks}
-          folder={{ id: folder.id, name: folder.name }}
+          folder={folder}
           activeVerseId={activeVerseId}
           onVerseSelect={setActiveVerseId}
           onBack={() => router.push('/bookmarks')}

--- a/app/(features)/bookmarks/components/BookmarkCard.tsx
+++ b/app/(features)/bookmarks/components/BookmarkCard.tsx
@@ -61,8 +61,10 @@ export const BookmarkCard = memo(function BookmarkCard({
 
   const router = useRouter();
 
+  const numericVerseId = Number(enrichedBookmark.verseId);
+
   const handlePlayPause = useCallback(() => {
-    if (playingId === Number(enrichedBookmark.verseId)) {
+    if (playingId === numericVerseId) {
       audioRef.current?.pause();
       setPlayingId(null);
       setLoadingId(null);
@@ -70,7 +72,7 @@ export const BookmarkCard = memo(function BookmarkCard({
       setIsPlaying(false);
     } else if (enrichedBookmark.verseKey && enrichedBookmark.verseText) {
       const verseForAudio = {
-        id: Number(enrichedBookmark.verseId),
+        id: numericVerseId,
         verse_key: enrichedBookmark.verseKey,
         text_uthmani: enrichedBookmark.verseText,
         translations: enrichedBookmark.translation
@@ -94,7 +96,7 @@ export const BookmarkCard = memo(function BookmarkCard({
     enrichedBookmark.verseKey,
     enrichedBookmark.verseText,
     enrichedBookmark.translation,
-    enrichedBookmark.verseId,
+    numericVerseId,
     audioRef,
     setActiveVerse,
     setPlayingId,
@@ -114,8 +116,8 @@ export const BookmarkCard = memo(function BookmarkCard({
     router.push(`/surah/${surahId}#verse-${enrichedBookmark.verseId}`);
   }, [enrichedBookmark.verseKey, enrichedBookmark.verseId, router]);
 
-  const isPlaying = playingId === Number(enrichedBookmark.verseId);
-  const isLoadingAudio = loadingId === Number(enrichedBookmark.verseId);
+  const isPlaying = playingId === numericVerseId;
+  const isLoadingAudio = loadingId === numericVerseId;
   const isVerseBookmarked = isBookmarked(enrichedBookmark.verseId);
   return (
     <LoadingError
@@ -193,7 +195,7 @@ export const BookmarkCard = memo(function BookmarkCard({
           <div className="space-y-6 md:flex-grow">
             <VerseArabic
               verse={{
-                id: Number(enrichedBookmark.verseId),
+                id: numericVerseId,
                 verse_key: enrichedBookmark.verseKey!,
                 text_uthmani: enrichedBookmark.verseText!,
               }}

--- a/types/bookmark.ts
+++ b/types/bookmark.ts
@@ -2,8 +2,8 @@
  * A saved verse reference with optional cached metadata for quick display.
  */
 export interface Bookmark {
-  /** Numeric verse identifier (stable internal ID). */
-  verseId: number;
+  /** Unique verse identifier stored as a string. */
+  verseId: string;
   /** Timestamp when the bookmark was created (ms since epoch). */
   createdAt: number;
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -6,7 +6,7 @@ export * from './settings';
 export * from './surah';
 export * from './word';
 export * from './juz';
-export * from './bookmark';
+export type { Bookmark, BookmarkWithVerse, Folder } from './bookmark';
 export * from './components';
 
 /**


### PR DESCRIPTION
## Summary
- treat bookmark verseId as a string
- re-export bookmark types explicitly
- parse string verse IDs once in `BookmarkCard`
- pass full folder object to bookmark sidebar

## Testing
- `npm test` (fails: ResponsiveVerseActions, Responsive System, SettingsSidebar, VerseOfDay, TafsirVerseCard)
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68aa1f5a3478832f96c462205db83c2c