### PR TITLE
test: switch msw server require to import

### DIFF
--- a/tests/setup/envPolyfills.ts
+++ b/tests/setup/envPolyfills.ts
@@ -1,0 +1,30 @@
+import { ReadableStream, WritableStream, TransformStream } from 'stream/web';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Web Streams and BroadcastChannel polyfills
+if (typeof globalThis.ReadableStream === 'undefined') {
+  // @ts-expect-error - define if missing
+  globalThis.ReadableStream = ReadableStream;
+}
+if (typeof globalThis.WritableStream === 'undefined') {
+  // @ts-expect-error - define if missing
+  globalThis.WritableStream = WritableStream;
+}
+if (typeof globalThis.TransformStream === 'undefined') {
+  // @ts-expect-error - define if missing
+  globalThis.TransformStream = TransformStream;
+}
+if (typeof globalThis.BroadcastChannel === 'undefined') {
+  // @ts-expect-error - define if missing
+  globalThis.BroadcastChannel = class {
+    constructor() {}
+    postMessage(): void {}
+    close(): void {}
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    onmessage: ((this: BroadcastChannel, ev: MessageEvent) => void) | null = null;
+  };
+}
+
+// TextEncoder/TextDecoder for MSW in JSDOM
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/tests/setup/setupTests.ts
+++ b/tests/setup/setupTests.ts
@@ -3,11 +3,11 @@ import 'jest-axe/extend-expect';
 // Provide Fetch/Response in JSDOM via whatwg-fetch so MSW interceptors work consistently
 import 'whatwg-fetch';
 
-import { ReadableStream, WritableStream, TransformStream } from 'stream/web';
-import { TextEncoder, TextDecoder } from 'util';
+import '@tests/setup/envPolyfills';
 
 import { jest, beforeAll, afterEach, afterAll } from '@jest/globals';
 import { logger } from '@/src/infrastructure/monitoring/Logger';
+import { server } from '@tests/setup/msw/server';
 
 declare global {
   interface HTMLMediaElement {
@@ -19,36 +19,6 @@ declare global {
     simulateEnd(): void;
   }
 }
-
-// Web Streams and BroadcastChannel polyfills
-if (typeof globalThis.ReadableStream === 'undefined') {
-  // @ts-expect-error - define if missing
-  globalThis.ReadableStream = ReadableStream;
-}
-if (typeof globalThis.WritableStream === 'undefined') {
-  // @ts-expect-error - define if missing
-  globalThis.WritableStream = WritableStream;
-}
-if (typeof globalThis.TransformStream === 'undefined') {
-  // @ts-expect-error - define if missing
-  globalThis.TransformStream = TransformStream;
-}
-if (typeof globalThis.BroadcastChannel === 'undefined') {
-  // @ts-expect-error - define if missing
-  globalThis.BroadcastChannel = class {
-    constructor() {}
-    postMessage(): void {}
-    close(): void {}
-    addEventListener(): void {}
-    removeEventListener(): void {}
-    onmessage: ((this: BroadcastChannel, ev: MessageEvent) => void) | null = null;
-  };
-}
-
-// TextEncoder/TextDecoder for MSW in JSDOM
-Object.assign(global, { TextDecoder, TextEncoder });
-
-const { server } = require('@tests/setup/msw/server');
 
 // Start MSW for tests unless explicitly disabled
 // Set JEST_ALLOW_NETWORK=1 to bypass MSW and allow real network requests


### PR DESCRIPTION
## Summary
- replace MSW server require with ESM import in test setup
- extract environment polyfills so MSW loads after polyfills

## Testing
- `npx eslint tests/setup/setupTests.ts tests/setup/envPolyfills.ts`
- `npm run type-check` *(fails: app/(features)/tafsir/__tests__/TafsirVersePage.test.tsx:86:30 - Unexpected token)*
- `npm test tests/unit/infrastructure/errors/ErrorHandler.actions1.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c6829692e4832f921e02fb288ed642