### PR TITLE
test: add bookmark page coverage

### DIFF
--- a/app/(features)/bookmarks/__tests__/LastReadPage.test.tsx
+++ b/app/(features)/bookmarks/__tests__/LastReadPage.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LastReadPage from '../last-read/page';
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+jest.mock('../components/BookmarksSidebar', () => ({
+  BookmarksSidebar: ({ onSectionChange }: any) => (
+    <nav>
+      <button onClick={() => onSectionChange('bookmarks')}>Bookmarks</button>
+      <button onClick={() => onSectionChange('pinned')}>Pins</button>
+      <button onClick={() => onSectionChange('last-read')}>Last Read</button>
+    </nav>
+  ),
+}));
+
+let lastRead: Record<string, number> = { '1': 3 };
+
+jest.mock('@/app/providers/BookmarkContext', () => ({
+  useBookmarks: () => ({
+    lastRead,
+  }),
+}));
+
+jest.mock('@/app/(features)/layout/context/HeaderVisibilityContext', () => ({
+  useHeaderVisibility: () => ({ isHidden: false }),
+}));
+
+const mockGetChapters = jest.fn();
+
+jest.mock('@/lib/api/chapters', () => ({
+  getChapters: () => mockGetChapters(),
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    aside: ({ children, ...props }: any) => <aside {...props}>{children}</aside>,
+  },
+  AnimatePresence: ({ children }: any) => children,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  push.mockClear();
+  mockGetChapters.mockResolvedValue([
+    { id: 1, name_simple: 'Al-Fatihah', verses_count: 7 },
+  ]);
+  lastRead = { '1': 3 };
+});
+
+describe('Last Read Page', () => {
+  it('renders last read progress and handles navigation', async () => {
+    render(<LastReadPage />);
+    expect(
+      await screen.findByRole('heading', { name: 'Last Read' })
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/Verse 3 of 7/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Pins'));
+    expect(push).toHaveBeenCalledWith('/bookmarks/pinned');
+  });
+
+  it('shows empty state message', async () => {
+    lastRead = {};
+    render(<LastReadPage />);
+    expect(await screen.findByText('No Recent Activity')).toBeInTheDocument();
+  });
+});
+

--- a/app/(features)/bookmarks/__tests__/PinnedPage.test.tsx
+++ b/app/(features)/bookmarks/__tests__/PinnedPage.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PinnedAyahPage from '../pinned/page';
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+jest.mock('../components/BookmarksSidebar', () => ({
+  BookmarksSidebar: ({ onSectionChange }: any) => (
+    <nav>
+      <button onClick={() => onSectionChange('bookmarks')}>Bookmarks</button>
+      <button onClick={() => onSectionChange('last-read')}>Last Read</button>
+      <button onClick={() => onSectionChange('pinned')}>Pins</button>
+    </nav>
+  ),
+}));
+
+const removeBookmark = jest.fn();
+let pinnedVerses = [{ verseId: '1', createdAt: 0 }];
+
+jest.mock('@/app/providers/BookmarkContext', () => ({
+  useBookmarks: () => ({
+    pinnedVerses,
+    removeBookmark,
+  }),
+}));
+
+jest.mock('@/app/(features)/layout/context/HeaderVisibilityContext', () => ({
+  useHeaderVisibility: () => ({ isHidden: false }),
+}));
+
+jest.mock('../components/BookmarkCard', () => ({
+  BookmarkCard: ({ bookmark }: any) => {
+    const { removeBookmark } = require('@/app/providers/BookmarkContext').useBookmarks();
+    return (
+      <div>
+        <span>{`Verse ${bookmark.verseId}`}</span>
+        <button onClick={() => removeBookmark(bookmark.verseId, 'pinned')}>Remove</button>
+      </div>
+    );
+  },
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    aside: ({ children, ...props }: any) => <aside {...props}>{children}</aside>,
+  },
+  AnimatePresence: ({ children }: any) => children,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  pinnedVerses = [{ verseId: '1', createdAt: 0 }];
+  push.mockClear();
+  removeBookmark.mockClear();
+});
+
+describe('Pinned Ayah Page', () => {
+  it('renders pinned verses and handles navigation', () => {
+    render(<PinnedAyahPage />);
+    expect(screen.getByText('Pinned Ayahs')).toBeInTheDocument();
+    expect(screen.getByText('Verse 1')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Last Read'));
+    expect(push).toHaveBeenCalledWith('/bookmarks/last-read');
+  });
+
+  it('removes a pinned verse', () => {
+    render(<PinnedAyahPage />);
+    fireEvent.click(screen.getByText('Remove'));
+    expect(removeBookmark).toHaveBeenCalledWith('1', 'pinned');
+  });
+
+  it('shows empty state message', () => {
+    pinnedVerses = [];
+    render(<PinnedAyahPage />);
+    expect(screen.getByText('No Pinned Verses')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for pinned bookmark page including navigation, removal, and empty state
- add tests for last-read page verifying progress display and empty state

## Testing
- `npm test -- --runTestsByPath app/(features)/bookmarks/__tests__/PinnedPage.test.tsx app/(features)/bookmarks/__tests__/LastReadPage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_68aa1f837074832f86d35e297dc149c7