### PR TITLE
chore: add AI doc and test scripts

### DIFF
--- a/docs/ai/scripts.md
+++ b/docs/ai/scripts.md
@@ -1,0 +1,6 @@
+# AI Tooling Scripts
+
+These npm scripts help keep documentation and tests in sync with the codebase.
+
+- **`npm run ai:docs`** – updates AI-focused documentation based on recent changes using `tools/ai/doc-updater.js`.
+- **`npm run ai:generate-test -- <path>`** – generates a test template for the specified file via `tools/ai/test-generator.js`.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "preview": "npm run build && npm start",
     "size-limit": "npx size-limit",
     "lighthouse": "npx lighthouse http://localhost:3000 --output=html --output-path=./lighthouse-report.html",
+    "ai:docs": "node tools/ai/doc-updater.js",
+    "ai:generate-test": "node tools/ai/test-generator.js",
     "rg": "node scripts/rg.js",
     "search": "npm run -s rg --",
     "search:todos": "npm run -s rg -- \"(TODO|FIXME|HACK|BUG|NOTE)[:\\s]\" --glob \"*.{ts,tsx,js,jsx}\"",


### PR DESCRIPTION
## Summary
- add `ai:docs` and `ai:generate-test` scripts
- document AI tooling scripts

## Testing
- `npm run check` *(fails: Code style issues found in 12 files. Run Prettier with --write to fix.)*
- `npm run lint` *(fails: Cannot find module 'config/build/scripts/eslint/no-raw-color-classes.mjs')*
- `npm run type-check` *(fails: Numerous TypeScript errors e.g. TS2322 in BookmarksLayout.tsx)*
- `npm run test:ci` *(fails: 33 failed, 39 passed, 72 total)*

------
https://chatgpt.com/codex/tasks/task_b_68b49406d25c832f9467725a2752b909