### PR TITLE
refactor: use semantic tokens for folder colors

### DIFF
--- a/app/(features)/bookmarks/components/BookmarksSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarksSidebar.tsx
@@ -50,9 +50,11 @@ export const BookmarksSidebar: React.FC<BookmarksSidebarProps> = ({
             {folders.map((folder) => {
               const IconComp = ({ className }: { className?: string }) =>
                 folder.icon ? (
-                  <span className={cn('text-xl', folder.color, className)}>{folder.icon}</span>
+                  <span className={cn('text-xl', folder.color || 'text-accent', className)}>
+                    {folder.icon}
+                  </span>
                 ) : (
-                  <FolderIcon className={cn(className, folder.color)} />
+                  <FolderIcon className={cn(className, folder.color || 'text-accent')} />
                 );
               return (
                 <ListItem

--- a/app/(features)/bookmarks/components/FolderCard.tsx
+++ b/app/(features)/bookmarks/components/FolderCard.tsx
@@ -46,7 +46,7 @@ export const FolderCard: React.FC<FolderCardProps> = React.memo(function FolderC
       <div className="flex items-center space-x-3">
         <div className="flex-shrink-0">
           {folder.icon ? (
-            <span className={cn('text-2xl', folder.color)} aria-hidden="true">
+            <span className={cn('text-2xl', folder.color || 'text-accent')} aria-hidden="true">
               {folder.icon}
             </span>
           ) : (

--- a/app/(features)/bookmarks/components/FolderSettingsModal.tsx
+++ b/app/(features)/bookmarks/components/FolderSettingsModal.tsx
@@ -14,14 +14,14 @@ interface FolderSettingsModalProps {
 }
 
 const FOLDER_COLORS = [
-  { name: 'Blue', value: 'text-blue-500' },
-  { name: 'Green', value: 'text-green-500' },
-  { name: 'Purple', value: 'text-purple-500' },
-  { name: 'Red', value: 'text-red-500' },
-  { name: 'Orange', value: 'text-orange-500' },
-  { name: 'Pink', value: 'text-pink-500' },
-  { name: 'Teal', value: 'text-teal-500' },
-  { name: 'Indigo', value: 'text-indigo-500' },
+  { name: 'Accent', value: 'text-accent' },
+  { name: 'Primary', value: 'text-primary' },
+  { name: 'Interactive', value: 'text-interactive' },
+  { name: 'Success', value: 'text-status-success' },
+  { name: 'Warning', value: 'text-status-warning' },
+  { name: 'Error', value: 'text-status-error' },
+  { name: 'Info', value: 'text-status-info' },
+  { name: 'Content Accent', value: 'text-content-accent' },
 ];
 
 const FOLDER_ICONS = ['📁', '📖', '⭐', '💎', '🌟', '📚', '🔖', '💫'];
@@ -34,14 +34,14 @@ export const FolderSettingsModal: React.FC<FolderSettingsModalProps> = ({
 }) => {
   const { renameFolder } = useBookmarks();
   const [name, setName] = useState('');
-  const [selectedColor, setSelectedColor] = useState('text-blue-500');
+  const [selectedColor, setSelectedColor] = useState('text-accent');
   const [selectedIcon, setSelectedIcon] = useState('📁');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (folder && isOpen) {
       setName(folder.name);
-      setSelectedColor(folder.color || 'text-blue-500');
+      setSelectedColor(folder.color || 'text-accent');
       setSelectedIcon(folder.icon || '📁');
     }
   }, [folder, isOpen]);

--- a/app/providers/__tests__/BookmarkContext.test.tsx
+++ b/app/providers/__tests__/BookmarkContext.test.tsx
@@ -33,9 +33,7 @@ const BookmarkTestComponent = () => {
       <button onClick={() => addBookmark('1:1', folders[0]?.id)}>Add Bookmark</button>
       <button onClick={() => removeBookmark('1:1', folders[0]?.id)}>Remove Bookmark</button>
       <button onClick={() => renameFolder(folders[0]?.id, 'New Name')}>Rename Folder</button>
-      <button
-        onClick={() => renameFolder(folders[0]?.id, folders[0]?.name || '', 'text-green-500')}
-      >
+      <button onClick={() => renameFolder(folders[0]?.id, folders[0]?.name || '', 'text-primary')}>
         Set Color
       </button>
       <button onClick={() => deleteFolder(folders[0]?.id)}>Delete Folder</button>
@@ -233,10 +231,10 @@ describe('BookmarkContext with Folders', () => {
 
     await waitFor(() => {
       const folders: Folder[] = JSON.parse(screen.getByTestId('folders').textContent || '[]');
-      expect(folders[0].color).toBe('text-green-500');
+      expect(folders[0].color).toBe('text-primary');
 
       const stored: Folder[] = JSON.parse(localStorage.getItem(BOOKMARKS_STORAGE_KEY) || '[]');
-      expect(stored[0].color).toBe('text-green-500');
+      expect(stored[0].color).toBe('text-primary');
     });
   });
 });


### PR DESCRIPTION
## Summary
- map folder color options to semantic Tailwind tokens
- ensure folder icons fall back to `text-accent`
- update bookmark context test for new color token

## Testing
- `npm run lint`
- `npm test app/providers/__tests__/BookmarkContext.test.tsx`
- `npm test` *(fails: Test Suites: 6 failed, 55 passed, 61 total)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1f6f8034832f9d9387ad2dbbae12