### PR TITLE
refactor: extract verse helpers

### DIFF
--- a/src/domain/entities/Verse.ts
+++ b/src/domain/entities/Verse.ts
@@ -1,28 +1,14 @@
 import { Translation } from '../value-objects/Translation';
+import {
+  getEstimatedReadingTime,
+  getWordCount,
+  isSajdahVerse,
+} from './verseUtils';
 
 /**
  * Verse domain entity representing a single Quranic verse
  */
 export class Verse {
-  private static readonly SAJDAH_VERSES = [
-    { surah: 7, ayah: 206 },
-    { surah: 13, ayah: 15 },
-    { surah: 16, ayah: 50 },
-    { surah: 17, ayah: 109 },
-    { surah: 19, ayah: 58 },
-    { surah: 22, ayah: 18 },
-    { surah: 22, ayah: 77 },
-    { surah: 25, ayah: 60 },
-    { surah: 27, ayah: 26 },
-    { surah: 32, ayah: 15 },
-    { surah: 38, ayah: 24 },
-    { surah: 41, ayah: 38 },
-    { surah: 53, ayah: 62 },
-    { surah: 84, ayah: 21 },
-    { surah: 96, ayah: 19 },
-  ];
-
-  private static readonly WORDS_PER_MINUTE = 150; // Average Arabic reading speed
 
   constructor(
     public readonly id: string,
@@ -72,48 +58,6 @@ export class Verse {
   }
 
   /**
-   * Checks if this verse requires prostration (sajdah)
-   */
-  isSajdahVerse(): boolean {
-    return Verse.SAJDAH_VERSES.some(
-      (sajdah) => sajdah.surah === this.surahId && sajdah.ayah === this.ayahNumber
-    );
-  }
-
-  /**
-   * Splits the Arabic text into segments for memorization
-   */
-  getMemorizationSegments(): string[] {
-    return this.arabicText
-      .split(/\s+/)
-      .map((segment) => segment.trim())
-      .filter((segment) => segment.length > 0);
-  }
-
-  /**
-   * Estimates reading time in seconds
-   */
-  getEstimatedReadingTime(): number {
-    const wordCount = this.getWordCount();
-    const timeInSeconds = Math.ceil((wordCount / Verse.WORDS_PER_MINUTE) * 60);
-    return Math.max(timeInSeconds, 1); // Minimum 1 second
-  }
-
-  /**
-   * Checks if the verse contains Bismillah
-   */
-  containsBismillah(): boolean {
-    return this.arabicText.includes('بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ');
-  }
-
-  /**
-   * Returns the word count of the Arabic text
-   */
-  getWordCount(): number {
-    return this.arabicText.split(/\s+/).filter((word) => word.trim().length > 0).length;
-  }
-
-  /**
    * Checks equality based on ID
    */
   equals(other: Verse): boolean {
@@ -146,10 +90,10 @@ export class Verse {
       arabicText: this.arabicText,
       uthmaniText: this.uthmaniText,
       translation: this.translation?.toPlainObject(),
-      wordCount: this.getWordCount(),
-      estimatedReadingTime: this.getEstimatedReadingTime(),
+      wordCount: getWordCount(this.arabicText),
+      estimatedReadingTime: getEstimatedReadingTime(this.arabicText),
       isFirstVerse: this.isFirstVerse(),
-      isSajdahVerse: this.isSajdahVerse(),
+      isSajdahVerse: isSajdahVerse(this.surahId, this.ayahNumber),
     };
   }
 }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,0 +1,5 @@
+export * from './Bookmark';
+export * from './Surah';
+export * from './Tafsir';
+export * from './Verse';
+export * from './verseUtils';

--- a/src/domain/entities/verseUtils.ts
+++ b/src/domain/entities/verseUtils.ts
@@ -1,0 +1,46 @@
+export const SAJDAH_VERSES = [
+  { surah: 7, ayah: 206 },
+  { surah: 13, ayah: 15 },
+  { surah: 16, ayah: 50 },
+  { surah: 17, ayah: 109 },
+  { surah: 19, ayah: 58 },
+  { surah: 22, ayah: 18 },
+  { surah: 22, ayah: 77 },
+  { surah: 25, ayah: 60 },
+  { surah: 27, ayah: 26 },
+  { surah: 32, ayah: 15 },
+  { surah: 38, ayah: 24 },
+  { surah: 41, ayah: 38 },
+  { surah: 53, ayah: 62 },
+  { surah: 84, ayah: 21 },
+  { surah: 96, ayah: 19 },
+];
+
+const WORDS_PER_MINUTE = 150; // Average Arabic reading speed
+
+export function isSajdahVerse(surahId: number, ayahNumber: number): boolean {
+  return SAJDAH_VERSES.some(
+    (sajdah) => sajdah.surah === surahId && sajdah.ayah === ayahNumber
+  );
+}
+
+export function getMemorizationSegments(arabicText: string): string[] {
+  return arabicText
+    .split(/\s+/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+export function getWordCount(arabicText: string): number {
+  return arabicText.split(/\s+/).filter((word) => word.trim().length > 0).length;
+}
+
+export function getEstimatedReadingTime(arabicText: string): number {
+  const wordCount = getWordCount(arabicText);
+  const timeInSeconds = Math.ceil((wordCount / WORDS_PER_MINUTE) * 60);
+  return Math.max(timeInSeconds, 1); // Minimum 1 second
+}
+
+export function containsBismillah(arabicText: string): boolean {
+  return arabicText.includes('بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ');
+}

--- a/src/domain/repositories/IBookmarkRepository.ts
+++ b/src/domain/repositories/IBookmarkRepository.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from '../entities/Bookmark';
+import { Bookmark } from '../entities';
 import { BookmarkPosition } from '../value-objects/BookmarkPosition';
 import { StoredBookmark } from '../value-objects/StoredBookmark';
 

--- a/src/domain/repositories/IVerseRepository.ts
+++ b/src/domain/repositories/IVerseRepository.ts
@@ -1,4 +1,4 @@
-import { Verse } from '../entities/Verse';
+import { Verse } from '../entities';
 
 export interface IVerseRepository {
   // Basic CRUD operations

--- a/src/domain/services/BookmarkImportService.ts
+++ b/src/domain/services/BookmarkImportService.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Bookmark } from '../entities/Bookmark';
+import { Bookmark } from '../entities';
 import { IBookmarkRepository } from '../repositories/IBookmarkRepository';
 import { IVerseRepository } from '../repositories/IVerseRepository';
 import { BookmarkPosition } from '../value-objects/BookmarkPosition';

--- a/src/domain/services/BookmarkMutationService.ts
+++ b/src/domain/services/BookmarkMutationService.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from '../entities/Bookmark';
+import { Bookmark } from '../entities';
 import { BookmarkNotFoundError, UnauthorizedBookmarkError } from '../errors/DomainErrors';
 import { IBookmarkRepository } from '../repositories/IBookmarkRepository';
 

--- a/src/domain/services/BookmarkService.ts
+++ b/src/domain/services/BookmarkService.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Bookmark } from '../entities/Bookmark';
-import { Verse } from '../entities/Verse';
+import { Bookmark, Verse } from '../entities';
 import {
   BookmarkAlreadyExistsError,
   VerseNotFoundError,

--- a/src/infrastructure/repositories/BookmarkRepository.ts
+++ b/src/infrastructure/repositories/BookmarkRepository.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from '../../domain/entities/Bookmark';
+import { Bookmark } from '../../domain/entities';
 import { IBookmarkRepository } from '../../domain/repositories/IBookmarkRepository';
 import { BookmarkPosition } from '../../domain/value-objects/BookmarkPosition';
 import { StoredBookmark } from '../../domain/value-objects/StoredBookmark';

--- a/src/infrastructure/repositories/VerseRepository.ts
+++ b/src/infrastructure/repositories/VerseRepository.ts
@@ -1,6 +1,6 @@
 import * as apiVerses from '../../../lib/api/verses';
 import * as apiSearch from '../../../lib/api/verses';
-import { Verse } from '../../domain/entities/Verse';
+import { Verse } from '../../domain/entities';
 import { IVerseRepository } from '../../domain/repositories/IVerseRepository';
 import { logger } from '../monitoring/Logger';
 import { mapApiVerseToDomain } from './verseMapper';

--- a/src/infrastructure/repositories/bookmark/queries.ts
+++ b/src/infrastructure/repositories/bookmark/queries.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from '../../../domain/entities/Bookmark';
+import { Bookmark } from '../../../domain/entities';
 import { BookmarkPosition } from '../../../domain/value-objects/BookmarkPosition';
 import { getStoredBookmarks, mapStoredToBookmark } from './storage';
 

--- a/src/infrastructure/repositories/bookmark/storage.ts
+++ b/src/infrastructure/repositories/bookmark/storage.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from '../../../domain/entities/Bookmark';
+import { Bookmark } from '../../../domain/entities';
 import { BookmarkPosition } from '../../../domain/value-objects/BookmarkPosition';
 import { StoredBookmark, isStoredBookmark } from '../../../domain/value-objects/StoredBookmark';
 import { logger } from '../../monitoring/Logger';

--- a/src/infrastructure/repositories/verse/miscQueries.ts
+++ b/src/infrastructure/repositories/verse/miscQueries.ts
@@ -1,5 +1,5 @@
 import * as apiVerses from '../../../../lib/api/verses';
-import { Verse } from '../../../domain/entities/Verse';
+import { Verse } from '../../../domain/entities';
 import { logger } from '../../monitoring/Logger';
 import { mapApiVerseToDomain } from '../verseMapper';
 import { findBySurah } from './surahQueries';

--- a/src/infrastructure/repositories/verse/segmentQueries.ts
+++ b/src/infrastructure/repositories/verse/segmentQueries.ts
@@ -1,5 +1,5 @@
 import * as apiVerses from '../../../../lib/api/verses';
-import { Verse } from '../../../domain/entities/Verse';
+import { Verse } from '../../../domain/entities';
 import { logger } from '../../monitoring/Logger';
 import { mapApiVerseToDomain } from '../verseMapper';
 

--- a/src/infrastructure/repositories/verse/surahQueries.ts
+++ b/src/infrastructure/repositories/verse/surahQueries.ts
@@ -1,5 +1,5 @@
 import * as apiVerses from '../../../../lib/api/verses';
-import { Verse } from '../../../domain/entities/Verse';
+import { Verse } from '../../../domain/entities';
 import { logger } from '../../monitoring/Logger';
 import { mapApiVerseToDomain } from '../verseMapper';
 

--- a/src/infrastructure/repositories/verseMapper.ts
+++ b/src/infrastructure/repositories/verseMapper.ts
@@ -1,5 +1,5 @@
 import { Verse as ApiVerse } from '../../../types';
-import { Verse } from '../../domain/entities/Verse';
+import { Verse } from '../../domain/entities';
 import { Translation } from '../../domain/value-objects/Translation';
 
 /**

--- a/tests/unit/domain/services/BookmarkImportService.test.ts
+++ b/tests/unit/domain/services/BookmarkImportService.test.ts
@@ -1,5 +1,4 @@
-import { Bookmark } from '../../../../src/domain/entities/Bookmark';
-import { Verse } from '../../../../src/domain/entities/Verse';
+import { Bookmark, Verse } from '../../../../src/domain/entities';
 import { IBookmarkRepository } from '../../../../src/domain/repositories/IBookmarkRepository';
 import { IVerseRepository } from '../../../../src/domain/repositories/IVerseRepository';
 import { BookmarkImportService } from '../../../../src/domain/services/BookmarkImportService';

--- a/tests/unit/domain/services/BookmarkMutationService.test.ts
+++ b/tests/unit/domain/services/BookmarkMutationService.test.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from '../../../../src/domain/entities/Bookmark';
+import { Bookmark } from '../../../../src/domain/entities';
 import { BookmarkMutationService } from '../../../../src/domain/services/BookmarkMutationService';
 import { BookmarkPosition } from '../../../../src/domain/value-objects/BookmarkPosition';
 import {

--- a/tests/unit/domain/services/BookmarkService.test.ts
+++ b/tests/unit/domain/services/BookmarkService.test.ts
@@ -1,5 +1,4 @@
-import { Bookmark } from '../../../../src/domain/entities/Bookmark';
-import { Verse } from '../../../../src/domain/entities/Verse';
+import { Bookmark, Verse } from '../../../../src/domain/entities';
 import {
   BookmarkAlreadyExistsError,
   VerseNotFoundError,


### PR DESCRIPTION
## Summary
- move sajdah list and reading helpers to `verseUtils`
- slim `Verse` to validation and serialization
- expose entities and helpers from `src/domain/entities`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_68bc68f1e200832fa7ace874e0d3554e