### PR TITLE
fix: anchor verses for bookmark navigation

### DIFF
--- a/app/(features)/surah/[surahId]/components/Verse.tsx
+++ b/app/(features)/surah/[surahId]/components/Verse.tsx
@@ -85,7 +85,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
   }, [addBookmark, removeBookmark, findBookmark, verse.id]);
 
   return (
-    <div ref={verseRef} className="mb-8 pb-8 border-b border-border">
+    <div id={`verse-${verse.id}`} ref={verseRef} className="mb-8 pb-8 border-b border-border">
       {/* Mobile: stacked layout, Desktop: side-by-side */}
       <div className="space-y-4 md:space-y-0 md:flex md:items-start md:gap-x-6">
         {/* Verse actions */}


### PR DESCRIPTION
## Summary
- assign unique `verse-${id}` IDs to verse containers so anchors scroll correctly

## Testing
- `npm run lint` *(fails: prettier errors in existing tests)*
- `npx eslint app/(features)/surah/[surahId]/components/Verse.tsx`
- `npm run test` *(fails: multiple failing suites such as responsive hooks and mobile performance)*

------
https://chatgpt.com/codex/tasks/task_b_68aa23a65760832f82858eadeff1a380