### PR TITLE
chore: replace darwin swc with linux build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.0",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
-        "@next/swc-darwin-arm64": "^15.5.3",
         "@radix-ui/react-popover": "latest",
         "@radix-ui/react-slider": "latest",
         "@radix-ui/react-tooltip": "latest",
@@ -81,6 +80,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@next/swc-linux-x64": "^15.5.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4044,21 +4046,6 @@
         "fast-glob": "3.3.1"
       }
     },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.3.tgz",
-      "integrity": "sha512-nzbHQo69+au9wJkGKTU9lP7PXv0d1J5ljFpvb+LnEomLtSbJkbZyEs6sbF3plQmiOB2l9OBtN2tNSvCH1nQ9Jg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-darwin-x64": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.2.tgz",
@@ -4106,6 +4093,9 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@next/swc-linux-x64": {
+      "optional": true
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "15.5.2",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "whatwg-fetch": "^3.6.20"
   },
   "optionalDependencies": {
-    "@next/swc-darwin-arm64": "^15.5.3"
+    "@next/swc-linux-x64": "^15.5.3"
   },
   "size-limit": [
     {


### PR DESCRIPTION
## Summary
- replace optional dependency on `@next/swc-darwin-arm64` with Linux build

## Testing
- `npm install`
- `npm run check` *(fails: TS2379 and TS4114 errors in infrastructure errors module)*
- `npm test` *(fails: 118 failed, 292 passed, 410 total)*

------
https://chatgpt.com/codex/tasks/task_b_68c2e6938998832fb628b5ade8b65551