### PR TITLE
style: organize imports

### DIFF
--- a/app/(features)/home/hooks/useRandomVerse.ts
+++ b/app/(features)/home/hooks/useRandomVerse.ts
@@ -4,10 +4,10 @@ import { useCallback, useState } from 'react';
 import useSWR from 'swr';
 
 import { getRandomVerse } from '@/lib/api';
+import { logger } from '@/src/infrastructure/monitoring/Logger';
 import { Verse } from '@/types';
 
 export const RETRY_LIMIT = 3;
-import { logger } from '@/src/infrastructure/monitoring/Logger';
 
 interface UseRandomVerseOptions {
   translationId: number;

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
@@ -1,17 +1,17 @@
 'use client';
+import { useCallback } from 'react';
+
 import { useBookmarks } from '@/app/providers/BookmarkContext';
 import { useSettings } from '@/app/providers/SettingsContext';
 import { useAudio } from '@/app/shared/player/context/AudioContext';
 import { ResponsiveVerseActions } from '@/app/shared/ResponsiveVerseActions';
 import { VerseArabic } from '@/app/shared/VerseArabic';
 import { sanitizeHtml } from '@/lib/text/sanitizeHtml';
-import { Verse as VerseType, Translation } from '@/types';
+import { Translation, Verse as VerseType } from '@/types';
 
 interface VerseCardProps {
   verse: VerseType;
 }
-
-import { useCallback } from 'react';
 
 export function VerseCard({ verse }: VerseCardProps) {
   const {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,12 +10,11 @@ import localFont from 'next/font/local';
 import { cookies } from 'next/headers';
 import Script from 'next/script';
 
+import './fonts.css';
+import './globals.css';
 import { ClientProviders } from './providers/ClientProviders';
 import { TranslationProvider } from './providers/TranslationProvider';
 import { ErrorBoundary } from './shared/components/error-boundary';
-
-import './fonts.css';
-import './globals.css';
 
 const kfgqpc = localFont({
   src: '../public/fonts/KFGQPC-Uthman-Taha.ttf',
@@ -87,7 +86,11 @@ export const metadata = {
   description: 'Read, Study, and Learn The Holy Quran',
 };
 
-export default async function RootLayout({ children }: { children: React.ReactNode }): Promise<React.JSX.Element> {
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): Promise<React.JSX.Element> {
   const cookieStore = await cookies();
   const stored = cookieStore.get('theme');
   const theme =

--- a/lib/responsive/index.ts
+++ b/lib/responsive/index.ts
@@ -1,13 +1,12 @@
 import { useResponsiveFocus } from '../focus';
-
-export * from './breakpoints';
-export * from './orientation';
-export * from './variants';
-export * from './container';
-
 import { useBreakpoint } from './breakpoints';
 import { useOrientation } from './orientation';
 import { getVariantForBreakpoint } from './variants';
+
+export * from './breakpoints';
+export * from './container';
+export * from './orientation';
+export * from './variants';
 
 export const responsiveClasses = {
   container: 'w-full max-w-sm mx-auto md:max-w-2xl lg:max-w-4xl xl:max-w-6xl',

--- a/templates/ARCHITECTURE_COMPLIANT_TEST.test.tsx
+++ b/templates/ARCHITECTURE_COMPLIANT_TEST.test.tsx
@@ -11,15 +11,13 @@ import { createPerformanceTestSuite } from '@/app/testUtils/performanceTestUtils
 
 import { ExampleComponent } from '../ExampleComponent';
 import {
-  setupTestEnvironment,
-  resetTestEnvironment,
   clearTestEnvironment,
+  resetTestEnvironment,
   runComponentTests,
   runHookTests,
   runIntegrationTest,
+  setupTestEnvironment,
 } from './architecture/test-utils';
-
-// Component under test
 import { useExampleData } from '../hooks/useExampleData';
 
 /**


### PR DESCRIPTION
## Summary
- group and alphabetize imports across files for consistent style
- tidy feature and template files to satisfy import/order

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bd6d0973f8832fa18add8fec27d1f1