### PR TITLE
test: remove fallback fetch stubs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -149,6 +149,12 @@ Mock implementations for external dependencies:
 - Access pattern tracking
 - Memory constraints
 
+### Network requests (MSW)
+
+API calls are intercepted with [Mock Service Worker](https://mswjs.io/). Default handlers live in `tests/setup/msw/handlers.ts`.
+For custom responses in a test, import `addHandlers` from `@tests/setup/msw/server` and add handlers using `server.use`.
+Avoid mocking `fetch` directly.
+
 ## 🚀 Running Tests
 
 ### Development Commands


### PR DESCRIPTION
## Summary
- remove legacy fetch stubs from test setup
- document using `server.use` for custom MSW handlers

## Testing
- `npm test` *(fails: BookmarkContext.operations tests, responsive-hooks, VerseOfDay.transition)*
- `npm run lint tests/setup/setupTests.ts tests/README.md`


------
https://chatgpt.com/codex/tasks/task_b_68c682961ce4832fa9bfe2162cc2b33e