### PR TITLE
refactor: use SectionId for bookmark navigation

### DIFF
--- a/app/(features)/bookmarks/components/BookmarksContent.tsx
+++ b/app/(features)/bookmarks/components/BookmarksContent.tsx
@@ -7,11 +7,15 @@ import {
   BookmarkFolderCard,
   BookmarkVerseCard,
 } from '@/app/shared/ui/cards';
+import type {
+  BookmarkNavigationContent,
+  SectionId,
+} from '@/app/shared/ui/cards/BookmarkNavigationCard';
 import type { Folder } from '@/types/bookmark';
 
 interface BookmarksContentProps {
-  activeSection?: string;
-  onSectionChange?: (section: string) => void;
+  activeSection?: SectionId;
+  onSectionChange?: (section: SectionId) => void;
   children?: React.ReactNode;
   folders?: Folder[];
   onVerseClick?: (verseKey: string) => void;
@@ -38,7 +42,7 @@ export const BookmarksContent: React.FC<BookmarksContentProps> = ({
     });
   };
 
-  const sections = [
+  const sections: BookmarkNavigationContent[] = [
     { id: 'bookmarks', icon: BookmarkIcon, label: 'All Bookmarks', description: 'Manage folders' },
     { id: 'pinned', icon: PinIcon, label: 'Pinned Verses', description: 'Quick access' },
     { id: 'last-read', icon: ClockIcon, label: 'Recent', description: 'Last visited' },

--- a/app/(features)/bookmarks/components/BookmarksSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarksSidebar.tsx
@@ -4,10 +4,11 @@ import React from 'react';
 import { BaseSidebar } from '@/app/shared/components/BaseSidebar';
 import { BookmarksContent } from './BookmarksContent';
 import type { Folder } from '@/types/bookmark';
+import type { SectionId } from '@/app/shared/ui/cards/BookmarkNavigationCard';
 
 interface BookmarksSidebarProps {
-  activeSection?: string;
-  onSectionChange?: (section: string) => void;
+  activeSection?: SectionId;
+  onSectionChange?: (section: SectionId) => void;
   children?: React.ReactNode;
   folders?: Folder[];
   onVerseClick?: (verseKey: string) => void;

--- a/app/(features)/bookmarks/last-read/page.tsx
+++ b/app/(features)/bookmarks/last-read/page.tsx
@@ -8,6 +8,7 @@ import { ClockIcon } from '@/app/shared/icons';
 import { useRouter } from 'next/navigation';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
 import { useBookmarks } from '@/app/providers/BookmarkContext';
+import type { SectionId } from '@/app/shared/ui/cards/BookmarkNavigationCard';
 
 export default function LastReadPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -22,7 +23,7 @@ export default function LastReadPage() {
     };
   }, []);
 
-  const handleSectionChange = (section: string) => {
+  const handleSectionChange = (section: SectionId) => {
     if (section === 'bookmarks') {
       router.push('/bookmarks');
     } else if (section === 'pinned') {

--- a/app/(features)/bookmarks/memorization/page.tsx
+++ b/app/(features)/bookmarks/memorization/page.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
 import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useModal } from '@/app/shared/hooks/useModal';
+import type { SectionId } from '@/app/shared/ui/cards/BookmarkNavigationCard';
 
 export default function MemorizationPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -25,7 +26,7 @@ export default function MemorizationPage() {
     };
   }, []);
 
-  const handleSectionChange = (section: string) => {
+  const handleSectionChange = (section: SectionId) => {
     if (section === 'bookmarks') {
       router.push('/bookmarks');
     } else if (section === 'pinned') {

--- a/app/(features)/bookmarks/page.tsx
+++ b/app/(features)/bookmarks/page.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
 import { useSidebar } from '@/app/providers/SidebarContext';
+import type { SectionId } from '@/app/shared/ui/cards/BookmarkNavigationCard';
 
 const BookmarksPage = () => {
   const { folders } = useBookmarks();
@@ -51,7 +52,7 @@ const BookmarksPage = () => {
     router.push(`/bookmarks/${folderId}`);
   };
 
-  const handleSectionChange = (section: string) => {
+  const handleSectionChange = (section: SectionId) => {
     if (section === 'pinned') {
       router.push('/bookmarks/pinned');
     } else if (section === 'last-read') {

--- a/app/(features)/bookmarks/pinned/page.tsx
+++ b/app/(features)/bookmarks/pinned/page.tsx
@@ -9,6 +9,7 @@ import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisib
 import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useSidebar } from '@/app/providers/SidebarContext';
 import { BookmarkCard } from '../components/BookmarkCard';
+import type { SectionId } from '@/app/shared/ui/cards/BookmarkNavigationCard';
 
 export default function PinnedAyahPage() {
   const router = useRouter();
@@ -23,7 +24,7 @@ export default function PinnedAyahPage() {
     };
   }, []);
 
-  const handleSectionChange = (section: string) => {
+  const handleSectionChange = (section: SectionId) => {
     if (section === 'bookmarks') {
       router.push('/bookmarks');
     } else if (section === 'last-read') {

--- a/app/shared/ui/cards/BookmarkNavigationCard.tsx
+++ b/app/shared/ui/cards/BookmarkNavigationCard.tsx
@@ -13,10 +13,10 @@ import { colors } from '../../design-system/card-tokens';
  */
 
 // Valid bookmark section identifiers
-type SectionId = 'bookmarks' | 'pinned' | 'last-read' | 'memorization';
+export type SectionId = 'bookmarks' | 'pinned' | 'last-read' | 'memorization';
 
-interface BookmarkNavigationContent {
-  id: string;
+export interface BookmarkNavigationContent {
+  id: SectionId;
   icon: React.ComponentType<{ size?: number; className?: string }>;
   label: string;
   description: string;
@@ -24,7 +24,7 @@ interface BookmarkNavigationContent {
 
 interface BookmarkNavigationCardProps extends Omit<BaseCardProps, 'children'> {
   content: BookmarkNavigationContent;
-  onSectionChange?: (sectionId: string) => void;
+  onSectionChange?: (sectionId: SectionId) => void;
 }
 
 // Map section IDs to URLs for smooth navigation
@@ -35,8 +35,7 @@ const routes: Record<SectionId, string> = {
   memorization: '/bookmarks/memorization',
 };
 
-const getSectionHref = (sectionId: string): string =>
-  routes[sectionId as SectionId] || '/bookmarks';
+const getSectionHref = (sectionId: SectionId): string => routes[sectionId];
 
 export const BookmarkNavigationCard: React.FC<BookmarkNavigationCardProps> = ({
   content,
@@ -48,10 +47,10 @@ export const BookmarkNavigationCard: React.FC<BookmarkNavigationCardProps> = ({
 }) => {
   const { id, icon: IconComponent, label, description } = content;
 
-  const handleClick: React.MouseEventHandler<HTMLAnchorElement | HTMLDivElement> = (e) => {
+  const handleClick = () => {
     // Trigger section change before navigation for immediate feedback
     onSectionChange?.(id);
-    onClick?.(e);
+    onClick?.();
   };
 
   return (


### PR DESCRIPTION
## Summary
- define `SectionId` union and use it for bookmark navigation card ids and callbacks
- type bookmark components with `SectionId` and enforce valid section ids

## Testing
- `npm run type-check` *(fails: app/(features)/home/hooks/useVerseOfDay.ts(29,23): error TS2554: Expected 1 arguments, but got 0. ...)*

------
https://chatgpt.com/codex/tasks/task_b_68adf93da8b8832f994f8ad035bf2fc4