### PR TITLE
feat: add verseApiId to bookmarks

### DIFF
--- a/app/(features)/bookmarks/components/BookmarkCard.tsx
+++ b/app/(features)/bookmarks/components/BookmarkCard.tsx
@@ -61,10 +61,11 @@ export const BookmarkCard = memo(function BookmarkCard({
 
   const router = useRouter();
 
-  const numericVerseId = Number(enrichedBookmark.verseId);
+  const verseApiId = enrichedBookmark.verseApiId;
 
   const handlePlayPause = useCallback(() => {
-    if (playingId === numericVerseId) {
+    if (!verseApiId) return;
+    if (playingId === verseApiId) {
       audioRef.current?.pause();
       setPlayingId(null);
       setLoadingId(null);
@@ -72,7 +73,7 @@ export const BookmarkCard = memo(function BookmarkCard({
       setIsPlaying(false);
     } else if (enrichedBookmark.verseKey && enrichedBookmark.verseText) {
       const verseForAudio = {
-        id: numericVerseId,
+        id: verseApiId,
         verse_key: enrichedBookmark.verseKey,
         text_uthmani: enrichedBookmark.verseText,
         translations: enrichedBookmark.translation
@@ -86,17 +87,17 @@ export const BookmarkCard = memo(function BookmarkCard({
           : [],
       };
       setActiveVerse(verseForAudio);
-      setPlayingId(verseForAudio.id);
-      setLoadingId(verseForAudio.id);
+      setPlayingId(verseApiId);
+      setLoadingId(verseApiId);
       setIsPlaying(true);
       openPlayer();
     }
   }, [
+    verseApiId,
     playingId,
     enrichedBookmark.verseKey,
     enrichedBookmark.verseText,
     enrichedBookmark.translation,
-    numericVerseId,
     audioRef,
     setActiveVerse,
     setPlayingId,
@@ -116,8 +117,8 @@ export const BookmarkCard = memo(function BookmarkCard({
     router.push(`/surah/${surahId}#verse-${enrichedBookmark.verseId}`);
   }, [enrichedBookmark.verseKey, enrichedBookmark.verseId, router]);
 
-  const isPlaying = playingId === numericVerseId;
-  const isLoadingAudio = loadingId === numericVerseId;
+  const isPlaying = playingId === verseApiId;
+  const isLoadingAudio = loadingId === verseApiId;
   const isVerseBookmarked = isBookmarked(enrichedBookmark.verseId);
   return (
     <LoadingError
@@ -126,7 +127,8 @@ export const BookmarkCard = memo(function BookmarkCard({
         !enrichedBookmark.verseText ||
         !enrichedBookmark.translation ||
         !enrichedBookmark.verseKey ||
-        !enrichedBookmark.surahName
+        !enrichedBookmark.surahName ||
+        !enrichedBookmark.verseApiId
       }
       error={error}
       loadingFallback={
@@ -195,7 +197,7 @@ export const BookmarkCard = memo(function BookmarkCard({
           <div className="space-y-6 md:flex-grow">
             <VerseArabic
               verse={{
-                id: numericVerseId,
+                id: verseApiId!,
                 verse_key: enrichedBookmark.verseKey!,
                 text_uthmani: enrichedBookmark.verseText!,
               }}

--- a/app/(features)/bookmarks/hooks/useBookmarkVerse.ts
+++ b/app/(features)/bookmarks/hooks/useBookmarkVerse.ts
@@ -19,7 +19,13 @@ export function useBookmarkVerse(bookmark: Bookmark): UseBookmarkVerseReturn {
 
   useEffect(() => {
     const fetchVerseData = async () => {
-      if (bookmark.verseText && bookmark.surahName && bookmark.translation && bookmark.verseKey) {
+      if (
+        bookmark.verseText &&
+        bookmark.surahName &&
+        bookmark.translation &&
+        bookmark.verseKey &&
+        bookmark.verseApiId
+      ) {
         return;
       }
       setIsLoading(true);
@@ -41,6 +47,7 @@ export function useBookmarkVerse(bookmark: Bookmark): UseBookmarkVerseReturn {
           verseText: verse.text_uthmani,
           surahName: surahInfo?.name_simple || `Surah ${surahIdStr}`,
           translation: verse.translations?.[0]?.text,
+          verseApiId: verse.id,
         });
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch verse');

--- a/app/providers/BookmarkContext.tsx
+++ b/app/providers/BookmarkContext.tsx
@@ -186,6 +186,7 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
           verseText: verse.text_uthmani,
           surahName: surahInfo?.name_simple || `Surah ${surahIdStr}`,
           translation: verse.translations?.[0]?.text,
+          verseApiId: verse.id,
         });
       } catch {
         // Silent fail for metadata fetch errors

--- a/types/bookmark.ts
+++ b/types/bookmark.ts
@@ -4,6 +4,8 @@
 export interface Bookmark {
   /** Unique verse identifier stored as a string. */
   verseId: string;
+  /** Numeric verse identifier from the source API. */
+  verseApiId?: number;
   /** Timestamp when the bookmark was created (ms since epoch). */
   createdAt: number;
 


### PR DESCRIPTION
## Summary
- track API verse IDs in bookmarks
- use verseApiId for bookmark audio playback

## Testing
- `npx eslint app/providers/BookmarkContext.tsx "app/(features)/bookmarks/hooks/useBookmarkVerse.ts" "app/(features)/bookmarks/components/BookmarkCard.tsx" types/bookmark.ts && echo "ESLint passed"`
- `npm run type-check`
- `npm test` *(fails: Responsive System and ResponsiveVerseActions tests)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_68aa23c4b9bc832f96b7b4779895839a