### PR TITLE
refactor: modularize delete folder modal

### DIFF
--- a/app/(features)/bookmarks/components/DeleteFolderModal.tsx
+++ b/app/(features)/bookmarks/components/DeleteFolderModal.tsx
@@ -1,20 +1,10 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import React, { useState } from 'react';
-
-import { useBookmarks } from '@/app/providers/BookmarkContext';
-import { logger } from '@/src/infrastructure/monitoring/Logger';
+import React from 'react';
 import { Folder } from '@/types';
 
-import {
-  ModalHeader,
-  FolderPreview,
-  WarningMessage,
-  ModalActions,
-  BACKDROP_VARIANTS,
-  MODAL_VARIANTS,
-} from './delete-folder-modal';
+import { BACKDROP_VARIANTS, ModalBody, useDeleteFolder } from './delete-folder-modal';
 
 interface DeleteFolderModalProps {
   isOpen: boolean;
@@ -27,22 +17,7 @@ export const DeleteFolderModal = ({
   onClose,
   folder,
 }: DeleteFolderModalProps): React.JSX.Element => {
-  const { deleteFolder } = useBookmarks();
-  const [isDeleting, setIsDeleting] = useState(false);
-
-  const handleDelete = async (): Promise<void> => {
-    if (!folder) return;
-
-    setIsDeleting(true);
-    try {
-      deleteFolder(folder.id);
-      onClose();
-    } catch (error) {
-      logger.error('Failed to delete folder:', undefined, error as Error);
-    } finally {
-      setIsDeleting(false);
-    }
-  };
+  const { handleDelete, isDeleting } = useDeleteFolder(folder, onClose);
 
   return (
     <AnimatePresence>
@@ -59,29 +34,12 @@ export const DeleteFolderModal = ({
           />
 
           {/* Modal */}
-          <motion.div
-            variants={MODAL_VARIANTS}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg bg-surface border border-border rounded-2xl shadow-modal z-modal"
-          >
-            <ModalHeader onClose={onClose} />
-
-            <div className="px-6 pb-6">
-              <FolderPreview folder={folder} />
-
-              <div className="space-y-4">
-                <p className="text-foreground">
-                  Are you sure you want to permanently delete this folder?
-                </p>
-                <WarningMessage folder={folder} />
-              </div>
-
-              <ModalActions onClose={onClose} onDelete={handleDelete} isDeleting={isDeleting} />
-            </div>
-          </motion.div>
+          <ModalBody
+            folder={folder}
+            onClose={onClose}
+            onDelete={handleDelete}
+            isDeleting={isDeleting}
+          />
         </>
       )}
     </AnimatePresence>

--- a/app/(features)/bookmarks/components/delete-folder-modal/ModalBody.tsx
+++ b/app/(features)/bookmarks/components/delete-folder-modal/ModalBody.tsx
@@ -1,0 +1,46 @@
+import { motion } from 'framer-motion';
+import React from 'react';
+
+import { Folder } from '@/types';
+
+import { ModalHeader } from './ModalHeader';
+import { FolderPreview } from './FolderPreview';
+import { WarningMessage } from './WarningMessage';
+import { ModalActions } from './ModalActions';
+import { MODAL_VARIANTS } from './animations';
+
+interface ModalBodyProps {
+  folder: Folder;
+  onClose: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+}
+
+export const ModalBody = ({
+  folder,
+  onClose,
+  onDelete,
+  isDeleting,
+}: ModalBodyProps): React.JSX.Element => (
+  <motion.div
+    variants={MODAL_VARIANTS}
+    initial="hidden"
+    animate="visible"
+    exit="exit"
+    transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+    className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg bg-surface border border-border rounded-2xl shadow-modal z-modal"
+  >
+    <ModalHeader onClose={onClose} />
+
+    <div className="px-6 pb-6">
+      <FolderPreview folder={folder} />
+
+      <div className="space-y-4">
+        <p className="text-foreground">Are you sure you want to permanently delete this folder?</p>
+        <WarningMessage folder={folder} />
+      </div>
+
+      <ModalActions onClose={onClose} onDelete={onDelete} isDeleting={isDeleting} />
+    </div>
+  </motion.div>
+);

--- a/app/(features)/bookmarks/components/delete-folder-modal/index.ts
+++ b/app/(features)/bookmarks/components/delete-folder-modal/index.ts
@@ -3,3 +3,5 @@ export { FolderPreview } from './FolderPreview';
 export { WarningMessage } from './WarningMessage';
 export { ModalActions } from './ModalActions';
 export { BACKDROP_VARIANTS, MODAL_VARIANTS } from './animations';
+export { ModalBody } from './ModalBody';
+export { useDeleteFolder } from './useDeleteFolder';

--- a/app/(features)/bookmarks/components/delete-folder-modal/useDeleteFolder.ts
+++ b/app/(features)/bookmarks/components/delete-folder-modal/useDeleteFolder.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react';
+
+import { useBookmarks } from '@/app/providers/BookmarkContext';
+import { logger } from '@/src/infrastructure/monitoring/Logger';
+import { Folder } from '@/types';
+
+export const useDeleteFolder = (folder: Folder | null, onClose: () => void) => {
+  const { deleteFolder } = useBookmarks();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    if (!folder) return;
+
+    setIsDeleting(true);
+    try {
+      deleteFolder(folder.id);
+      onClose();
+    } catch (error) {
+      logger.error('Failed to delete folder:', undefined, error as Error);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deleteFolder, folder, onClose]);
+
+  return { handleDelete, isDeleting };
+};
+
+export type UseDeleteFolderReturn = ReturnType<typeof useDeleteFolder>;


### PR DESCRIPTION
## Summary
- extract delete folder handler to helper hook
- move modal body markup to dedicated component
- streamline delete folder modal using new helpers

## Testing
- `npx prettier --write app/(features)/bookmarks/components/DeleteFolderModal.tsx app/(features)/bookmarks/components/delete-folder-modal/index.ts app/(features)/bookmarks/components/delete-folder-modal/ModalBody.tsx app/(features)/bookmarks/components/delete-folder-modal/useDeleteFolder.ts`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run type-check` *(fails: Cannot find type definition file for '@testing-library/jest-dom')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bd801623c8832fb44953782e3f2771